### PR TITLE
Adding username login

### DIFF
--- a/lib/glimesh/accounts.ex
+++ b/lib/glimesh/accounts.ex
@@ -82,20 +82,23 @@ defmodule Glimesh.Accounts do
   end
 
   @doc """
-  Gets a user by email and password.
+  Gets a user by email or username and verify password.
 
   ## Examples
 
-      iex> get_user_by_email_and_password("foo@example.com", "correct_password")
+      iex> get_user_by_login_and_password("foo@example.com", "correct_password")
       %User{}
 
-      iex> get_user_by_email_and_password("foo@example.com", "invalid_password")
+      iex> get_user_by_login_and_password("some_username", "correct_password")
+      %User{}
+
+      iex> get_user_by_login_and_password("foo@example.com", "invalid_password")
       nil
 
   """
-  def get_user_by_email_and_password(email, password)
-      when is_binary(email) and is_binary(password) do
-    user = Repo.get_by(User, email: email)
+  def get_user_by_login_and_password(login, password)
+      when is_binary(login) and is_binary(password) do
+    user = Repo.one(from u in User, where: u.email == ^login or u.username == ^login)
     if User.valid_password?(user, password), do: user
   end
 

--- a/lib/glimesh/accounts/user.ex
+++ b/lib/glimesh/accounts/user.ex
@@ -98,6 +98,7 @@ defmodule Glimesh.Accounts.User do
   defp validate_username(changeset) do
     changeset
     |> validate_required([:username])
+    # It's important to make sure username's cannot look like emails, so don't allow @'s
     |> validate_format(:username, ~r/^(?![_.])(?!.*[_.]{2})[a-zA-Z0-9._]+(?<![_.])$/i,
       message: "Use only alphanumeric characters, no spaces"
     )

--- a/lib/glimesh_web/controllers/user_session_controller.ex
+++ b/lib/glimesh_web/controllers/user_session_controller.ex
@@ -9,11 +9,11 @@ defmodule GlimeshWeb.UserSessionController do
     render(conn, "new.html", error_message: nil)
   end
 
-  def create(conn, %{"user" => %{"email" => email, "password" => password} = user_params}) do
-    if user = Accounts.get_user_by_email_and_password(email, password) do
+  def create(conn, %{"user" => %{"login" => login, "password" => password} = user_params}) do
+    if user = Accounts.get_user_by_login_and_password(login, password) do
       attempt_login(conn, user, user_params)
     else
-      render(conn, "new.html", error_message: gettext("Invalid e-mail or password"))
+      render(conn, "new.html", error_message: gettext("Invalid e-mail / username or password"))
     end
   end
 

--- a/lib/glimesh_web/templates/user_session/new.html.eex
+++ b/lib/glimesh_web/templates/user_session/new.html.eex
@@ -22,10 +22,10 @@
 
                     <div class="input-group mb-3">
                         <div class="input-group-prepend">
-                            <span class="input-group-text"><i class="fas fa-at fa-fw"></i></span>
+                            <span class="input-group-text"><i class="fas fa-user fa-fw"></i></span>
                         </div>
-                        <%= email_input f, :email, class: "form-control", placeholder: "Email", autofocus: "true", required: true, autocomplete: "username", "aria-label": "Email"  %>
-                        <%= error_tag f, :email %>
+                        <%= text_input f, :login, class: "form-control", placeholder: "Email or Username", autofocus: "true", required: true, autocomplete: "username", "aria-label": "Email or Username"  %>
+                        <%= error_tag f, :login %>
                     </div>
 
                     <div class="input-group mb-3">

--- a/test/glimesh/accounts_test.exs
+++ b/test/glimesh/accounts_test.exs
@@ -17,21 +17,33 @@ defmodule Glimesh.AccountsTest do
     end
   end
 
-  describe "get_user_by_email_and_password/1" do
+  describe "get_user_by_login_and_password/1" do
     test "does not return the user if the email does not exist" do
-      refute Accounts.get_user_by_email_and_password("unknown@example.com", "hello world!")
+      refute Accounts.get_user_by_login_and_password("unknown@example.com", "hello world!")
     end
 
-    test "does not return the user if the password is not valid" do
+    test "does not return the user with email if the password is not valid" do
       user = user_fixture()
-      refute Accounts.get_user_by_email_and_password(user.email, "invalid")
+      refute Accounts.get_user_by_login_and_password(user.email, "invalid")
+    end
+
+    test "does not return the user with username if the password is not valid" do
+      user = user_fixture()
+      refute Accounts.get_user_by_login_and_password(user.username, "invalid")
     end
 
     test "returns the user if the email and password are valid" do
       %{id: id} = user = user_fixture()
 
       assert %User{id: ^id} =
-               Accounts.get_user_by_email_and_password(user.email, valid_user_password())
+               Accounts.get_user_by_login_and_password(user.email, valid_user_password())
+    end
+
+    test "returns the user if the username and password are valid" do
+      %{id: id} = user = user_fixture()
+
+      assert %User{id: ^id} =
+               Accounts.get_user_by_login_and_password(user.username, valid_user_password())
     end
   end
 
@@ -370,7 +382,7 @@ defmodule Glimesh.AccountsTest do
         })
 
       assert is_nil(user.password)
-      assert Accounts.get_user_by_email_and_password(user.email, "new valid password")
+      assert Accounts.get_user_by_login_and_password(user.email, "new valid password")
     end
 
     test "deletes all tokens for the given user", %{user: user} do
@@ -575,7 +587,7 @@ defmodule Glimesh.AccountsTest do
     test "updates the password", %{user: user} do
       {:ok, updated_user} = Accounts.reset_user_password(user, %{password: "new valid password"})
       assert is_nil(updated_user.password)
