### PR TITLE
Added site wide account bans. 

### DIFF
--- a/lib/glimesh/accounts.ex
+++ b/lib/glimesh/accounts.ex
@@ -88,6 +88,11 @@ defmodule Glimesh.Accounts do
   """
   def get_user!(id), do: Repo.get!(User, id)
 
+  def is_user_banned_by_username(username) do
+    user = Repo.get_by(User, username: username)
+    user.is_banned
+  end
+
   ## User registration
 
   @doc """

--- a/lib/glimesh/accounts.ex
+++ b/lib/glimesh/accounts.ex
@@ -46,12 +46,12 @@ defmodule Glimesh.Accounts do
       nil
 
   """
-  def get_by_username(username) when is_binary(username) do
-    Repo.get_by(User, username: username)
+  def get_by_username(username, ignore_banned \\ false) when is_binary(username) do
+    Repo.get_by(User, username: username, is_banned: ignore_banned)
   end
 
-  def get_by_username!(username) when is_binary(username) do
-    Repo.get_by!(User, username: username)
+  def get_by_username!(username, ignore_banned \\ false) when is_binary(username) do
+    Repo.get_by!(User, username: username, is_banned: ignore_banned)
   end
 
   @doc """

--- a/lib/glimesh/accounts.ex
+++ b/lib/glimesh/accounts.ex
@@ -88,7 +88,7 @@ defmodule Glimesh.Accounts do
   """
   def get_user!(id), do: Repo.get!(User, id)
 
-  def is_user_banned_by_username(username) do
+  def is_user_banned_by_username?(username) do
     user = Repo.get_by(User, username: username)
     user.is_banned
   end

--- a/lib/glimesh/accounts/user.ex
+++ b/lib/glimesh/accounts/user.ex
@@ -19,6 +19,7 @@ defmodule Glimesh.Accounts.User do
     field :can_payments, :boolean, default: false
     field :is_admin, :boolean, default: false
     field :is_banned, :boolean, default: false
+    field :ban_reason, :string
 
     field :avatar, Glimesh.Avatar.Type
     field :social_twitter, :string

--- a/lib/glimesh/accounts/user.ex
+++ b/lib/glimesh/accounts/user.ex
@@ -18,6 +18,7 @@ defmodule Glimesh.Accounts.User do
     field :can_stream, :boolean, default: false
     field :can_payments, :boolean, default: false
     field :is_admin, :boolean, default: false
+    field :is_banned, :boolean, default: false
 
     field :avatar, Glimesh.Avatar.Type
     field :social_twitter, :string

--- a/lib/glimesh/accounts/user.ex
+++ b/lib/glimesh/accounts/user.ex
@@ -60,7 +60,8 @@ defmodule Glimesh.Accounts.User do
       :password,
       :displayname,
       :is_admin,
-      :can_payments
+      :can_payments,
+      :is_banned
     ])
     |> validate_username()
     |> validate_email()

--- a/lib/glimesh/chat.ex
+++ b/lib/glimesh/chat.ex
@@ -101,24 +101,7 @@ defmodule Glimesh.Chat do
       raise ArgumentError, message: "User must not be banned"
     end
 
-    # Need to add this since phoenix likes strings and our tests don't use them :)
-    message_contain_link_helper =
-      if attrs["message"] do
-        message_contains_link(attrs["message"])
-      else
-        if attrs.message, do: message_contains_link(attrs.message), else: [true]
-      end
-
-    create_message =
-      case message_contain_link_helper do
-        [true] ->
-          if channel.block_links, do: false, else: true
-
-        _ ->
-          true
-      end
-
-    if create_message do
+    if allow_link_in_message(channel, attrs) do
       %ChatMessage{
         channel: channel,
         user: user
@@ -225,6 +208,25 @@ defmodule Glimesh.Chat do
       [{^username, _}] -> false
       [] -> true
     end
+  end
+
+  def allow_link_in_message(channel, attrs) do
+    # Need to add this since phoenix likes strings and our tests don't use them :)
+    message_contain_link_helper =
+      if attrs["message"] do
+        message_contains_link(attrs["message"])
+      else
+        if attrs.message, do: message_contains_link(attrs.message), else: [true]
+      end
+
+    create_message =
+      case message_contain_link_helper do
+        [true] ->
+          if channel.block_links, do: false, else: true
+
+        _ ->
+          true
+      end
   end
 
   def render_global_badge(user) do

--- a/lib/glimesh/chat.ex
+++ b/lib/glimesh/chat.ex
@@ -97,7 +97,7 @@ defmodule Glimesh.Chat do
       [] -> true
     end
 
-    if Accounts.is_user_banned_by_username(username) do
+    if Glimesh.Accounts.is_user_banned_by_username(username) do
       raise ArgumentError, message: "User must not be banned"
     end
 

--- a/lib/glimesh/chat.ex
+++ b/lib/glimesh/chat.ex
@@ -97,6 +97,10 @@ defmodule Glimesh.Chat do
       [] -> true
     end
 
+    if Accounts.is_user_banned_by_username(username) do
+      raise ArgumentError, message: "User must not be banned"
+    end
+
     # Need to add this since phoenix likes strings and our tests don't use them :)
     message_contain_link_helper =
       if attrs["message"] do

--- a/lib/glimesh/chat.ex
+++ b/lib/glimesh/chat.ex
@@ -97,7 +97,7 @@ defmodule Glimesh.Chat do
       [] -> true
     end
 
-    if Glimesh.Accounts.is_user_banned_by_username(username) do
+    if Glimesh.Accounts.is_user_banned_by_username?(username) do
       raise ArgumentError, message: "User must not be banned"
     end
 

--- a/lib/glimesh/streams.ex
+++ b/lib/glimesh/streams.ex
@@ -104,13 +104,14 @@ defmodule Glimesh.Streams do
     Repo.get_by!(Channel, id: id) |> Repo.preload([:category, :user])
   end
 
-  def get_channel_for_username!(username) do
+  def get_channel_for_username!(username, ignore_banned \\ false) do
     Repo.one(
       from c in Channel,
         join: u in User,
         on: c.user_id == u.id,
         where: u.username == ^username,
-        where: c.inaccessible == false
+        where: c.inaccessible == false,
+        where: u.is_banned == ^ignore_banned
     )
     |> Repo.preload([:category, :user])
   end

--- a/lib/glimesh_web/controllers/user_auth.ex
+++ b/lib/glimesh_web/controllers/user_auth.ex
@@ -3,6 +3,7 @@ defmodule GlimeshWeb.UserAuth do
   import Phoenix.Controller
 
   alias Glimesh.Accounts
+  alias GlimeshWeb.Endpoint
   alias GlimeshWeb.Router.Helpers, as: Routes
 
   # Make the remember me cookie valid for 60 days.
@@ -76,13 +77,26 @@ defmodule GlimeshWeb.UserAuth do
     user_token && Accounts.delete_session_token(user_token)
 
     if live_socket_id = get_session(conn, :live_socket_id) do
-      GlimeshWeb.Endpoint.broadcast(live_socket_id, "disconnect", %{})
+      Endpoint.broadcast(live_socket_id, "disconnect", %{})
     end
 
     conn
     |> renew_session()
     |> delete_resp_cookie(@remember_me_cookie)
     |> redirect(to: "/")
+  end
+
+  def ban_user(conn) do
+    user_token = get_session(conn, :user_token)
+    user_token && Accounts.delete_session_token(user_token)
+
+    if live_socket_id = get_session(conn, :live_socket_id) do
+      Endpoint.broadcast(live_socket_id, "disconnect", %{})
+    end
+
+    conn
+    |> renew_session()
+    |> delete_resp_cookie(@remember_me_cookie)
   end
 
   @doc """

