### PR TITLE
Added an error message to avatar upload failing

### DIFF
--- a/lib/glimesh_web/templates/user_settings/profile.html.eex
+++ b/lib/glimesh_web/templates/user_settings/profile.html.eex
@@ -16,6 +16,9 @@
                         <div class="mb-4 text-left">
                             <p><%= gettext("Click Update Settings down below when you've chosen the file.") %> </p>
                             <%= file_input f, :avatar, id: "customFile", class: "", accept: "image/png, image/jpeg" %>
+                            <%= if f.errors[:avatar] do %>
+                                <div><span class="text-danger"><%= gettext("Invalid image. Must be either png or jpg.")%></span></div>
+                            <% end %>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
Before when an avatar upload failed it told the user to check for errors below but didn't post one for the avatar. Added a custom message now(would use the normal error_tag but it just spits out "invalid", which isn't helpful). 