### PR TITLE
Renaming stream key to hmac key and generating correct pastable key for

### DIFF
--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -69,3 +69,8 @@ $fa-font-path: "~@fortawesome/fontawesome-free/webfonts";
 .text-color-link {
     color: var(--body-color);
 }
+
+.stream-key:not(:focus) {
+    color: transparent;
+    text-shadow: 0 0 10px var(--input-color);
+}

--- a/config/releases.exs
+++ b/config/releases.exs
@@ -169,6 +169,8 @@ if appsignal_api_key = System.get_env("APPSIGNAL_API_KEY") do
       "user",
       "streamKey",
       "stream_key",
+      "hmac_key",
+      "hmacKey",
       "token",
       "api_token",
       "client_secret",

--- a/lib/glimesh/channel_lookups.ex
+++ b/lib/glimesh/channel_lookups.ex
@@ -115,10 +115,10 @@ defmodule Glimesh.ChannelLookups do
     |> Repo.preload([:category, :user, :tags])
   end
 
-  def get_channel_for_stream_key!(stream_key) do
+  def get_channel_by_hmac_key(hmac_key) do
     Repo.one(
       from c in Channel,
-        where: c.stream_key == ^stream_key and c.inaccessible == false
+        where: c.hmac_key == ^hmac_key and c.inaccessible == false
     )
     |> Repo.preload([:category, :user])
   end

--- a/lib/glimesh/chat/effects.ex
+++ b/lib/glimesh/chat/effects.ex
@@ -36,8 +36,8 @@ defmodule Glimesh.Chat.Effects do
             "data-toggle": "tooltip",
             title: gettext("Glimesh Staff")
           ]
-          
-          user.is_gct ->
+
+        user.is_gct ->
           [
             "data-toggle": "tooltip",
             title: gettext("Glimesh Community Team")

--- a/lib/glimesh/graphql/resolvers/channel_resolver.ex
+++ b/lib/glimesh/graphql/resolvers/channel_resolver.ex
@@ -20,13 +20,15 @@ defmodule Glimesh.Resolvers.ChannelResolver do
     {:ok, ChannelLookups.get_channel_for_username!(username)}
   end
 
-  # def find_channel(%{stream_key: stream_key}, %{context: %{user_access: %UserAccess{chat: true, user: user}}}) do
-  def find_channel(%{stream_key: stream_key}, %{context: %{is_admin: true}}) do
-    {:ok, ChannelLookups.get_channel_for_stream_key!(stream_key)}
+  def find_channel(%{hmac_key: hmac_key}, %{context: %{is_admin: true}}) do
+    case ChannelLookups.get_channel_by_hmac_key(hmac_key) do
+      %Glimesh.Streams.Channel{} = channel -> {:ok, channel}
+      _ -> {:error, "Channel not found with hmacKey."}
+    end
   end
 
-  def find_channel(%{stream_key: _}, _) do
-    {:error, "Unauthorized to access streamKey query."}
+  def find_channel(%{hmac_key: _}, _) do
+    {:error, "Unauthorized to access hmacKey query."}
   end
 
   # Streams

--- a/lib/glimesh/graphql/schema/channel_types.ex
+++ b/lib/glimesh/graphql/schema/channel_types.ex
@@ -40,7 +40,7 @@ defmodule Glimesh.Schema.ChannelTypes do
     field :channel, :channel do
       arg(:id, :id)
       arg(:username, :string)
-      arg(:stream_key, :string)
+      arg(:hmac_key, :string)
       resolve(&ChannelResolver.find_channel/2)
     end
 
@@ -172,9 +172,19 @@ defmodule Glimesh.Schema.ChannelTypes do
     field :stream_key, :string do
       resolve(fn channel, _, %{context: %{current_user: current_user}} ->
         if current_user.is_admin do
-          {:ok, channel.stream_key}
+          {:ok, Glimesh.Streams.get_stream_key(channel)}
         else
           {:error, "Unauthorized to access streamKey field."}
+        end
+      end)
+    end
+
+    field :hmac_key, :string do
+      resolve(fn channel, _, %{context: %{current_user: current_user}} ->
+        if current_user.is_admin do
+          {:ok, channel.hmac_key}
+        else
+          {:error, "Unauthorized to access hmacKey field."}
         end
       end)
     end

--- a/lib/glimesh/streams.ex
+++ b/lib/glimesh/streams.ex
@@ -78,7 +78,7 @@ defmodule Glimesh.Streams do
     with :ok <- Bodyguard.permit(__MODULE__, :update_channel, user, channel) do
       channel
       |> change_channel()
-      |> Channel.stream_key_changeset()
+      |> Channel.hmac_key_changeset()
       |> Repo.update()
     end
   end
@@ -232,6 +232,8 @@ defmodule Glimesh.Streams do
 
   def prompt_mature_content(%Channel{mature_content: true}, nil), do: true
   def prompt_mature_content(_, _), do: false
+
+  def get_stream_key(%Channel{id: id, hmac_key: hmac_key}), do: "#{id}-#{hmac_key}"
 
   # System API Calls
 

--- a/lib/glimesh/streams/channel.ex
+++ b/lib/glimesh/streams/channel.ex
@@ -17,7 +17,7 @@ defmodule Glimesh.Streams.Channel do
     field :language, :string
     field :mature_content, :boolean, default: false
     field :thumbnail, :string
-    field :stream_key, :string
+    field :hmac_key, :string
     field :inaccessible, :boolean, default: false
     field :backend, :string
     field :disable_hyperlinks, :boolean, default: false
@@ -40,7 +40,7 @@ defmodule Glimesh.Streams.Channel do
     channel
     |> changeset(attrs)
     |> put_change(:status, "offline")
-    |> put_change(:stream_key, generate_stream_key())
+    |> put_change(:hmac_key, generate_hmac_key())
   end
 
   def start_changeset(channel, attrs \\ %{}) do
@@ -56,9 +56,9 @@ defmodule Glimesh.Streams.Channel do
     |> put_change(:status, "offline")
   end
 
-  def stream_key_changeset(channel) do
+  def hmac_key_changeset(channel) do
     channel
-    |> put_change(:stream_key, generate_stream_key())
+    |> put_change(:hmac_key, generate_hmac_key())
   end
 
   def changeset(channel, attrs \\ %{}) do
@@ -70,7 +70,7 @@ defmodule Glimesh.Streams.Channel do
       :language,
       :mature_content,
       :thumbnail,
-      :stream_key,
+      :hmac_key,
       :chat_rules_md,
       :inaccessible,
       :status,
@@ -151,7 +151,7 @@ defmodule Glimesh.Streams.Channel do
     end
   end
 
-  defp generate_stream_key do
+  defp generate_hmac_key do
     :crypto.strong_rand_bytes(64) |> Base.encode64() |> binary_part(0, 64)
   end
 end

--- a/lib/glimesh_web/live/user_settings/components/channel_settings_live.ex
+++ b/lib/glimesh_web/live/user_settings/components/channel_settings_live.ex
@@ -11,6 +11,7 @@ defmodule GlimeshWeb.UserSettings.Components.ChannelSettingsLive do
      socket
      |> put_flash(:info, nil)
      |> put_flash(:error, nil)
+     |> assign(:stream_key, Glimesh.Streams.get_stream_key(session["channel"]))
      |> assign(:channel_changeset, session["channel_changeset"])
      |> assign(:categories, session["categories"])
      |> assign(:channel, session["channel"])
@@ -44,11 +45,12 @@ defmodule GlimeshWeb.UserSettings.Components.ChannelSettingsLive do
              socket.assigns.channel
            ) do
       case Streams.rotate_stream_key(socket.assigns.channel.user, socket.assigns.channel) do
