### PR TITLE
Made the toggle button work for logged out viewers

### DIFF
--- a/lib/glimesh_web/live/chat_live/index.ex
+++ b/lib/glimesh_web/live/chat_live/index.ex
@@ -92,7 +92,7 @@ defmodule GlimeshWeb.ChatLive.Index do
   end
 
   @impl true
-  def handle_event("toggle_timestamps", params, socket) when params == %{} do
+  def handle_event("toggle_timestamps", params, socket) when map_size(params) == 0 do
     timestamp_state = Kernel.not(socket.assigns.show_timestamps)
     {:noreply,
      socket
@@ -105,7 +105,7 @@ defmodule GlimeshWeb.ChatLive.Index do
   end
 
   @impl true
-  def handle_event("toggle_timestamps", _params, socket) do
+  def handle_event("toggle_timestamps", %{"user" => username}, socket) do
     timestamp_state = Kernel.not(socket.assigns.show_timestamps)
 
     {:ok, user_preferences} =

--- a/lib/glimesh_web/live/chat_live/index.ex
+++ b/lib/glimesh_web/live/chat_live/index.ex
@@ -92,6 +92,19 @@ defmodule GlimeshWeb.ChatLive.Index do
   end
 
   @impl true
+  def handle_event("toggle_timestamps", params, socket) when params == %{} do
+    timestamp_state = Kernel.not(socket.assigns.show_timestamps)
+    {:noreply,
+     socket
+     |> assign(:update_action, "append")
+     |> assign(:show_timestamps, timestamp_state)
+     |> assign(:user_preferences, %{show_timestamps: timestamp_state})
+     |> push_event("update_previous_messages_with_timestamp_state", %{
+       show_timestamps: timestamp_state
+     })}
+  end
+
+  @impl true
   def handle_event("toggle_timestamps", _params, socket) do
     timestamp_state = Kernel.not(socket.assigns.show_timestamps)
 

--- a/lib/glimesh_web/live/chat_live/message_form.html.leex
+++ b/lib/glimesh_web/live/chat_live/message_form.html.leex
@@ -33,7 +33,7 @@
         <a class="dropdown-item" href="#"
           onclick="window.open('<%= Routes.chat_pop_out_url(@socket, :index, @channel_username) %>', '_blank', 'width=400,height=600,location=no,menubar=no,toolbar=no')">Pop-out
           Chat</a>
-        <a id="toggle-timestamps" class="dropdown-item", href="#" phx-click="toggle_timestamps"><%= if @show_timestamps, do: gettext("Disable Timestamps"), else: gettext("Enable Timestamps") %> </a>
+        <a id="toggle-timestamps" class="dropdown-item", href="#" phx-click="toggle_timestamps" <%= if @user, do: 'phx-value-user=#{@user.username}' %>><%= if @show_timestamps, do: gettext("Disable Timestamps"), else: gettext("Enable Timestamps") %> </a>
       </div>
     </div>
 


### PR DESCRIPTION
When the params map is empty(logged out user), the toggle_timestamp event will only trigger the JS side of it, which will toggle the timestamps for that page. They will have to either log in to persist through refreshes/different chats or keep toggling it back on. 