--- a/lib/glimesh_web/controllers/user_session_controller.ex
+++ b/lib/glimesh_web/controllers/user_session_controller.ex
@@ -11,25 +11,7 @@ defmodule GlimeshWeb.UserSessionController do
 
   def create(conn, %{"user" => %{"email" => email, "password" => password} = user_params}) do
     if user = Accounts.get_user_by_email_and_password(email, password) do
-      case user.is_banned do
-        false ->
-          if user.tfa_token do
-            conn
-            |> put_session(:tfa_user_id, user.id)
-            |> render("tfa.html", error_message: nil)
-          else
-            UserAuth.log_in_user(conn, user, user_params)
-          end
-
-        true ->
-          render(conn, "new.html",
-            error_message:
-              gettext(
-                "User account is banned. Please contact support at %{email} for more information.",
-                email: "support@glimesh.tv"
-              )
-          )
-      end
+      attempt_login(conn, user, user_params)
     else
       render(conn, "new.html", error_message: gettext("Invalid e-mail or password"))
     end
@@ -54,5 +36,27 @@ defmodule GlimeshWeb.UserSessionController do
     conn
     |> put_flash(:info, gettext("Logged out successfully."))
     |> UserAuth.log_out_user()
+  end
+
+  # Attempt a login if the user isn't banned
+  def attempt_login(conn, %{is_banned: false} = user, user_params) do
+    if user.tfa_token do
+      conn
+      |> put_session(:tfa_user_id, user.id)
+      |> render("tfa.html", error_message: nil)
+    else
+      UserAuth.log_in_user(conn, user, user_params)
+    end
+  end
+
+  # Attempt a login on a banned user
+  def attempt_login(conn, %{is_banned: true}, _user_params) do
+    render(conn, "new.html",
+      error_message:
+        gettext(
+          "User account is banned. Please contact support at %{email} for more information.",
+          email: "support@glimesh.tv"
+        )
+    )
   end
 end

