### PR TITLE
Set the chat rules entry to nil if the box is empty

### DIFF
--- a/lib/glimesh/streams/channel.ex
+++ b/lib/glimesh/streams/channel.ex
@@ -89,11 +89,19 @@ defmodule Glimesh.Streams.Channel do
   def set_chat_rules_content_html(changeset) do
     case changeset do
       %Ecto.Changeset{valid?: true, changes: %{chat_rules_md: chat_rules_md}} ->
-        put_change(
-          changeset,
-          :chat_rules_html,
-          Glimesh.Accounts.Profile.safe_user_markdown_to_html(chat_rules_md)
-        )
+        if chat_rules_md do
+          put_change(
+            changeset,
+            :chat_rules_html,
+            Glimesh.Accounts.Profile.safe_user_markdown_to_html(chat_rules_md)
+          )
+        else
+          put_change(
+            changeset,
+            :chat_rules_html,
+            nil
+          )
+        end
 
       _ ->
         changeset

--- a/test/glimesh/channel_test.exs
+++ b/test/glimesh/channel_test.exs
@@ -7,6 +7,7 @@ defmodule Glimesh.ChannelTest do
   describe "stream_settings" do
     @valid_attrs %{title: "Valid Title", category_id: 2}
     @invalid_attrs %{title: nil}
+    @blank_chat_rules %{chat_rules_md: ""}
 
     test "delete_channel/1 soft deletes channel successfully" do
       [channel, streamer] = channel_streamer_fixture()
@@ -27,6 +28,14 @@ defmodule Glimesh.ChannelTest do
       [channel, streamer] = channel_streamer_fixture()
       {:ok, channel} = Streams.update_channel(streamer, channel, @invalid_attrs)
       assert channel.title == nil
+    end
+
+    test "update_channel/2 with blank chat rules defaults to nil" do
+      [channel, streamer] = channel_streamer_fixture()
+      {:ok, channel} = Streams.update_channel(streamer, channel, %{chat_rules_md: "Test rules"})
+      assert channel.chat_rules_html =~ "<p>\nTest rules</p>\n"
+      {:ok, channel} = Streams.update_channel(streamer, channel, @blank_chat_rules)
+      assert channel.chat_rules_html == nil
     end
   end
 end


### PR DESCRIPTION
Previously if you cleared out the chat rules box, earmark tried to convert it to HTML and failed since it was nil.