### PR TITLE
Removed more padding around images on the profile

### DIFF
--- a/lib/glimesh/accounts/profile.ex
+++ b/lib/glimesh/accounts/profile.ex
@@ -3,7 +3,7 @@ defmodule Glimesh.Accounts.Profile do
 
   def safe_user_markdown_to_html(profile_content_md) do
     {:ok, html_doc, []} = Earmark.as_html(profile_content_md)
-    html_doc |> HtmlSanitizeEx.basic_html() |> String.replace("\n  ", "")
+    html_doc |> format_profile_images()
   end
 
   def youtube_video_id(youtube_intro_url) do
@@ -50,5 +50,14 @@ defmodule Glimesh.Accounts.Profile do
         "#{streamer.displayname}'s new profile page on Glimesh, the next-gen live streaming platform.",
       image_url: avatar_path
     }
+  end
+
+  def format_profile_images(html_doc) do
+    html_doc
+    |> HtmlSanitizeEx.basic_html()
+    |> String.replace("\n  ", "")
+    |> String.replace("\n</a>", "</a>")
+    |> String.replace(">  <img", "><img")
+    |> String.replace(">\n<a href", "><a href")
   end
 end


### PR DESCRIPTION
Removed the padding around the `a` tags that are generated when an image is also a link.

Before formatting:
```html
<p>\n  <img src=\"https://i.imgur.com/g54xVf9.png\" alt=\"Imgur\" />\n<a href=\"https://glimesh.tv\">  <img src=\"https://i.imgur.com/kA1kBLq.png\" alt=\"Imgur\" />\n</a>  <img src=\"https://i.imgur.com/39GsPWr.png\" alt=\"Imgur\" />\n  <img src=\"https://i.imgur.com/KhCZjLJ.png\" alt=\"Imgur\" />\n  <img src=\"https://i.imgur.com/CqkmVQN.png\" alt=\"Imgur\" />\n  <img src=\"https://i.imgur.com/wHoYNn1.png\" alt=\"Imgur\" />\n</p>\n
```
After formatting:
```html
<p><img src=\"https://i.imgur.com/g54xVf9.png\" alt=\"Imgur\" /><a href=\"https://glimesh.tv\"><img src=\"https://i.imgur.com/kA1kBLq.png\" alt=\"Imgur\" /></a><img src=\"https://i.imgur.com/39GsPWr.png\" alt=\"Imgur\" /><img src=\"https://i.imgur.com/KhCZjLJ.png\" alt=\"Imgur\" /><img src=\"https://i.imgur.com/CqkmVQN.png\" alt=\"Imgur\" /><img src=\"https://i.imgur.com/wHoYNn1.png\" alt=\"Imgur\" />\n</p>\n
```