--- a/lib/glimesh_web/plugs/ban_plug.ex
+++ b/lib/glimesh_web/plugs/ban_plug.ex
@@ -1,0 +1,32 @@
+defmodule GlimeshWeb.Plugs.Ban do
+  import Plug.Conn
+
+  alias GlimeshWeb.UserAuth
+
+  def init(_opts), do: nil
+
+  def call(conn, _opts) do
+    user = conn.assigns.current_user
+
+    if is_user_banned(user) do
+      conn
+      |> UserAuth.ban_user()
+      |> replace_path("/")
+    else
+      conn
+    end
+  end
+
+  defp is_user_banned(user) do
+    case user do
+      nil -> false
+      _ -> if user.is_banned, do: true, else: false
+    end
+  end
+
+  defp replace_path(conn, path) do
+    conn
+    |> Map.replace!(:request_path, path)
+    |> Map.replace!(:path_info, ["banned"])
+  end
+end

--- a/lib/glimesh_web/router.ex
+++ b/lib/glimesh_web/router.ex
@@ -12,6 +12,7 @@ defmodule GlimeshWeb.Router do
     plug :put_secure_browser_headers
     plug :fetch_current_user
     plug GlimeshWeb.Plugs.Locale
+    plug GlimeshWeb.Plugs.Ban
   end
 
   pipeline :api do

--- a/lib/glimesh_web/templates/user_session/new.html.eex
+++ b/lib/glimesh_web/templates/user_session/new.html.eex
@@ -246,11 +246,11 @@
 
                     <h3>Login to our Alpha!</h3>
                     <%= form_for @conn, Routes.user_session_path(@conn, :create), [as: :user, class: "text-left"], fn f -> %>
-                    <%= if @error_message do %>
-                    <div class="alert alert-danger">
-                        <p><%= @error_message %></p>
-                    </div>
-                    <% end %>
+                        <%= if @error_message do %>
+                            <div class="alert alert-danger">
+                              <div class="text-center"><%= @error_message %></div>
+                            </div>
+                        <% end %>
 
                     <div class="coming-soon">
                         <div class="">

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -104,7 +104,7 @@ msgid "Invalid Password"
 msgstr "Passwort ungültig"
 
 #, elixir-format
