### PR TITLE
Disabling hyperlinking in chat and/or blocking links entirely

### DIFF
--- a/lib/glimesh/chat.ex
+++ b/lib/glimesh/chat.ex
@@ -92,7 +92,15 @@ defmodule Glimesh.Chat do
       [] -> true
     end
 
-    create_message = case message_contains_link(attrs["message"]) do
+    #Need to add this since phoenix likes strings and our tests don't use them :)
+    message_contain_link_helper = if attrs["message"] do
+      message_contains_link(attrs["message"])
+    else
+      if attrs.message, do: message_contains_link(attrs.message), else: [true]
+    end
+
+
+    create_message = case message_contain_link_helper do
       [true] ->
         if channel.block_links, do: false, else: true
       _ -> true

--- a/lib/glimesh/chat.ex
+++ b/lib/glimesh/chat.ex
@@ -115,15 +115,7 @@ defmodule Glimesh.Chat do
       |> Repo.insert()
       |> broadcast(:chat_message)
     else
-      {:error, %Ecto.Changeset{
-        action: :validate,
-        changes: %{message: attrs["message"]},
-        errors: [
-          message: {gettext("can't have link"), [validation: :required]}
-        ],
-        data: %Glimesh.Chat.ChatMessage{},
-        valid?: false
-        }}
+      throw_error_on_chat(gettext("This channel has links disabled!"), attrs)
     end
   end
 
@@ -305,4 +297,16 @@ defmodule Glimesh.Chat do
   defp flatten_list([head | tail]), do: flatten_list(head) ++ flatten_list(tail)
   defp flatten_list([]), do: []
   defp flatten_list(element), do: [element]
+
+  def throw_error_on_chat(error_message, attrs) do
+    {:error, %Ecto.Changeset{
+        action: :validate,
+        changes: %{message: attrs["message"]},
+        errors: [
+          message: {error_message, [validation: :required]}
+        ],
+        data: %Glimesh.Chat.ChatMessage{},
+        valid?: false
+      }}
+  end
 end

--- a/lib/glimesh/streams/channel.ex
+++ b/lib/glimesh/streams/channel.ex
@@ -15,6 +15,7 @@ defmodule Glimesh.Streams.Channel do
     field :stream_key, :string
     field :inaccessible, :boolean, default: false
     field :backend, :string
+    field :disable_hyperlinks, :boolean, default: false
 
     field :chat_rules_md, :string
     field :chat_rules_html, :string
@@ -41,7 +42,8 @@ defmodule Glimesh.Streams.Channel do
       :stream_key,
       :chat_rules_md,
       :inaccessible,
-      :status
+      :status,
+      :disable_hyperlinks
     ])
     |> validate_length(:chat_rules_md, max: 8192)
     |> set_chat_rules_content_html()

--- a/lib/glimesh/streams/channel.ex
+++ b/lib/glimesh/streams/channel.ex
@@ -16,6 +16,7 @@ defmodule Glimesh.Streams.Channel do
     field :inaccessible, :boolean, default: false
     field :backend, :string
     field :disable_hyperlinks, :boolean, default: false
+    field :block_links, :boolean, default: false
 
     field :chat_rules_md, :string
     field :chat_rules_html, :string
@@ -43,7 +44,8 @@ defmodule Glimesh.Streams.Channel do
       :chat_rules_md,
       :inaccessible,
       :status,
-      :disable_hyperlinks
+      :disable_hyperlinks,
+      :block_links
     ])
     |> validate_length(:chat_rules_md, max: 8192)
     |> set_chat_rules_content_html()

--- a/lib/glimesh_web/live/chat_live/index.html.leex
+++ b/lib/glimesh_web/live/chat_live/index.html.leex
@@ -21,7 +21,7 @@
                                 width="20" height="20" class="img-chat-avatar" />
                             <%= link chat_message.user.displayname, to: Routes.user_profile_path(@socket, :index, chat_message.user.username), class: "text-white", target: "_blank" %>:
                             <br>
