### PR TITLE
:bug: Allow drift between 2FA device clock and backend

### DIFF
--- a/lib/glimesh/tfa.ex
+++ b/lib/glimesh/tfa.ex
@@ -23,9 +23,10 @@ defmodule Glimesh.Tfa do
     EQRCode.png(input, width: 355, background_color: <<255, 255, 255>>, color: <<0, 0, 0>>)
   end
 
-  defp generate_hmac(secret, period) do
+  defp generate_hmac(secret, period, seconds_ago) do
     moving_factor =
       DateTime.utc_now()
+      |> DateTime.add(seconds_ago * -1)
       |> DateTime.to_unix()
       |> Integer.floor_div(period)
       |> Integer.to_string(16)
@@ -57,9 +58,9 @@ defmodule Glimesh.Tfa do
   Generate Time-Based One-Time Password.
   The default period used to calculate the moving factor is 30s
   """
-  def generate_totp(secret, period \\ 30) do
+  def generate_totp(secret, steps_ago \\ 0, period \\ 30) do
     secret
-    |> generate_hmac(period)
+    |> generate_hmac(period, steps_ago * period)
     |> hmac_dynamic_truncation
     |> generate_hotp
   end
@@ -67,12 +68,15 @@ defmodule Glimesh.Tfa do
   @doc """
   Validates the pin with the secret key supplied
   """
-  def validate_pin(pin, secret) do
-    if secret == nil do
-      true
-    else
-      pin == generate_totp(secret)
-    end
+  def validate_pin(pin, secret, steps \\ 1)
+      
+  def validate_pin(_pin, secret, _steps) when is_nil(secret) do
+    true
+  end
+  
+  def validate_pin(pin, secret, steps) do
+    0..steps
+    |> Enum.any?(&(pin == generate_totp(secret, &1)))
   end
 
   @doc """

--- a/lib/glimesh/tfa.ex
+++ b/lib/glimesh/tfa.ex
@@ -23,10 +23,10 @@ defmodule Glimesh.Tfa do
     EQRCode.png(input, width: 355, background_color: <<255, 255, 255>>, color: <<0, 0, 0>>)
   end
 
-  defp generate_hmac(secret, period, seconds_ago) do
+  defp generate_hmac(secret, period, seconds_offset \\ 0) do
     moving_factor =
       DateTime.utc_now()
-      |> DateTime.add(seconds_ago * -1)
+      |> DateTime.add(seconds_offset)
       |> DateTime.to_unix()
       |> Integer.floor_div(period)
       |> Integer.to_string(16)
@@ -60,7 +60,7 @@ defmodule Glimesh.Tfa do
   """
   def generate_totp(secret, steps_ago \\ 0, period \\ 30) do
     secret
-    |> generate_hmac(period, steps_ago * period)
+    |> generate_hmac(period, steps_ago * period * -1)
     |> hmac_dynamic_truncation
     |> generate_hotp
   end

--- a/lib/glimesh/tfa.ex
+++ b/lib/glimesh/tfa.ex
@@ -23,7 +23,7 @@ defmodule Glimesh.Tfa do
     EQRCode.png(input, width: 355, background_color: <<255, 255, 255>>, color: <<0, 0, 0>>)
   end
 
-  defp generate_hmac(secret, period, seconds_offset \\ 0) do
+  defp generate_hmac(secret, period, seconds_offset) do
     moving_factor =
       DateTime.utc_now()
       |> DateTime.add(seconds_offset)

--- a/lib/glimesh/tfa.ex
+++ b/lib/glimesh/tfa.ex
@@ -69,11 +69,11 @@ defmodule Glimesh.Tfa do
   Validates the pin with the secret key supplied
   """
   def validate_pin(pin, secret, steps \\ 1)
-      
+
   def validate_pin(_pin, secret, _steps) when is_nil(secret) do
     true
   end
-  
+
   def validate_pin(pin, secret, steps) do
     0..steps
     |> Enum.any?(&(pin == generate_totp(secret, &1)))

--- a/test/glimesh_web/controllers/user_session_controller_test.exs
+++ b/test/glimesh_web/controllers/user_session_controller_test.exs
@@ -115,7 +115,38 @@ defmodule GlimeshWeb.UserSessionControllerTest do
       assert response =~ user.username
       assert response =~ "Sign Out"
     end
+    
+    test "logs the user in within allowed 2fa time drift", %{conn: conn, user: user} do
+      secret = Glimesh.Tfa.generate_secret(user.hashed_password)
+      pin = Glimesh.Tfa.generate_totp(secret, 1)
+      password = valid_user_password()
 