-#: lib/glimesh_web/controllers/user_session_controller.ex:22
+#: lib/glimesh_web/controllers/user_session_controller.ex:34
 msgid "Invalid e-mail or password"
 msgstr "E-mail oder Passwort ist ungültig"
 
@@ -443,7 +443,7 @@ msgid "Level the playing field."
 msgstr "Wettbewerbsgleichheit"
 
 #, elixir-format
-#: lib/glimesh_web/controllers/user_session_controller.ex:43
+#: lib/glimesh_web/controllers/user_session_controller.ex:55
 msgid "Logged out successfully."
 msgstr "Erfolgreich Abgemeldet"
 
@@ -925,7 +925,7 @@ msgid "Enter your 2FA code!"
 msgstr "Gebe deinen 2FA code ein"
 
 #, elixir-format
-#: lib/glimesh_web/controllers/user_session_controller.ex:33
+#: lib/glimesh_web/controllers/user_session_controller.ex:45
 msgid "Invalid 2FA code, if you need help please email %{email}"
 msgstr "Ungültiger 2FA code. Wenn du Hilfe brauchst bitte schreibe eine email an %{email}"
 

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -106,7 +106,7 @@ msgid "Invalid Password"
 msgstr ""
 
 #, elixir-format
-#: lib/glimesh_web/controllers/user_session_controller.ex:22
+#: lib/glimesh_web/controllers/user_session_controller.ex:34
 msgid "Invalid e-mail or password"
 msgstr ""
 
@@ -444,7 +444,7 @@ msgid "Level the playing field."
 msgstr ""
 
 #, elixir-format
-#: lib/glimesh_web/controllers/user_session_controller.ex:43
+#: lib/glimesh_web/controllers/user_session_controller.ex:55
 msgid "Logged out successfully."
 msgstr ""
 
@@ -937,7 +937,7 @@ msgid "Enter your 2FA code!"
 msgstr ""
 
 #, elixir-format
-#: lib/glimesh_web/controllers/user_session_controller.ex:33
+#: lib/glimesh_web/controllers/user_session_controller.ex:45
 msgid "Invalid 2FA code, if you need help please email %{email}"
 msgstr ""
 

--- a/priv/gettext/es/LC_MESSAGES/default.po
+++ b/priv/gettext/es/LC_MESSAGES/default.po
@@ -107,7 +107,7 @@ msgid "Invalid Password"
 msgstr ""
 
 #, elixir-format
-#: lib/glimesh_web/controllers/user_session_controller.ex:22
+#: lib/glimesh_web/controllers/user_session_controller.ex:34
 msgid "Invalid e-mail or password"
 msgstr ""
 
@@ -445,7 +445,7 @@ msgid "Level the playing field."
 msgstr ""
 
 #, elixir-format
-#: lib/glimesh_web/controllers/user_session_controller.ex:43
+#: lib/glimesh_web/controllers/user_session_controller.ex:55
 msgid "Logged out successfully."
 msgstr ""
 
@@ -938,7 +938,7 @@ msgid "Enter your 2FA code!"
 msgstr ""
 
 #, elixir-format
-#: lib/glimesh_web/controllers/user_session_controller.ex:33
+#: lib/glimesh_web/controllers/user_session_controller.ex:45
 msgid "Invalid 2FA code, if you need help please email %{email}"
 msgstr ""
 

--- a/priv/gettext/es_AR/LC_MESSAGES/default.po
+++ b/priv/gettext/es_AR/LC_MESSAGES/default.po
@@ -107,7 +107,7 @@ msgid "Invalid Password"
 msgstr ""
 
 #, elixir-format
-#: lib/glimesh_web/controllers/user_session_controller.ex:22
+#: lib/glimesh_web/controllers/user_session_controller.ex:34
 msgid "Invalid e-mail or password"
 msgstr ""
 
