### PR TITLE
Fixed channel settings page

### DIFF
--- a/lib/glimesh/streams/channel.ex
+++ b/lib/glimesh/streams/channel.ex
@@ -74,6 +74,7 @@ defmodule Glimesh.Streams.Channel do
       :block_links
     ])
     |> validate_length(:chat_rules_md, max: 8192)
+    |> validate_length(:title, max: 250)
     |> set_chat_rules_content_html()
     |> cast_attachments(attrs, [:poster, :chat_bg])
   end

--- a/lib/glimesh_web/controllers/user_settings_controller.ex
+++ b/lib/glimesh_web/controllers/user_settings_controller.ex
@@ -94,6 +94,7 @@ defmodule GlimeshWeb.UserSettingsController do
   def update_channel(conn, %{"channel" => channel_params}) do
     channel = conn.assigns.channel
     user = conn.assigns.current_user
+    launched = Application.get_env(:glimesh, :launched, false)
 
     case Streams.update_channel(user, channel, channel_params) do
       {:ok, _} ->
@@ -103,7 +104,7 @@ defmodule GlimeshWeb.UserSettingsController do
         |> UserAuth.log_in_user(conn.assigns.current_user)
 
       {:error, changeset} ->
-        render(conn, "stream.html", channel_changeset: changeset)
+        render(conn, "stream.html", channel_changeset: changeset, launched: launched)
     end
   end
 

--- a/lib/glimesh_web/live/user_settings/components/channel_settings_live.html.leex
+++ b/lib/glimesh_web/live/user_settings/components/channel_settings_live.html.leex
@@ -1,11 +1,9 @@
 <%= form_for @channel_changeset, @route, [multipart: true, class: "form"], fn f -> %>
-<div class="row">
-    <%= if @channel_changeset.action do %>
-    <div class="alert alert-danger">
-        <p> <%= gettext("Oops, something went wrong! Please check the errors below.") %></p>
+<%= if @channel_changeset.action do %>
+    <div class="alert alert-danger text-center">
+        <%= gettext("Oops, something went wrong! Please check the errors below.") %>
     </div>
-    <% end %>
-</div>
+<% end %>
 
 <%= if @user.can_stream do %>
 <div class="form-group">
@@ -40,8 +38,11 @@
                 <%= file_input f, :poster, class: "custom-file-input", accept: "image/png, image/jpeg" %>
                 <%= label f, gettext("Choose file"), class: "custom-file-label" %>
             </div>
-
-            <%= error_tag f, :poster %>
+            <%= if f.errors[:poster] do %>
+                <div>
+                    <span class="text-danger"><%= gettext("Invalid image. Must be either a PNG or JPG.")%></span>
+                </div>
+            <% end %>
         </div>
     </div>
     <div class="col-sm-6">
@@ -55,8 +56,11 @@
                 <%= file_input f, :chat_bg, class: "custom-file-input", accept: "image/png, image/jpeg" %>
                 <%= label f, :chat_bg, gettext("Choose file"), class: "custom-file-label" %>
             </div>
-
-            <%= error_tag f, :chat_bg %>
+            <%= if f.errors[:chat_bg] do %>
+                <div>
+                    <span class="text-danger"><%= gettext("Invalid image. Max size is 100KB.")%></span>
+                </div>
+            <% end %>
         </div>
     </div>
 </div>

--- a/test/glimesh_web/controllers/user_settings_controller_test.exs
+++ b/test/glimesh_web/controllers/user_settings_controller_test.exs
@@ -17,6 +17,63 @@ defmodule GlimeshWeb.UserSettingsControllerTest do
     end
   end
 
+  describe "GET /user/settings/stream" do
+    setup :register_and_log_in_streamer
+    test "renders channel settings page when you have a channel", %{conn: conn} do
+      conn = get(conn, Routes.user_settings_path(conn, :stream))
+      response = html_response(conn, 200)
+      assert response =~ "Channel title"
+    end
+  end
+
+  describe "PUT /user/settings/create_channel" do
+    test "creates channel when user doesn't have one", %{conn: conn} do
+      conn = put(conn, Routes.user_settings_path(conn, :create_channel))
+      assert redirected_to(conn) == Routes.user_settings_path(conn, :stream)
+    end
+  end
+
+  describe "PUT /user/settings/delete_channel" do
+    setup :register_and_log_in_streamer
+    test "deletes the channel if the user has one", %{conn: conn} do
+      conn = put(conn, Routes.user_settings_path(conn, :delete_channel))
+      assert redirected_to(conn) == Routes.user_settings_path(conn, :stream)
+    end
+  end
+
+  describe "PUT /user/settings/update_channel" do
+    setup :register_and_log_in_streamer
+    test "updates the title", %{conn: conn} do
+      channel_conn =
+        put(conn, Routes.user_settings_path(conn, :update_channel), %{
+          "channel" => %{
+            "title" => "some new title"
+          }
+        })
+
+        assert redirected_to(channel_conn) == Routes.user_settings_path(conn, :stream)
+        assert get_flash(channel_conn, :info) =~ "Stream settings updated successfully"
+
+        response = html_response(get(conn, Routes.user_settings_path(conn, :stream)), 200)
+        assert response =~ "some new title"
+    end
+
+    test "invalid title doesn't update", %{conn: conn} do
+      channel_conn =
+        put(conn, Routes.user_settings_path(conn, :update_channel), %{
+          "channel" => %{
+            "title" => """
+            u06rnPOWfai1tyO79N9B2SF2sIxetMqkWbDHWeMCdcrHMtH5IorWQvZeF4F6ZGaHwx1ABn3UqFE4UkVlFZLgVjWodXZfRBEUE5bjehnnARY8M
+            z2161na4akcHU3hMxfgHgCFuTplOwXRPxWuuxIiko26tMvTXtDeRhh6u4Cj8euSMc6pXCpkmR6RsxajRi21scXhIbsVrUNmPnoMrVpAlWEMM7fCdMbNXXjFhyki8L9EZjYRmMxErZAqykr
+            """ # 251 character title
+          }
+        })
+
+      response = html_response(channel_conn, 200)
+      assert response =~ "Must not exceed 250 characters"
+    end
+  end
+
   describe "PUT /users/settings/update_profile" do
     test "updates the social media profiles", %{conn: conn} do
       profile_conn =


### PR DESCRIPTION
It was missing the `launched` assign when returning the page after updating which was required. I also added error messages for invalid images instead of the generic `Invalid` message that currently shows up. 

Fixes #366 