### PR TITLE
:seedling: Add per-environment seeding as part of application setup

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -77,7 +77,8 @@ defmodule Glimesh.MixProject do
   defp aliases do
     [
       setup: ["deps.get", "ecto.setup", "cmd npm install --prefix assets"],
-      "ecto.setup": ["ecto.create", "ecto.migrate", "run priv/repo/seeds.exs"],
+      "ecto.seed": ["run priv/repo/seeds.#{Mix.env()}.exs"],
+      "ecto.setup": ["ecto.create", "ecto.migrate", "ecto.seed"],
       "ecto.reset": ["ecto.drop", "ecto.setup"],
       test: ["ecto.create --quiet", "ecto.migrate --quiet", "test"],
       code_quality: ["format", "credo --strict"]

--- a/priv/repo/seeds.dev.exs
+++ b/priv/repo/seeds.dev.exs
@@ -1,0 +1,1 @@
+Code.require_file("seeds.exs")

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -1,0 +1,4 @@
+# In this file we load all seeds from the seeds subdirectory
+for seed <- "seeds/*.exs" |> Path.expand(__DIR__) |> Path.wildcard() do
+  Code.require_file(seed)
+end

--- a/priv/repo/seeds.prod.exs
+++ b/priv/repo/seeds.prod.exs
@@ -1,1 +1,0 @@
-Code.require_file("seeds.exs")

--- a/priv/repo/seeds.prod.exs
+++ b/priv/repo/seeds.prod.exs
@@ -1,0 +1,1 @@
+Code.require_file("seeds.exs")

--- a/priv/repo/seeds.test.exs
+++ b/priv/repo/seeds.test.exs
@@ -1,0 +1,1 @@
+Code.require_file("seeds.exs")

--- a/priv/repo/seeds/categories.exs
+++ b/priv/repo/seeds/categories.exs
@@ -1,15 +1,3 @@
-# Script for populating the database. You can run it as:
-#
-#     mix run priv/repo/seeds.exs
-#
-# Inside the script, you can read and write to any of your
-# repositories directly:
-#
-#     Glimesh.Repo.insert!(%Glimesh.SomeSchema{})
-#
-# We recommend using the bang functions (`insert!`, `update!`
-# and so on) as they will fail if something goes wrong.
-
 standard_categories = %{
   "Art" => [
     "Digital",

--- a/priv/repo/seeds/streams.exs
+++ b/priv/repo/seeds/streams.exs
@@ -1,15 +1,3 @@
-# Script for populating the database. You can run it as:
-#
-#     mix run priv/repo/seeds.exs
-#
-# Inside the script, you can read and write to any of your
-# repositories directly:
-#
-#     Glimesh.Repo.insert!(%Glimesh.SomeSchema{})
-#
-# We recommend using the bang functions (`insert!`, `update!`
-# and so on) as they will fail if something goes wrong.
-
 num_streams = 100
 
 possible_categories = Enum.map(Glimesh.Streams.list_categories(), fn x -> x.id end)


### PR DESCRIPTION
The application can't currently launch through the docker-compose setup because `priv/repo/seeds.exs` doesn't exist. I have added a seed file for each environment, which can in turn include one or more other seed files. I have added the current seeds (categories and streams) through a wildcard inclusion for both dev and test but not production.