@@ -445,7 +445,7 @@ msgid "Level the playing field."
 msgstr ""
 
 #, elixir-format
-#: lib/glimesh_web/controllers/user_session_controller.ex:43
+#: lib/glimesh_web/controllers/user_session_controller.ex:55
 msgid "Logged out successfully."
 msgstr ""
 
@@ -938,7 +938,7 @@ msgid "Enter your 2FA code!"
 msgstr ""
 
 #, elixir-format
-#: lib/glimesh_web/controllers/user_session_controller.ex:33
+#: lib/glimesh_web/controllers/user_session_controller.ex:45
 msgid "Invalid 2FA code, if you need help please email %{email}"
 msgstr ""
 

--- a/priv/gettext/es_MX/LC_MESSAGES/default.po
+++ b/priv/gettext/es_MX/LC_MESSAGES/default.po
@@ -107,7 +107,7 @@ msgid "Invalid Password"
 msgstr ""
 
 #, elixir-format
-#: lib/glimesh_web/controllers/user_session_controller.ex:22
+#: lib/glimesh_web/controllers/user_session_controller.ex:34
 msgid "Invalid e-mail or password"
 msgstr ""
 
@@ -445,7 +445,7 @@ msgid "Level the playing field."
 msgstr ""
 
 #, elixir-format
-#: lib/glimesh_web/controllers/user_session_controller.ex:43
+#: lib/glimesh_web/controllers/user_session_controller.ex:55
 msgid "Logged out successfully."
 msgstr ""
 
@@ -938,7 +938,7 @@ msgid "Enter your 2FA code!"
 msgstr ""
 
 #, elixir-format
-#: lib/glimesh_web/controllers/user_session_controller.ex:33
+#: lib/glimesh_web/controllers/user_session_controller.ex:45
 msgid "Invalid 2FA code, if you need help please email %{email}"
 msgstr ""
 

--- a/priv/gettext/ja/LC_MESSAGES/default.po
+++ b/priv/gettext/ja/LC_MESSAGES/default.po
@@ -104,7 +104,7 @@ msgid "Invalid Password"
 msgstr "無効なパスワード"
 
 #, elixir-format
-#: lib/glimesh_web/controllers/user_session_controller.ex:22
+#: lib/glimesh_web/controllers/user_session_controller.ex:34
 msgid "Invalid e-mail or password"
 msgstr "メールアドレスまたはパスワードが無効です。"
 
@@ -443,7 +443,7 @@ msgid "Level the playing field."
 msgstr "公平な競争の場。"
 
 #, elixir-format
-#: lib/glimesh_web/controllers/user_session_controller.ex:43
+#: lib/glimesh_web/controllers/user_session_controller.ex:55
 msgid "Logged out successfully."
 msgstr "正常にログアウトしました。"
 
@@ -930,7 +930,7 @@ msgid "Enter your 2FA code!"
 msgstr ""
 
 #, elixir-format
-#: lib/glimesh_web/controllers/user_session_controller.ex:33
+#: lib/glimesh_web/controllers/user_session_controller.ex:45
 msgid "Invalid 2FA code, if you need help please email %{email}"
 msgstr ""
 

--- a/priv/gettext/ru/LC_MESSAGES/default.po
+++ b/priv/gettext/ru/LC_MESSAGES/default.po
@@ -107,7 +107,7 @@ msgid "Invalid Password"
 msgstr ""
 
 #, elixir-format
-#: lib/glimesh_web/controllers/user_session_controller.ex:22
+#: lib/glimesh_web/controllers/user_session_controller.ex:34
 msgid "Invalid e-mail or password"
 msgstr ""
 
@@ -445,7 +445,7 @@ msgid "Level the playing field."
 msgstr ""
 
 #, elixir-format
-#: lib/glimesh_web/controllers/user_session_controller.ex:43
+#: lib/glimesh_web/controllers/user_session_controller.ex:55
 msgid "Logged out successfully."
 msgstr ""
 