-                            <%= unless @channel.disable_hyperlinks, do: Glimesh.Chat.hyperlink_message(chat_message.message), else: chat_message.message %>
+                            <%= unless @channel.disable_hyperlinks || @channel.block_links, do: Glimesh.Chat.hyperlink_message(chat_message.message), else: chat_message.message %>
                         </div>
                         <% end %>
                     </div>

--- a/lib/glimesh_web/live/chat_live/index.html.leex
+++ b/lib/glimesh_web/live/chat_live/index.html.leex
@@ -21,7 +21,7 @@
                                 width="20" height="20" class="img-chat-avatar" />
                             <%= link chat_message.user.displayname, to: Routes.user_profile_path(@socket, :index, chat_message.user.username), class: "text-white", target: "_blank" %>:
                             <br>
-                            <%= Glimesh.Chat.hyperlink_message(chat_message.message) %>
+                            <%= unless @channel.disable_hyperlinks, do: Glimesh.Chat.hyperlink_message(chat_message.message), else: chat_message.message %>
                         </div>
                         <% end %>
                     </div>

--- a/lib/glimesh_web/templates/user_settings/stream.html.eex
+++ b/lib/glimesh_web/templates/user_settings/stream.html.eex
@@ -40,9 +40,14 @@
                 </div>
                 <div class="col-sm-6">
                     <div class="form-group">
-                        <%= label f, gettext("Hyperlinks") %>
-                        <%= select f, :disable_hyperlinks, [Enabled: false, Disabled: true],[class: "form-control"] %>
+                        <%= label f, gettext("Should links automatically be clickable?") %>
+                        <%= select f, :disable_hyperlinks, [Yes: false, No: true], [class: "form-control", disabled: @channel.block_links] %>
                         <%= error_tag f, :disable_hyperlinks %>
+                    </div>
+                    <div class="form-group">
+                        <%= label f, gettext("Block viewers from posting links?") %>
+                        <%= select f, :block_links, [Yes: true, No: false],[class: "form-control"] %>
+                        <%= error_tag f, :block_links %>
                     </div>
                 </div>
             </div>

--- a/lib/glimesh_web/templates/user_settings/stream.html.eex
+++ b/lib/glimesh_web/templates/user_settings/stream.html.eex
@@ -38,6 +38,13 @@
                         <%= error_tag f, :chat_rules_md %>
                     </div>
                 </div>
+                <div class="col-sm-6">
+                    <div class="form-group">
+                        <%= label f, gettext("Hyperlinks") %>
+                        <%= select f, :disable_hyperlinks, [Enabled: false, Disabled: true],[class: "form-control"] %>
+                        <%= error_tag f, :disable_hyperlinks %>
+                    </div>
+                </div>
             </div>
             <div class="row">
                 <div class="col-sm-6">

--- a/priv/repo/migrations/20200921050912_disabling_hyperlinks.exs
+++ b/priv/repo/migrations/20200921050912_disabling_hyperlinks.exs
@@ -4,6 +4,7 @@ defmodule Glimesh.Repo.Migrations.DisablingHyperlinks do
   def change do
     alter table(:channels) do
       add :disable_hyperlinks, :boolean, default: false
+      add :block_links, :boolean, default: false
     end
 
   end

--- a/priv/repo/migrations/20200921050912_disabling_hyperlinks.exs
+++ b/priv/repo/migrations/20200921050912_disabling_hyperlinks.exs
@@ -1,0 +1,10 @@
+defmodule Glimesh.Repo.Migrations.DisablingHyperlinks do
+  use Ecto.Migration
+
+  def change do
+    alter table(:channels) do
+      add :disable_hyperlinks, :boolean, default: false
+    end
+
+  end
+end


### PR DESCRIPTION
Allows channels to disable just hyperlink(the link will still show but isn't clickable) or disabling links outright. If the channel decides to disable links completely it will grey out the option to disable hyperlinks and automatically convert any hyperlinks in the chat back to normal unclickable links and then block future messages from containing links. 