+      {:ok, user} = Glimesh.Accounts.update_tfa(user, pin, password, %{tfa_token: secret})
+
+      conn =
+        post(conn, Routes.user_session_path(conn, :create), %{
+          "user" => %{"email" => user.email, "password" => password}
+        })
+
+      assert get_session(conn, :tfa_user_id) == user.id
+      response = html_response(conn, 200)
+      assert response =~ "Enter your 2FA code!"
+
+      conn =
+        post(conn, Routes.user_session_path(conn, :tfa), %{
+          "user" => %{"tfa" => pin}
+        })
+
+      assert get_session(conn, :user_token)
+      assert redirected_to(conn) =~ "/"
+
+      # Now do a logged in request and assert on the menu
+      conn = get(conn, "/")
+      response = html_response(conn, 200)
+      assert response =~ user.username
+      assert response =~ "Sign Out"
+    end
+    
     test "errors and redirects on incorrect 2fa", %{conn: conn, user: user} do
       secret = Glimesh.Tfa.generate_secret(user.hashed_password)
       password = valid_user_password()
@@ -133,6 +164,31 @@ defmodule GlimeshWeb.UserSessionControllerTest do
       conn =
         post(conn, Routes.user_session_path(conn, :tfa), %{
           "user" => %{"tfa" => "123456"}
+        })
+
+      response = html_response(conn, 200)
+      assert response =~ "<h3>Login to our Alpha!</h3>"
+      assert response =~ "Invalid 2FA code"
+    end
+    
+    test "errors and redirects on 2fa drift steps out of bounds", %{conn: conn, user: user} do
+        secret = Glimesh.Tfa.generate_secret(user.hashed_password)
+        pin = Glimesh.Tfa.generate_totp(secret, 2)
+        password = valid_user_password()
+
+        {:ok, user} =
+          Glimesh.Accounts.update_tfa(user, Glimesh.Tfa.generate_totp(secret), password, %{
+            tfa_token: secret
+          })
+
+      conn =
+        post(conn, Routes.user_session_path(conn, :create), %{
+          "user" => %{"email" => user.email, "password" => password}
+        })
+
+      conn =
+        post(conn, Routes.user_session_path(conn, :tfa), %{
+          "user" => %{"tfa" => pin}
         })
 
       response = html_response(conn, 200)

--- a/test/glimesh_web/controllers/user_session_controller_test.exs
+++ b/test/glimesh_web/controllers/user_session_controller_test.exs
@@ -115,7 +115,7 @@ defmodule GlimeshWeb.UserSessionControllerTest do
       assert response =~ user.username
       assert response =~ "Sign Out"
     end
-    
+
     test "logs the user in within allowed 2fa time drift", %{conn: conn, user: user} do
       secret = Glimesh.Tfa.generate_secret(user.hashed_password)
       pin = Glimesh.Tfa.generate_totp(secret, 1)
@@ -146,7 +146,7 @@ defmodule GlimeshWeb.UserSessionControllerTest do
       assert response =~ user.username
       assert response =~ "Sign Out"
     end
-    
+
     test "errors and redirects on incorrect 2fa", %{conn: conn, user: user} do
       secret = Glimesh.Tfa.generate_secret(user.hashed_password)
       password = valid_user_password()
@@ -170,16 +170,16 @@ defmodule GlimeshWeb.UserSessionControllerTest do
       assert response =~ "<h3>Login to our Alpha!</h3>"
       assert response =~ "Invalid 2FA code"
     end
-    
-    test "errors and redirects on 2fa drift steps out of bounds", %{conn: conn, user: user} do
-        secret = Glimesh.Tfa.generate_secret(user.hashed_password)
-        pin = Glimesh.Tfa.generate_totp(secret, 2)
-        password = valid_user_password()
 
-        {:ok, user} =
-          Glimesh.Accounts.update_tfa(user, Glimesh.Tfa.generate_totp(secret), password, %{
-            tfa_token: secret
-          })
+    test "errors and redirects on 2fa drift steps out of bounds", %{conn: conn, user: user} do
+      secret = Glimesh.Tfa.generate_secret(user.hashed_password)
+      pin = Glimesh.Tfa.generate_totp(secret, 2)
+      password = valid_user_password()
+
+      {:ok, user} =
+        Glimesh.Accounts.update_tfa(user, Glimesh.Tfa.generate_totp(secret), password, %{
+          tfa_token: secret
+        })
 
       conn =
         post(conn, Routes.user_session_path(conn, :create), %{


### PR DESCRIPTION
Closes #360

According to [RFC 6238](https://tools.ietf.org/html/rfc6238):

>  Because of possible clock drifts between a client and a validation
   server, we **RECOMMEND that the validator be set with a specific limit
   to the number of time steps a prover can be "out of synch" before
   being rejected.**
>
>   This limit can be set both forward and backward from the calculated
   time step on receipt of the OTP value.  If the time step is
   30 seconds as recommended, and the validator is set to only accept
   two time steps backward, then the maximum elapsed time drift would be
   around 89 seconds, i.e., 29 seconds in the calculated time step and
   60 seconds for two backward time steps.
>
>   This would mean the validator could perform a validation against the
   current time and then two further validations for each backward step
   (for a total of 3 validations).  Upon successful validation, the
   validation server can record the detected clock drift for the token
   in terms of the number of time steps.  When a new OTP is received
   after this step, the validator can validate the OTP with the current
   timestamp adjusted with the recorded number of time-step clock drifts
   for the token.

This change adds an additional `step` parameter when using `validate_pin`. The number of steps is the number of _additional_ backward steps, the `validate_pin` method will **always** perform a check of the pin against the current time.