### PR TITLE
Require displayname to match username

### DIFF
--- a/lib/glimesh/accounts/user.ex
+++ b/lib/glimesh/accounts/user.ex
@@ -110,12 +110,14 @@ defmodule Glimesh.Accounts.User do
     |> delete_change(:password)
   end
 
-  defp validate_displayname(changeset) do
-    username = get_field(changeset, :username)
-
-    changeset
-    |> validate_length(:displayname, min: 3, max: 50)
-    |> validate_format(:displayname, ~r/#{username}/i)
+  def validate_displayname(changeset) do
+    validate_change(changeset, :displayname, fn (current_field, value) ->
+      if String.downcase(value) !== get_field(changeset, :username) do
+        [{current_field, "Display name must match Username"}]
+        else
+        []
+      end
+    end)
   end
 
   @doc """

--- a/test/glimesh_web/controllers/user_settings_controller_test.exs
+++ b/test/glimesh_web/controllers/user_settings_controller_test.exs
@@ -20,6 +20,51 @@ defmodule GlimeshWeb.UserSettingsControllerTest do
     end
   end
 
+  describe "PUT /users/settings/update_profile" do
+    test "updates the social media profiles", %{conn: conn, user: user} do
+      profile_conn =
+        put(conn, Routes.user_settings_path(conn, :update_profile), %{
+          "user" => %{
+            "social_twitter" => "some-fake-twitter-url"
+          }
+        })
+
+      assert redirected_to(profile_conn) == Routes.user_settings_path(conn, :edit)
+      assert get_flash(profile_conn, :info) =~ "Profile updated successfully"
+
+      response = html_response(get(conn, Routes.user_settings_path(conn, :edit)), 200)
+      assert response =~ "some-fake-twitter-url"
+    end
+
+    test "does update displayname if case changes", %{conn: conn, user: user} do
+      profile_conn =
+        put(conn, Routes.user_settings_path(conn, :update_profile), %{
+          "user" => %{
+            "displayname" => String.upcase(user.username),
+          }
+        })
+
+      assert redirected_to(profile_conn) == Routes.user_settings_path(conn, :edit)
+      assert get_flash(profile_conn, :info) =~ "Profile updated successfully"
+
+      response = html_response(get(conn, Routes.user_settings_path(conn, :edit)), 200)
+      assert response =~ String.upcase(user.username)
+    end
+
+    test "does not update displayname if it does not match username", %{conn: conn, user: user} do
+      profile_conn =
+        put(conn, Routes.user_settings_path(conn, :update_profile), %{
+          "user" => %{
+            "displayname" => user.username <> "f",
+          }
+        })
+
+      response = html_response(profile_conn, 200)
+      assert response =~ "<h2 class=\"mt-4\">Your Profile</h2>"
+      assert response =~ "Display name must match Username"
+    end
+  end
+
   describe "PUT /users/settings/update_password" do
     test "updates the user password and resets tokens", %{conn: conn, user: user} do
       new_password_conn =


### PR DESCRIPTION
Adds some tests for the functionality and also doesn't double validate 