### PR TITLE
Adding API Logging functionality

### DIFF
--- a/lib/glimesh/accounts/user.ex
+++ b/lib/glimesh/accounts/user.ex
@@ -6,7 +6,7 @@ defmodule Glimesh.Accounts.User do
   import GlimeshWeb.Gettext
   import Ecto.Changeset
 
-  @derive {Inspect, except: [:password]}
+  @derive {Inspect, except: [:password, :hashed_password, :tfa_token]}
   schema "users" do
     field :username, :string
     field :displayname, :string

--- a/lib/glimesh/application.ex
+++ b/lib/glimesh/application.ex
@@ -27,6 +27,8 @@ defmodule Glimesh.Application do
       # {Glimesh.Worker, arg}
     ]
 
+    GlimeshWeb.ApiLogger.start_logger()
+
     # See https://hexdocs.pm/elixir/Supervisor.html
     # for other strategies and supported options
     opts = [strategy: :one_for_one, name: Glimesh.Supervisor]

--- a/lib/glimesh_web/api_logger.ex
+++ b/lib/glimesh_web/api_logger.ex
@@ -1,0 +1,30 @@
+defmodule GlimeshWeb.ApiLogger do
+  @moduledoc """
+  Glimesh API Logger
+  """
+  require Logger
+
+  def start_logger do
+    :telemetry.attach(
+      "absinthe-query-logger",
+      [:absinthe, :execute, :operation, :start],
+      &GlimeshWeb.ApiLogger.log_query/4,
+      nil
+    )
+  end
+
+  def log_query(_event, _time, %{blueprint: %{input: raw_query}, options: options}, _)
+      when is_binary(raw_query) do
+    context =
+      Keyword.get(options, :context, %{
+        access_type: "Unknown",
+        access_identifier: "Unknown"
+      })
+
+    Logger.info(
+      "[Absinthe Operation] Access Type: #{context.access_type} Access Identifier: #{
+        context.access_identifier
+      } Query: #{inspect(raw_query)} "
+    )
+  end
+end

--- a/lib/glimesh_web/channels/api_socket.ex
+++ b/lib/glimesh_web/channels/api_socket.ex
@@ -20,6 +20,8 @@ defmodule GlimeshWeb.ApiSocket do
            context: %{
              is_admin: false,
              current_user: nil,
+             access_type: "app",
+             access_identifier: client_id,
              user_access: %Glimesh.Accounts.UserAccess{}
            }
          )}
@@ -39,6 +41,8 @@ defmodule GlimeshWeb.ApiSocket do
            context: %{
              is_admin: user_access.user.is_admin,
              current_user: user_access.user,
+             access_type: "user",
+             access_identifier: user_access.user.username,
              user_access: user_access
            }
          )}

--- a/lib/glimesh_web/plugs/api_context_plug.ex
+++ b/lib/glimesh_web/plugs/api_context_plug.ex
@@ -17,15 +17,19 @@ defmodule GlimeshWeb.Plugs.ApiContextPlug do
             # Allows us to pattern match admin APIs
             is_admin: user_access.user.is_admin,
             current_user: user_access.user,
+            access_type: "user",
+            access_identifier: user_access.user.username,
             user_access: user_access
           }
         )
 
-      {:ok, %OauthApplication{}} ->
+      {:ok, %OauthApplication{uid: uid}} ->
         Absinthe.Plug.put_options(conn,
           context: %{
             is_admin: false,
             current_user: nil,
+            access_type: "app",
+            access_identifier: uid,
             user_access: %Glimesh.Accounts.UserAccess{}
           }
         )


### PR DESCRIPTION
Adds a simple API logger so we can understand how people are using the API. Shouldn't leak any query or mutation details.