### PR TITLE
Added the channel ID to prefix the stream key

### DIFF
--- a/lib/glimesh/streams.ex
+++ b/lib/glimesh/streams.ex
@@ -49,11 +49,13 @@ defmodule Glimesh.Streams do
 
   def create_channel(%User{} = user, attrs \\ %{category_id: Enum.at(list_categories(), 0).id}) do
     with :ok <- Bodyguard.permit(__MODULE__, :create_channel, user) do
-      %Channel{
+      {:ok, channel } = %Channel{
         user: user
       }
       |> Channel.create_changeset(attrs)
       |> Repo.insert()
+
+      rotate_stream_key(user, channel) # Has to be done to generate a stream key for the channel
     end
   end
 
@@ -79,7 +81,7 @@ defmodule Glimesh.Streams do
     with :ok <- Bodyguard.permit(__MODULE__, :update_channel, user, channel) do
       channel
       |> change_channel()
-      |> Channel.stream_key_changeset()
+      |> Channel.stream_key_changeset(channel.id)
       |> Repo.update()
     end
   end

--- a/lib/glimesh/streams/channel.ex
+++ b/lib/glimesh/streams/channel.ex
@@ -37,7 +37,6 @@ defmodule Glimesh.Streams.Channel do
     channel
     |> changeset(attrs)
     |> put_change(:status, "offline")
-    |> put_change(:stream_key, generate_stream_key())
   end
 
   def start_changeset(channel, attrs \\ %{}) do
@@ -53,9 +52,9 @@ defmodule Glimesh.Streams.Channel do
     |> put_change(:status, "offline")
   end
 
-  def stream_key_changeset(channel) do
+  def stream_key_changeset(channel, channel_id) do
     channel
-    |> put_change(:stream_key, generate_stream_key())
+    |> put_change(:stream_key, generate_stream_key(channel_id))
   end
 
   def changeset(channel, attrs \\ %{}) do
@@ -108,7 +107,8 @@ defmodule Glimesh.Streams.Channel do
     end
   end
 
-  defp generate_stream_key do
-    :crypto.strong_rand_bytes(64) |> Base.encode64() |> binary_part(0, 64)
+  defp generate_stream_key(channel_id) do
+    key = :crypto.strong_rand_bytes(64) |> Base.encode64() |> binary_part(0, 64)
+    "#{channel_id}-#{key}"
   end
 end


### PR DESCRIPTION
Fixed #370 

Instead of storing just the generated stream key by itself in the DB, the channel ID is prefixed to it with a dash as a seperator. 

The new saved format is now `<channel_id>-<stream_key>` as outlined in the linked issue. 