-      assert Accounts.get_user_by_email_and_password(user.email, "new valid password")
+      assert Accounts.get_user_by_login_and_password(user.email, "new valid password")
     end
 
     test "deletes all tokens for the given user", %{user: user} do

--- a/test/glimesh_web/controllers/user_reset_password_controller_test.exs
+++ b/test/glimesh_web/controllers/user_reset_password_controller_test.exs
@@ -92,7 +92,7 @@ defmodule GlimeshWeb.UserResetPasswordControllerTest do
       assert redirected_to(conn) == Routes.user_session_path(conn, :new)
       refute get_session(conn, :user_token)
       assert get_flash(conn, :info) =~ "Password reset successfully"
-      assert Accounts.get_user_by_email_and_password(user.email, "new valid password")
+      assert Accounts.get_user_by_login_and_password(user.email, "new valid password")
     end
 
     test "does not reset password on invalid data", %{conn: conn, token: token} do

--- a/test/glimesh_web/controllers/user_security_controller_text.exs
+++ b/test/glimesh_web/controllers/user_security_controller_text.exs
@@ -34,7 +34,7 @@ defmodule GlimeshWeb.UserSecurityControllerTest do
       assert redirected_to(new_password_conn) == Routes.user_security_path(conn, :edit)
       assert get_session(new_password_conn, :user_token) != get_session(conn, :user_token)
       assert get_flash(new_password_conn, :info) =~ "Password updated successfully"
-      assert Accounts.get_user_by_email_and_password(user.email, "new valid password")
+      assert Accounts.get_user_by_login_and_password(user.email, "new valid password")
     end
 
     test "does not update password on invalid data", %{conn: conn} do

--- a/test/glimesh_web/controllers/user_session_controller_test.exs
+++ b/test/glimesh_web/controllers/user_session_controller_test.exs
@@ -23,10 +23,27 @@ defmodule GlimeshWeb.UserSessionControllerTest do
   end
 
   describe "POST /users/log_in" do
-    test "logs the user in", %{conn: conn, user: user} do
+    test "logs the user in with email", %{conn: conn, user: user} do
       conn =
         post(conn, Routes.user_session_path(conn, :create), %{
-          "user" => %{"email" => user.email, "password" => valid_user_password(), "tfa" => nil}
+          "user" => %{"login" => user.email, "password" => valid_user_password(), "tfa" => nil}
+        })
+
+      assert get_session(conn, :user_token)
+      assert redirected_to(conn) =~ "/"
+
+      # Now do a logged in request and assert on the menu
+      conn = get(conn, "/")
+      response = html_response(conn, 200)
+      assert response =~ user.username
+      assert response =~ "Settings"
+      assert response =~ "Sign Out"
+    end
+
+    test "logs the user in with username", %{conn: conn, user: user} do
+      conn =
+        post(conn, Routes.user_session_path(conn, :create), %{
+          "user" => %{"login" => user.username, "password" => valid_user_password(), "tfa" => nil}
         })
 
       assert get_session(conn, :user_token)
@@ -44,7 +61,7 @@ defmodule GlimeshWeb.UserSessionControllerTest do
       conn =
         post(conn, Routes.user_session_path(conn, :create), %{
           "user" => %{
-            "email" => user.email,
+            "login" => user.email,
             "password" => valid_user_password(),
             "remember_me" => "true",
             "tfa" => nil
@@ -58,19 +75,19 @@ defmodule GlimeshWeb.UserSessionControllerTest do
     test "emits error message with invalid credentials", %{conn: conn, user: user} do
       conn =
         post(conn, Routes.user_session_path(conn, :create), %{
-          "user" => %{"email" => user.email, "password" => "invalid_password"}
+          "user" => %{"login" => user.email, "password" => "invalid_password"}
         })
 
       response = html_response(conn, 200)
       assert response =~ "<h3>Login to our Alpha!</h3>"
-      assert response =~ "Invalid email or password"
+      assert response =~ "Invalid e-mail / username or password"
     end
 
     test "emits error message with banned user", %{conn: conn, banned_user: banned_user} do
       conn =
         post(conn, Routes.user_session_path(conn, :create), %{
           "user" => %{
-            "email" => banned_user.email,
+            "login" => banned_user.email,
             "password" => valid_user_password(),
             "tfa" => nil
           }
@@ -94,7 +111,7 @@ defmodule GlimeshWeb.UserSessionControllerTest do
 
       conn =
         post(conn, Routes.user_session_path(conn, :create), %{
-          "user" => %{"email" => user.email, "password" => password}
+          "user" => %{"login" => user.email, "password" => password}
         })
 
       assert get_session(conn, :tfa_user_id) == user.id
@@ -125,7 +142,7 @@ defmodule GlimeshWeb.UserSessionControllerTest do
 
       conn =
         post(conn, Routes.user_session_path(conn, :create), %{
-          "user" => %{"email" => user.email, "password" => password}
+          "user" => %{"login" => user.email, "password" => password}
         })
 
       assert get_session(conn, :tfa_user_id) == user.id
@@ -158,7 +175,7 @@ defmodule GlimeshWeb.UserSessionControllerTest do
 
       conn =
         post(conn, Routes.user_session_path(conn, :create), %{
-          "user" => %{"email" => user.email, "password" => password}
+          "user" => %{"login" => user.email, "password" => password}
         })
 
       conn =
@@ -183,7 +200,7 @@ defmodule GlimeshWeb.UserSessionControllerTest do
 
       conn =
         post(conn, Routes.user_session_path(conn, :create), %{
-          "user" => %{"email" => user.email, "password" => password}
+          "user" => %{"login" => user.email, "password" => password}
         })
 
       conn =


### PR DESCRIPTION
Allows a user to optionally login with their username as well. Keeps the autofill the form the same though to encourage password managers to still work.