### PR TITLE
Fixed the streamer title component to be translated

### DIFF
--- a/lib/glimesh_web/live/user_live/components/streamer_title.ex
+++ b/lib/glimesh_web/live/user_live/components/streamer_title.ex
@@ -1,5 +1,6 @@
 defmodule GlimeshWeb.UserLive.Components.StreamerTitle do
   use GlimeshWeb, :live_view
+  import Gettext, only: [with_locale: 2]
 
   alias Glimesh.Streams
 
@@ -17,7 +18,9 @@ defmodule GlimeshWeb.UserLive.Components.StreamerTitle do
           <%= text_input f, :title, [class: "form-control"] %>
 
           <div class="input-group-append">
+          <%= with_locale(@user.locale, fn -> %>
             <%= submit gettext("Save Info"), class: "btn btn-primary" %>
+          <% end) %>
           </div>
 
           </div>


### PR DESCRIPTION
Found there's a with_locale function for liveview. Who would've known. 

Only noticed an issue with translations on the streamer title liveview component but there's probably more. 