### PR TITLE
📐 Left align "Community Driven" homepage header

### DIFF
--- a/lib/glimesh_web/live/homepage_live.html.leex
+++ b/lib/glimesh_web/live/homepage_live.html.leex
@@ -50,7 +50,7 @@
             <img src="/images/dotstorming-community-project.png" alt="" class="img-fluid">
           </div>
           <div class="col-md-6">
-            <h2 class="featurette-heading text-md-right"><%= gettext("Community Driven.") %> <br><small
+            <h2 class="featurette-heading"><%= gettext("Community Driven.") %> <br><small
                 class="text-muted"><%= gettext("Built by the community, for the community.") %></small></h2>
             <p class="lead text-justify">
               <%= gettext("Community is one of our main focuse at Glimesh and we make sure to include you every step of the way. We host staff meetings live on our platform every Tuesday that are open to everyone and if there's a feature you wish we had, you can collaborate on our %{a_start}open source codebase%{a_end} to create it!", a_start: '<a href="https://github.com/Glimesh" target="_blank">', a_end: "</a>") |> raw() %>


### PR DESCRIPTION
This change left aligns the "Community Driven" header on the home page to avoid a ragged left edge, which is generally [frowned upon](https://mrwweb.com/no-justification-dont-use-right-center-and-full-justification-on-the-web/) (with LTR languages at least) due to the negative impact it has on reading speed and comprehension, plus the inconsistent aesthetic.

## Before:
![Before change, with right-justified text](https://user-images.githubusercontent.com/5422053/104679340-52df7900-56a2-11eb-9f78-76c6b73f1a86.png)

## After:
![After change, with left-justified text](https://user-images.githubusercontent.com/5422053/104679311-43f8c680-56a2-11eb-9d4d-4c188ee3f3fd.png)