### PR TITLE
Reorder CI to run tests before code quality checks

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -37,7 +37,7 @@ jobs:
         restore-keys: ${{ runner.os }}-mix-
     - name: Install dependencies
       run: mix deps.get
-    - name: Code Quality
-      run: mix code_quality
     - name: Run tests
       run: mix test
+    - name: Code Quality
+      run: mix code_quality


### PR DESCRIPTION
this is so if there are test errors it will be caught before the code readability check as it will always stop the following task.