### PR TITLE
Attach tags and usage to streams

### DIFF
--- a/assets/js/hooks/TagSelector.js
+++ b/assets/js/hooks/TagSelector.js
@@ -11,12 +11,22 @@ export default {
     },
     tagify() {
         let tags = JSON.parse(this.el.dataset.tags);
+        let categoryId = this.el.dataset.category;
         let allowedRegex = /^[A-Za-z0-9: -]{2,18}$/;
 
         return new Tagify(this.el, {
             whitelist: tags,
             trim: true,
             maxTags: 10,
+            originalInputValueFormat: (valuesArr) => {
+                return JSON.stringify(
+                    valuesArr.map(item => {
+                        return {
+                        category_id: categoryId,
+                        value: item.value
+                    }
+                }));
+            },
             templates: {
                 tag: function(tagData) {
                     try{

--- a/lib/glimesh/streams/stream.ex
+++ b/lib/glimesh/streams/stream.ex
@@ -48,7 +48,8 @@ defmodule Glimesh.Streams.Stream do
       :avg_chatters,
       :new_subscribers,
       :resub_subscribers,
-      :global_tags
+      :global_tags,
+      :category_tags
     ])
     |> cast_attachments(attrs, [:thumbnail])
   end

--- a/lib/glimesh/streams/tag.ex
+++ b/lib/glimesh/streams/tag.ex
@@ -10,7 +10,7 @@ defmodule Glimesh.Streams.Tag do
     field :name, :string
     field :slug, :string
 
-    field :count_usage, :integer, default: 1
+    field :count_usage, :integer, default: 0
 
     belongs_to :category, Glimesh.Streams.Category
 
@@ -26,22 +26,22 @@ defmodule Glimesh.Streams.Tag do
     |> validate_required([:name])
     |> validate_length(:name, min: 2, max: 18)
     |> validate_format(:name, ~r/^[A-Za-z0-9: -]{2,18}$/)
+    |> set_slug_attribute()
     |> set_identifier_attribute()
     |> unique_constraint(:identifier)
-    |> set_slug_attribute()
   end
 
   def set_identifier_attribute(changeset) do
-    category_name =
+    category_slug =
       if category_id = get_field(changeset, :category_id) do
-        Glimesh.ChannelCategories.get_category_by_id!(category_id).name
+        Glimesh.ChannelCategories.get_category_by_id!(category_id).slug
       else
-        "Global"
+        "global"
       end
 
-    name = get_field(changeset, :name)
+    slug = get_field(changeset, :slug)
 
-    put_change(changeset, :identifier, "#{category_name} - #{name}")
+    put_change(changeset, :identifier, "#{category_slug} - #{slug}")
   end
 
   def set_slug_attribute(changeset) do

--- a/test/glimesh/channel_lookups_test.exs
+++ b/test/glimesh/channel_lookups_test.exs
@@ -67,8 +67,8 @@ defmodule Glimesh.ChannelLookupsTest do
 
       {:ok, _} =
         channel
-        |> Glimesh.Repo.preload(:tags)
-        |> Glimesh.Streams.Channel.tags_changeset([some_tag])
+        |> Ecto.Changeset.change()
+        |> Ecto.Changeset.put_assoc(:tags, [some_tag])
         |> Glimesh.Repo.update()
 
       {:ok, _} = Glimesh.Streams.start_stream(channel)

--- a/test/glimesh/streams_test.exs
+++ b/test/glimesh/streams_test.exs
@@ -84,6 +84,21 @@ defmodule Glimesh.StreamsTest do
       assert new_channel.status == "live"
     end
 
+    test "start_stream/1 stores historical tags", %{channel: channel} do
+      tag = tag_fixture()
+
+      {:ok, channel} =
+        channel
+        |> Glimesh.Repo.preload(:tags)
+        |> Ecto.Changeset.change()
+        |> Ecto.Changeset.put_assoc(:tags, [tag])
+        |> Glimesh.Repo.update()
+
+      {:ok, stream} = Streams.start_stream(channel)
+
+      assert stream.category_tags == [tag.id]
+    end
+
     test "start_stream/1 stops any other streams that still are lingering", %{channel: channel} do
       %Glimesh.Streams.Stream{channel: channel}
       |> Glimesh.Streams.Stream.changeset(%{})

--- a/test/glimesh_web/api/channel_test.exs
+++ b/test/glimesh_web/api/channel_test.exs
@@ -3,6 +3,8 @@ defmodule GlimeshWeb.Api.ChannelTest do
 
   alias Glimesh.Streams
 
+  import Glimesh.AccountsFixtures
+
   @channels_query """
   query getChannels {
     channels {
@@ -150,23 +152,19 @@ defmodule GlimeshWeb.Api.ChannelTest do
   def create_channel(%{user: user}) do
     {:ok, channel} = Streams.create_channel(user)
 
-    {:ok, channel} =
-      Streams.update_channel(user, channel, %{
-        "tags" => "[{\"value\":\"World of Warcraft\"}]"
-      })
+    %{tag: tag} = create_tag(%{})
+
+    {:ok, _} =
+      channel
+      |> Glimesh.Repo.preload(:tags)
+      |> Ecto.Changeset.change()
+      |> Ecto.Changeset.put_assoc(:tags, [tag])
+      |> Glimesh.Repo.update()
 
     %{channel: channel}
   end
 
   def create_tag(_) do
-    %Streams.Category{id: cat_id} = Glimesh.ChannelCategories.get_category("gaming")
-
-    {:ok, tag} =
-      Glimesh.ChannelCategories.create_tag(%{
-        category_id: cat_id,
-        name: "World of Warcraft"
-      })
-
-    %{tag: tag}
+    %{tag: tag_fixture()}
   end
 end

--- a/test/glimesh_web/controllers/user_settings_controller_test.exs
+++ b/test/glimesh_web/controllers/user_settings_controller_test.exs
@@ -78,11 +78,17 @@ defmodule GlimeshWeb.UserSettingsControllerTest do
       assert response =~ "Must not exceed 250 characters"
     end
 
-    test "puts tags", %{conn: conn} do
+    test "puts tags", %{conn: conn, channel: channel} do
+      tags_input =
+        Jason.encode!([
+          %{category_id: channel.category_id, value: "Digital Media"},
+          %{category_id: channel.category_id, value: "some name"}
+        ])
+
       channel_conn =
         put(conn, Routes.user_settings_path(conn, :update_channel), %{
           "channel" => %{
-            "tags" => "[{\"value\":\"Digital Media\"},{\"value\":\"some name\"}]"
+            "tags" => tags_input
           }
         })
 

--- a/test/support/fixtures/accounts_fixtures.ex
+++ b/test/support/fixtures/accounts_fixtures.ex
@@ -8,6 +8,23 @@ defmodule Glimesh.AccountsFixtures do
   def unique_user_email, do: "user#{System.unique_integer()}@example.com"
   def valid_user_password, do: "hello world!"
 
+  def tag_fixture(tag_attrs \\ %{}) do
+    %Glimesh.Streams.Category{id: cat_id} = Glimesh.ChannelCategories.get_category("gaming")
+
+    {:ok, tag} =
+      Glimesh.ChannelCategories.create_tag(
+        Map.merge(
+          %{
+            category_id: cat_id,
+            name: "World of Warcraft"
+          },
+          tag_attrs
+        )
+      )
+
+    tag
+  end
+
   def streamer_fixture(user_attrs \\ %{}, channel_attrs \\ %{}) do
     # Users need to be confirmed & can_stream to be a streamer
     streamer =


### PR DESCRIPTION
- [x] Store tags inside the Stream whenever a channel goes live
- [x] Make it so count_usage is only incremented on start_stream
- [x] Use slug instead of name in identifier