### PR TITLE
Client ID API Authentication

### DIFF
--- a/lib/glimesh/oauth/token_resolver.ex
+++ b/lib/glimesh/oauth/token_resolver.ex
@@ -4,31 +4,8 @@ defmodule Glimesh.Oauth.TokenResolver do
   """
 
   alias Glimesh.Accounts.User
+  alias Glimesh.OauthApplications.OauthApplication
   alias Glimesh.Repo
-
-  @doc """
-  Will resolve a token to either a user, or an app.
-  """
-  def resolve_token(token) do
-    with {:error, msg} <- resolve_user(token),
-         {:error, msg} <- resolve_app(token) do
-      {:error, msg}
-    else
-      {:ok, something} ->
-        {:ok, something}
-    end
-
-    cond do
-      {:ok, user} = resolve_user(token) ->
-        {:ok, user}
-
-      {:ok, app} = resolve_app(token) ->
-        {:ok, app}
-
-      true ->
-        nil
-    end
-  end
 
   def resolve_app(nil) do
     {:error, "No client id specified"}
@@ -38,6 +15,15 @@ defmodule Glimesh.Oauth.TokenResolver do
     config = [otp_app: :glimesh]
 
     ExOauth2Provider.Applications.get_application(client_id, config)
+    |> handle_app()
+  end
+
+  defp handle_app(%OauthApplication{} = app) do
+    {:ok, app}
+  end
+
+  defp handle_app(_) do
+    {:error, "Application not found."}
   end
 
   def resolve_user(nil) do

--- a/lib/glimesh/oauth/token_resolver.ex
+++ b/lib/glimesh/oauth/token_resolver.ex
@@ -6,6 +6,40 @@ defmodule Glimesh.Oauth.TokenResolver do
   alias Glimesh.Accounts.User
   alias Glimesh.Repo
 
+  @doc """
+  Will resolve a token to either a user, or an app.
+  """
+  def resolve_token(token) do
+    with {:error, msg} <- resolve_user(token),
+         {:error, msg} <- resolve_app(token) do
+      {:error, msg}
+    else
+      {:ok, something} ->
+        {:ok, something}
+    end
+
+    cond do
+      {:ok, user} = resolve_user(token) ->
+        {:ok, user}
+
+      {:ok, app} = resolve_app(token) ->
+        {:ok, app}
+
+      true ->
+        nil
+    end
+  end
+
+  def resolve_app(nil) do
+    {:error, "No client id specified"}
+  end
+
+  def resolve_app(client_id) do
+    config = [otp_app: :glimesh]
+
+    ExOauth2Provider.Applications.get_application(client_id, config)
+  end
+
   def resolve_user(nil) do
     {:error, "No token specified"}
   end

--- a/lib/glimesh/resolvers/accounts_resolver.ex
+++ b/lib/glimesh/resolvers/accounts_resolver.ex
@@ -2,7 +2,6 @@ defmodule Glimesh.Resolvers.AccountsResolver do
   @moduledoc false
   alias Glimesh.Accounts
 
-  #
   def myself(_, _, %{context: %{current_user: current_user}}) do
     {:ok, Accounts.get_user!(current_user.id)}
   end

--- a/lib/glimesh/resolvers/streams_resolver.ex
+++ b/lib/glimesh/resolvers/streams_resolver.ex
@@ -27,6 +27,7 @@ defmodule Glimesh.Resolvers.StreamsResolver do
   end
 
   # Streams
+
   def start_stream(_parent, %{channel_id: channel_id}, %{context: %{is_admin: true}}) do
     channel = Streams.get_channel!(channel_id)
     {:ok, stream} = Streams.start_stream(channel)

--- a/lib/glimesh_web/channels/api_socket.ex
+++ b/lib/glimesh_web/channels/api_socket.ex
@@ -17,7 +17,7 @@ defmodule GlimeshWeb.ApiSocket do
   @impl true
   def connect(%{"client_id" => client_id}, socket, _connect_info) do
     case Glimesh.Oauth.TokenResolver.resolve_app(client_id) do
-      %Glimesh.OauthApplications.OauthApplication{} ->
+      {:ok, %Glimesh.OauthApplications.OauthApplication{}} ->
         {:ok,
          socket
          |> assign(:user_id, nil)

--- a/lib/glimesh_web/channels/user_socket.ex
+++ b/lib/glimesh_web/channels/user_socket.ex
@@ -29,6 +29,7 @@ defmodule GlimeshWeb.UserSocket do
          |> assign(:user_id, user.id)
          |> Absinthe.Phoenix.Socket.put_options(
            context: %{
+             is_admin: user.is_admin,
              current_user: user
            }
          )}

--- a/lib/glimesh_web/plugs/api_context_plug.ex
+++ b/lib/glimesh_web/plugs/api_context_plug.ex
@@ -2,6 +2,7 @@ defmodule GlimeshWeb.Plugs.ApiContextPlug do
   @behaviour Plug
 
   alias Glimesh.Accounts.User
+  alias Glimesh.Apps.App
 
   import Plug.Conn
   import Phoenix.Controller, only: [json: 2]
@@ -16,6 +17,14 @@ defmodule GlimeshWeb.Plugs.ApiContextPlug do
             # Allows us to pattern match admin APIs
             is_admin: user.is_admin,
             current_user: user
+          }
+        )
+
+      {:ok, %App{} = app} ->
+        Absinthe.Plug.put_options(conn,
+          context: %{
+            is_admin: false,
+            current_user: nil
           }
         )
 

--- a/test/glimesh_web/api/api_auth_test.exs
+++ b/test/glimesh_web/api/api_auth_test.exs
@@ -1,6 +1,8 @@
 defmodule GlimeshWeb.Api.ApiAuthTest do
   use GlimeshWeb.ConnCase
 
+  import Glimesh.AccountsFixtures
+
   @myself_query """
   query getMyself {
     myself {
@@ -35,6 +37,51 @@ defmodule GlimeshWeb.Api.ApiAuthTest do
 
       assert json_response(conn, 401) == %{
                "errors" => [%{"message" => "You must be logged in to access the api"}]
+             }
+    end
+  end
+
+  describe "read-only api access with client id" do
+    setup %{conn: conn} do
+      user = user_fixture()
+
+      {:ok, app} =
+        Glimesh.Apps.create_app(user, %{
+          name: "some name",
+          description: "some description",
+          homepage_url: "https://glimesh.tv/",
+          oauth_application: %{
+            redirect_uri: "http://localhost:8080/redirect"
+          }
+        })
+
+      %{
+        conn:
+          conn |> Plug.Conn.put_req_header("authorization", "Bearer #{app.oauth_application.uid}"),
+        client_id: app.oauth_application.uid
+      }
+    end
+
+    test "gets accepted", %{conn: conn, client_id: client_id} do
+      conn = get(conn, "/api")
+
+      assert json_response(conn, 400) == %{
+               "errors" => [%{"message" => "No query document supplied"}]
+             }
+    end
+
+    test "returns myself", %{conn: conn, client_id: client_id} do
+      conn =
+        post(
+          conn,
+          "/api",
+          %{
+            "query" => @myself_query
+          }
+        )
+
+      assert json_response(conn, 200) == %{
+               "data" => %{"myself" => nil}
              }
     end
   end


### PR DESCRIPTION
This PR adds support for using a Client ID for read-only access to the API, this allows devs to use the API for notifications for a web-based or OBS embedded web view.

For the GraphQL you can authorize with:
`Authorization: Client <id>`

For the WebSocket API you can authorize with:
`?client_id=<id>`