-        {:ok, changeset} ->
+        {:ok, channel} ->
           {:noreply,
            socket
            |> put_flash(:info, "Stream key reset")
-           |> assign(:channel_changeset, Streams.Channel.changeset(changeset))}
+           |> assign(:stream_key, Glimesh.Streams.get_stream_key(channel))
+           |> assign(:channel_changeset, Streams.Channel.changeset(channel))}
 
         {:error, _changeset} ->
           {:noreply, socket}

--- a/lib/glimesh_web/live/user_settings/components/channel_settings_live.html.leex
+++ b/lib/glimesh_web/live/user_settings/components/channel_settings_live.html.leex
@@ -12,17 +12,17 @@
         <%= gettext("A key used to uniquely identify and connect to your stream. Treat your Stream Key as a password.") %>
     </p>
     <div class="input-group">
-        <%= text_input f, :stream_key, [class: "form-control", disabled: "disabled"] %>
+        <input type="text" value="<%= @stream_key %>" class="form-control stream-key" readonly="readonly">
 
         <div class="input-group-append">
-            <button class="btn btn-info click-to-copy" type="button" data-copy-value="<%= input_value f, :stream_key %>"
+            <button class="btn btn-info click-to-copy" type="button" data-copy-value="<%= @stream_key %>"
                 data-copied-error-text="<%= gettext("Error copying Stream Key") %>"
                 data-copied-text="<%= gettext("Copied to Clipboard") %>"><%= gettext("Click to Copy") %></button>
             <button class="btn btn-danger" type="button" phx-click="rotate_stream_key" phx-throttle="5000">Reset Stream
                 Key</button>
         </div>
     </div>
-    <%= error_tag f, :stream_key %>
+    <%= error_tag f, :hmac_key %>
 </div>
 <% end %>
 

--- a/priv/repo/migrations/20210204152120_rename_stream_keys.exs
+++ b/priv/repo/migrations/20210204152120_rename_stream_keys.exs
@@ -1,0 +1,7 @@
+defmodule Glimesh.Repo.Migrations.RenameStreamKeys do
+  use Ecto.Migration
+
+  def change do
+    rename table(:channels), :stream_key, to: :hmac_key
+  end
+end

--- a/test/glimesh/streams_test.exs
+++ b/test/glimesh/streams_test.exs
@@ -60,9 +60,9 @@ defmodule Glimesh.StreamsTest do
       {:ok, channel: streamer.channel, streamer: streamer}
     end
 
-    test "rotate_stream_key/1 changes a stream key", %{channel: channel, streamer: streamer} do
+    test "rotate_stream_key/1 changes a hmac key", %{channel: channel, streamer: streamer} do
       {:ok, new_channel} = Streams.rotate_stream_key(streamer, channel)
-      assert new_channel.stream_key != channel.stream_key
+      assert new_channel.hmac_key != channel.hmac_key
     end
 
     test "prompt_mature_content/2 flags content correctly", %{


### PR DESCRIPTION
@haydenmc This will require a change in Janus FTL Plugin that I think we can sync up with the refactor deploy.

The GraphQL would look like:
```graphql
 $hmacKey = abcdefghijklmnopqrstuvwxyz

  query getChannel($hmacKey: String!) {
    channel(hmacKey: $hmacKey) {
      id
      title
      streamKey # 3-abcdefghijklmnopqrstuvwxyz
      hmacKey # abcdefghijklmnopqrstuvwxyz
      streamer { username }
    }
  }
```