### PR TITLE
Change the From header in emails to properly mention "Glimesh"

### DIFF
--- a/lib/glimesh_web/emails/email.ex
+++ b/lib/glimesh_web/emails/email.ex
@@ -12,7 +12,7 @@ defmodule GlimeshWeb.Emails.Email do
     new_email()
     |> put_html_layout({GlimeshWeb.LayoutView, "email.html"})
     |> put_text_layout({GlimeshWeb.LayoutView, "email.text"})
-    |> from("Glimesh <support@glimesh.tv>")
+    |> from("Glimesh <noreply@glimesh.tv>")
   end
 
   def user_confirmation_instructions(user, url) do

--- a/lib/glimesh_web/emails/email.ex
+++ b/lib/glimesh_web/emails/email.ex
@@ -12,7 +12,7 @@ defmodule GlimeshWeb.Emails.Email do
     new_email()
     |> put_html_layout({GlimeshWeb.LayoutView, "email.html"})
     |> put_text_layout({GlimeshWeb.LayoutView, "email.text"})
-    |> from("support@glimesh.tv")
+    |> from("Glimesh <support@glimesh.tv>")
   end
 
   def user_confirmation_instructions(user, url) do


### PR DESCRIPTION
With certain email providers (such as Gmail), emails sent through the Glimesh website would make it say it was from "support" instead of Glimesh.  That is because the From header of these emails only contains the email address, causing it to show the "user" of the address instead.

This PR fixes the situation by properly formatting the header to include the "Glimesh" name.

Before:
![image](https://user-images.githubusercontent.com/5963757/105135601-b31d5300-5ac6-11eb-9056-3600832ba18b.png)
After:
![image](https://user-images.githubusercontent.com/5963757/105135638-c03a4200-5ac6-11eb-9d5c-57e47aeb032e.png)