@@ -944,7 +944,7 @@ msgid "Enter your 2FA code!"
 msgstr ""
 
 #, elixir-format
-#: lib/glimesh_web/controllers/user_session_controller.ex:33
+#: lib/glimesh_web/controllers/user_session_controller.ex:45
 msgid "Invalid 2FA code, if you need help please email %{email}"
 msgstr ""
 

--- a/priv/gettext/sv/LC_MESSAGES/default.po
+++ b/priv/gettext/sv/LC_MESSAGES/default.po
@@ -106,7 +106,7 @@ msgid "Invalid Password"
 msgstr "felaktigt lösenord"
 
 #, elixir-format
-#: lib/glimesh_web/controllers/user_session_controller.ex:22
+#: lib/glimesh_web/controllers/user_session_controller.ex:34
 msgid "Invalid e-mail or password"
 msgstr "Ogiltig e-post eller lösenord"
 
@@ -448,7 +448,7 @@ msgid "Level the playing field."
 msgstr "Jämnar nivån på spelplanen"
 
 #, elixir-format
-#: lib/glimesh_web/controllers/user_session_controller.ex:43
+#: lib/glimesh_web/controllers/user_session_controller.ex:55
 msgid "Logged out successfully."
 msgstr "Du har loggat ut"
 
@@ -947,7 +947,7 @@ msgid "Enter your 2FA code!"
 msgstr ""
 
 #, elixir-format
-#: lib/glimesh_web/controllers/user_session_controller.ex:33
+#: lib/glimesh_web/controllers/user_session_controller.ex:45
 msgid "Invalid 2FA code, if you need help please email %{email}"
 msgstr ""
 

--- a/priv/gettext/vi/LC_MESSAGES/default.po
+++ b/priv/gettext/vi/LC_MESSAGES/default.po
@@ -107,7 +107,7 @@ msgid "Invalid Password"
 msgstr ""
 
 #, elixir-format
-#: lib/glimesh_web/controllers/user_session_controller.ex:22
+#: lib/glimesh_web/controllers/user_session_controller.ex:34
 msgid "Invalid e-mail or password"
 msgstr ""
 
@@ -445,7 +445,7 @@ msgid "Level the playing field."
 msgstr ""
 
 #, elixir-format
-#: lib/glimesh_web/controllers/user_session_controller.ex:43
+#: lib/glimesh_web/controllers/user_session_controller.ex:55
 msgid "Logged out successfully."
 msgstr ""
 
@@ -932,7 +932,7 @@ msgid "Enter your 2FA code!"
 msgstr ""
 
 #, elixir-format
-#: lib/glimesh_web/controllers/user_session_controller.ex:33
+#: lib/glimesh_web/controllers/user_session_controller.ex:45
 msgid "Invalid 2FA code, if you need help please email %{email}"
 msgstr ""
 

--- a/priv/repo/migrations/20200907160029_site-wide-account-bans.exs
+++ b/priv/repo/migrations/20200907160029_site-wide-account-bans.exs
@@ -1,0 +1,9 @@
+defmodule :"Elixir.Glimesh.Repo.Migrations.Site-wide-account-bans" do
+  use Ecto.Migration
+
+  def change do
+    alter table(:users) do
+      add :is_banned, :boolean, default: false
+    end
+  end
+end

--- a/priv/repo/migrations/20200907160029_site-wide-account-bans.exs
+++ b/priv/repo/migrations/20200907160029_site-wide-account-bans.exs
@@ -4,6 +4,7 @@ defmodule :"Elixir.Glimesh.Repo.Migrations.Site-wide-account-bans" do
   def change do
     alter table(:users) do
       add :is_banned, :boolean, default: false
+      add :ban_reason, :text
     end
   end
 end

--- a/priv/repo/migrations/20200907160029_site_wide_account_bans.exs
+++ b/priv/repo/migrations/20200907160029_site_wide_account_bans.exs
@@ -1,4 +1,4 @@
-defmodule :"Elixir.Glimesh.Repo.Migrations.SiteWideAccountBans" do
+defmodule Elixir.Glimesh.Repo.Migrations.SiteWideAccountBans do
   use Ecto.Migration
 
   def change do

--- a/priv/repo/migrations/20200907160029_site_wide_account_bans.exs
+++ b/priv/repo/migrations/20200907160029_site_wide_account_bans.exs
@@ -1,4 +1,4 @@
-defmodule :"Elixir.Glimesh.Repo.Migrations.Site-wide-account-bans" do
+defmodule :"Elixir.Glimesh.Repo.Migrations.SiteWideAccountBans" do
   use Ecto.Migration
 
   def change do

--- a/test/glimesh_web/controllers/user_session_controller_test.exs
+++ b/test/glimesh_web/controllers/user_session_controller_test.exs
@@ -4,7 +4,7 @@ defmodule GlimeshWeb.UserSessionControllerTest do
   import Glimesh.AccountsFixtures
 
   setup do
-    %{user: user_fixture()}
+    %{user: user_fixture(), banned_user: banned_fixture()}
   end
 
   describe "GET /users/log_in" do
@@ -64,6 +64,17 @@ defmodule GlimeshWeb.UserSessionControllerTest do
       response = html_response(conn, 200)
       assert response =~ "<h3>Login to our Alpha!</h3>"
       assert response =~ "Invalid email or password"
+    end
+
+    test "emits error message with banned user", %{conn: conn, banned_user: banned_user} do
+      conn =
+        post(conn, Routes.user_session_path(conn, :create), %{
+          "user" => %{"email" => banned_user.email, "password" => valid_user_password(), "tfa" => nil}
+        })
+
+      response = html_response(conn, 200)
+      assert response =~ "<h3>Login to our Alpha!</h3>"
+      assert response =~ "User account is banned. Please contact support at support@glimesh.tv for more information."
     end
   end
 

--- a/test/glimesh_web/controllers/user_session_controller_test.exs
+++ b/test/glimesh_web/controllers/user_session_controller_test.exs
@@ -69,12 +69,18 @@ defmodule GlimeshWeb.UserSessionControllerTest do
     test "emits error message with banned user", %{conn: conn, banned_user: banned_user} do
       conn =
         post(conn, Routes.user_session_path(conn, :create), %{
-          "user" => %{"email" => banned_user.email, "password" => valid_user_password(), "tfa" => nil}
+          "user" => %{
+            "email" => banned_user.email,
+            "password" => valid_user_password(),
+            "tfa" => nil
+          }
         })
 
       response = html_response(conn, 200)
       assert response =~ "<h3>Login to our Alpha!</h3>"
-      assert response =~ "User account is banned. Please contact support at support@glimesh.tv for more information."
+
+      assert response =~
+               "User account is banned. Please contact support at support@glimesh.tv for more information."
     end
   end
 

--- a/test/support/fixtures/accounts_fixtures.ex
+++ b/test/support/fixtures/accounts_fixtures.ex
@@ -41,6 +41,10 @@ defmodule Glimesh.AccountsFixtures do
     user_fixture(%{is_admin: true})
   end
 
+  def banned_fixture(_attrs \\ %{}) do
+    user_fixture(%{is_banned: true})
+  end
+
   def extract_user_token(fun) do
     {:ok, captured} = fun.(&"[TOKEN]#{&1}[TOKEN]")
     [_, token, _] = String.split(captured.body, "[TOKEN]")


### PR DESCRIPTION
Adds site wide account bans which was requested in issue #112 

Currently no way of issuing an account ban other than setting is_banned to true for a user in the DB. 

Once that is true the user will no longer be able to login and their current session will be logged out when they navigate to a new page.

Still have to add a check when displaying a user's profile, and they're still able to chat currently if marked as banned. 