### PR TITLE
Adding logic for routing viewers to close edge locations

### DIFF
--- a/assets/js/hooks/FtlVideo.js
+++ b/assets/js/hooks/FtlVideo.js
@@ -8,8 +8,8 @@ export default {
     mounted() {
         let container = this.el;
         
-        this.handleEvent("load_video", ({janus_uri, channel_id}) => {
-            player = new FtlPlayer(container, janus_uri);
+        this.handleEvent("load_video", ({janus_url, channel_id}) => {
+            player = new FtlPlayer(container, janus_url);
             let init = player.init(channel_id);
         })
 

--- a/lib/glimesh/janus.ex
+++ b/lib/glimesh/janus.ex
@@ -1,0 +1,52 @@
+defmodule Glimesh.Janus do
+  @moduledoc """
+  Logic to help with Janus
+  """
+  import Ecto.Query, warn: false
+
+  alias Glimesh.Janus.EdgeRoute
+  alias Glimesh.Repo
+
+  @doc """
+  Fetches either the closest edge host depending on location, or falls back to a safe globally available alternative.
+  """
+  def get_closest_edge_location(country) when is_binary(country) do
+    if edge = one_edge_by_location(country) do
+      edge
+    else
+      one_good_edge()
+    end
+  end
+
+  def get_closest_edge_location(_) do
+    one_good_edge()
+  end
+
+  def all_edge_routes do
+    Repo.all(EdgeRoute)
+  end
+
+  def create_edge_route(attrs \\ %{}) do
+    %EdgeRoute{}
+    |> EdgeRoute.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  defp one_good_edge do
+    Repo.one(
+      from e in EdgeRoute,
+        where: e.available == true,
+        order_by: [desc: :priority],
+        limit: 1
+    )
+  end
+
+  defp one_edge_by_location(country) do
+    Repo.one(
+      from e in EdgeRoute,
+        where: e.available == true and ^country in e.country_codes,
+        order_by: [desc: :priority],
+        limit: 1
+    )
+  end
+end

--- a/lib/glimesh/janus/edge_route.ex
+++ b/lib/glimesh/janus/edge_route.ex
@@ -1,0 +1,31 @@
+defmodule Glimesh.Janus.EdgeRoute do
+  @moduledoc """
+  Represents a routing location
+  """
+
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "janus_edge_routes" do
+    field :hostname, :string
+    field :url, :string
+    field :priority, :float, default: 1.00
+    field :available, :boolean
+    field :country_codes, {:array, :string}
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(janus_edge_route, attrs) do
+    janus_edge_route
+    |> cast(attrs, [
+      :hostname,
+      :url,
+      :priority,
+      :available,
+      :country_codes
+    ])
+    |> validate_required([:hostname, :available])
+  end
+end

--- a/lib/glimesh_web/live/user_live/stream.ex
+++ b/lib/glimesh_web/live/user_live/stream.ex
@@ -10,7 +10,15 @@ defmodule GlimeshWeb.UserLive.Stream do
   def mount(%{"username" => streamer_username}, session, socket) do
     # If the viewer is logged in set their locale, otherwise it defaults to English
     if session["locale"], do: Gettext.put_locale(session["locale"])
-    if connected?(socket), do: Process.send(self(), :load_stream, [])
+
+    if connected?(socket) do
+      # Wait until the socket connection is ready to load the stream
+      Process.send(
+        self(),
+        {:load_stream, Map.get(session, "country")},
+        []
+      )
+    end
 
     case ChannelLookups.get_channel_for_username!(streamer_username) do
       %Glimesh.Streams.Channel{} = channel ->
@@ -27,7 +35,8 @@ defmodule GlimeshWeb.UserLive.Stream do
          |> assign(:streamer, channel.user)
          |> assign(:channel, channel)
          |> assign(:backend, channel.backend)
-         |> assign(:janus_hostname, "Loading...")
+         |> assign(:janus_url, "Pending...")
+         |> assign(:janus_hostname, "Pending...")
          |> assign(:channel_id, channel.id)
          |> assign(:user, maybe_user)}
 
@@ -36,7 +45,7 @@ defmodule GlimeshWeb.UserLive.Stream do
     end
   end
 
-  def handle_info(:load_stream, socket) do
+  def handle_info({:load_stream, country}, socket) do
     # Keep track of viewers using their socket ID, but later we'll keep track of chatters by their user
     Presence.track_presence(
       self(),
@@ -45,36 +54,26 @@ defmodule GlimeshWeb.UserLive.Stream do
       %{}
     )
 
-    janus_uri = random_janus_server()
-    janus_hostname = hostname_from_url(janus_uri)
+    case Glimesh.Janus.get_closest_edge_location(country) do
+      %Glimesh.Janus.EdgeRoute{url: janus_url, hostname: janus_hostname} ->
+        {:noreply,
+         socket
+         |> push_event("load_video", %{
+           janus_url: janus_url,
+           channel_id: socket.assigns.channel_id
+         })
+         |> assign(:janus_url, janus_url)
+         |> assign(:janus_hostname, janus_hostname)}
 
-    {:noreply,
-     socket
-     |> push_event("load_video", %{
-       janus_uri: janus_uri,
-       channel_id: socket.assigns.channel_id
-     })
-     |> assign(:janus_uri, janus_uri)
-     |> assign(:janus_hostname, janus_hostname)}
+      _ ->
+        # In the event we can't find an edge, something is real wrong
+        {:noreply, socket}
+    end
   end
 
   def handle_event("show_mature", _value, socket) do
     Process.send(self(), :load_stream, [])
 
     {:noreply, assign(socket, :prompt_mature, false)}
-  end
-
-  defp random_janus_server do
-    [
-      "https://do-nyc3-edge1.kjfk.live.glimesh.tv/janus",
-      "https://do-nyc3-edge2.kjfk.live.glimesh.tv/janus",
-      "https://do-nyc3-edge3.kjfk.live.glimesh.tv/janus"
-    ]
-    |> Enum.random()
-  end
-
-  defp hostname_from_url(url) do
-    %URI{host: host} = URI.parse(url)
-    host |> String.split(".") |> hd()
   end
 end

--- a/lib/glimesh_web/live/user_live/stream.ex
+++ b/lib/glimesh_web/live/user_live/stream.ex
@@ -37,6 +37,7 @@ defmodule GlimeshWeb.UserLive.Stream do
          |> assign(:backend, channel.backend)
          |> assign(:janus_url, "Pending...")
          |> assign(:janus_hostname, "Pending...")
+         |> assign(:player_error, nil)
          |> assign(:channel_id, channel.id)
          |> assign(:user, maybe_user)}
 
@@ -67,7 +68,9 @@ defmodule GlimeshWeb.UserLive.Stream do
 
       _ ->
         # In the event we can't find an edge, something is real wrong
-        {:noreply, socket}
+        {:noreply,
+         socket
+         |> assign(:player_error, "Unable to find edge video location, we'll be back soon!")}
     end
   end
 

--- a/lib/glimesh_web/live/user_live/stream.html.leex
+++ b/lib/glimesh_web/live/user_live/stream.html.leex
@@ -1,159 +1,157 @@
 <div class="container-fluid">
-  <div class="row mt-3">
+    <div class="row mt-3">
 
-    <div id="video-column" class="col-lg-9 layout-spacing">
-      <div class="card">
-        <div class="card-header p-1">
-          <div class="row">
-            <div class="col align-self-center">
-              <%= live_render(@socket, GlimeshWeb.UserLive.Components.ChannelTitle, id: "channel-title", session: %{"user" => @user, "channel_id" => @channel.id}) %>
-            </div>
-            <div class="col-auto">
-              <div class="float-right">
-                <div class="stream-info btn-toolbar">
-                  <div class="btn-group mr-sm-2" role="group" aria-label="First group">
-                    <%= if @streamer.stripe_user_id do %>
-                    <%= live_render(@socket, GlimeshWeb.UserLive.Components.SubscribeButton, id: "subscribe-button", session: %{"user" => @user, "streamer" => @streamer}) %>
+        <div id="video-column" class="col-lg-9 layout-spacing">
+            <div class="card">
+                <div class="card-header p-1">
+                    <div class="row">
+                        <div class="col align-self-center">
+                            <%= live_render(@socket, GlimeshWeb.UserLive.Components.ChannelTitle, id: "channel-title", session: %{"user" => @user, "channel_id" => @channel.id}) %>
+                        </div>
+                        <div class="col-auto">
+                            <div class="float-right">
+                                <div class="stream-info btn-toolbar">
+                                    <div class="btn-group mr-sm-2" role="group" aria-label="First group">
+                                        <%= if @streamer.stripe_user_id do %>
+                                        <%= live_render(@socket, GlimeshWeb.UserLive.Components.SubscribeButton, id: "subscribe-button", session: %{"user" => @user, "streamer" => @streamer}) %>
+                                        <% end %>
+                                    </div>
+                                    <div class="btn-group mr-1" role="group" aria-label="Second group">
+                                        <%= live_render(@socket, GlimeshWeb.UserLive.Components.FollowButton, id: "follow-button", session: %{"user" => @user, "streamer" => @streamer}) %>
+                                    </div>
+                                    <div class="btn-group" role="group" aria-label="Third group">
+                                        <%= live_render(@socket, GlimeshWeb.UserLive.Components.ViewerCount, id: "viewer-count", session: %{"channel_id" => @channel.id}) %>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="card-body p-1">
+                    <%= if @prompt_mature do %>
+                    <div class="jumbotron jumbotron-fluid jumbotron-mature-content mb-0">
+                        <div class="container p-5">
+                            <div class="row justify-content-center">
+                                <div class="col-sm-6">
+                                    <h3 class="display-5 text-center"><%= gettext("Mature Content Warning") %></h3>
+                                    <p class="lead text-center">
+                                        <%= gettext("The streamer has flagged this channel as only appropriate for Mature Audiences.") %><br>
+                                        <%= gettext("Do you wish to continue?") %>
+                                    </p>
+                                </div>
+                                <div class="w-100"></div>
+                                <div class="col-8 col-lg-3">
+                                    <button type="button" phx-click="show_mature" class="btn btn-primary btn-block"><%= gettext("Agree & View Channel") %></button>
+                                </div>
+                            </div>
+
+                        </div>
+                    </div>
+
+                    <% else %>
+                    <div class="embed-responsive embed-responsive-16by9">
+                        <%= if @backend == "ftl" do %>
+                        <video id="video-player" class="embed-responsive-item" phx-hook="FtlVideo" poster="<%= Glimesh.ChannelPoster.url({@channel.poster, @channel}, :original) %>" controls muted playsinline></video>
+                        <% else %>
+                        No video player backend specified.
+                        <% end %>
+                    </div>
                     <% end %>
-                  </div>
-                  <div class="btn-group mr-1" role="group" aria-label="Second group">
-                    <%= live_render(@socket, GlimeshWeb.UserLive.Components.FollowButton, id: "follow-button", session: %{"user" => @user, "streamer" => @streamer}) %>
-                  </div>
-                  <div class="btn-group" role="group" aria-label="Third group">
-                    <%= live_render(@socket, GlimeshWeb.UserLive.Components.ViewerCount, id: "viewer-count", session: %{"channel_id" => @channel.id}) %>
-                  </div>
                 </div>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div class="card-body p-1">
-          <%= if @prompt_mature do %>
-          <div class="jumbotron jumbotron-fluid jumbotron-mature-content mb-0">
-            <div class="container p-5">
-              <div class="row justify-content-center">
-                <div class="col-sm-6">
-                  <h3 class="display-5 text-center"><%= gettext("Mature Content Warning") %></h3>
-                  <p class="lead text-center">
-                    <%= gettext("The streamer has flagged this channel as only appropriate for Mature Audiences.") %><br>
-                    <%= gettext("Do you wish to continue?") %>
-                  </p>
+                <div class="card-footer p-1 d-none d-sm-block">
+                    <div class="row">
+                        <div class="col-8 d-inline-flex align-items-center">
+                            <div id="streamer-avatar">
+                                <a href="<%= Routes.user_profile_path(@socket, :index, @channel.user.username) %>">
+                                    <img src="<%= Glimesh.Avatar.url({@channel.user.avatar, @channel.user}, :original)%>" alt="<%= @channel.user.displayname %>" width="48" height="48" class="img-avatar mr-2 float-left <%= if @channel.user.stripe_user_id, do: "img-verified-streamer", else: "" %>">
+                                </a>
+                            </div>
+                            <a title="<%= gettext("View Profile") %>" class="<%= Glimesh.Chat.Effects.get_username_color(@channel.user) %>" href="<%= Routes.user_profile_path(@socket, :index, @channel.user.username) %>">
+                                <h3 class="mb-0"><%= @channel.user.displayname %></h3>
+                            </a>
+
+                            <%= live_render(@socket, GlimeshWeb.UserLive.Components.SocialButtons, id: "social-buttons", container: {:ul, class: "list-inline ml-2 mb-0"}, session: %{"user_id" => @streamer.id}) %>
+
+                            <!--
+                            Video Edge Information
+                            Edge Hostname: <%= @janus_hostname %>
+                            Edge URL: <%= @janus_url %>
+                            -->
+                            <%# live_render(@socket, GlimeshWeb.UserLive.ViewerHeads, id: "viewer-heads", session: %{"user" => @user, "streamer" => @streamer.username, "fake_multiplier" => 12}) %>
+                        </div>
+                        <div class="col-4 align-self-center">
+                            <div class="float-right mr-sm-2">
+                                <%= live_render(@socket, GlimeshWeb.UserLive.Components.ReportButton, id: "report-button", session: %{"user" => @user, "streamer" => @streamer}) %>
+                            </div>
+                        </div>
+                    </div>
                 </div>
-                <div class="w-100"></div>
-                <div class="col-8 col-lg-3">
-                  <button type="button" phx-click="show_mature"
-                    class="btn btn-primary btn-block"><%= gettext("Agree & View Channel") %></button>
+            </div>
+        </div>
+
+        <div id="chat-column" class="col-lg-3 d-flex flex-column position-relative layout-spacing">
+            <div class="chat-flex">
+                <div class="chat-absolute">
+                    <%= live_render @socket, GlimeshWeb.ChatLive.Index, id: "chat", session: %{"user" => @user, "channel_id" => @channel.id} %>
                 </div>
-              </div>
-
             </div>
-          </div>
-
-          <% else %>
-          <div class="embed-responsive embed-responsive-16by9">
-            <%= if @backend == "ftl" do %>
-            <video id="video-player" class="embed-responsive-item" phx-hook="FtlVideo"
-              poster="<%= Glimesh.ChannelPoster.url({@channel.poster, @channel}, :original) %>" controls muted playsinline></video>
-            <% else %>
-            No video player backend specified.
-            <% end %>
-          </div>
-          <% end %>
         </div>
-        <div class="card-footer p-1 d-none d-sm-block">
-          <div class="row">
-            <div class="col-8 d-inline-flex align-items-center">
-              <div id="streamer-avatar">
-                <a href="<%= Routes.user_profile_path(@socket, :index, @channel.user.username) %>">
-                  <img src="<%= Glimesh.Avatar.url({@channel.user.avatar, @channel.user}, :original)%>"
-                    alt="<%= @channel.user.displayname %>" width="48" height="48"
-                    class="img-avatar mr-2 float-left <%= if @channel.user.stripe_user_id, do: "img-verified-streamer", else: "" %>">
-                </a>
-              </div>
-              <a title="<%= gettext("View Profile") %>"
-                class="<%= Glimesh.Chat.Effects.get_username_color(@channel.user) %>"
-                href="<%= Routes.user_profile_path(@socket, :index, @channel.user.username) %>">
-                <h3 class="mb-0"><%= @channel.user.displayname %></h3>
-              </a>
 
-              <%= live_render(@socket, GlimeshWeb.UserLive.Components.SocialButtons, id: "social-buttons", container: {:ul, class: "list-inline ml-2 mb-0"}, session: %{"user_id" => @streamer.id}) %>
+    </div>
 
-              <!--<code>Edge: <%= @janus_hostname %></code>-->
-              <%# live_render(@socket, GlimeshWeb.UserLive.ViewerHeads, id: "viewer-heads", session: %{"user" => @user, "streamer" => @streamer.username, "fake_multiplier" => 12}) %>
+    <div class="row">
+        <div class="col-lg-9 layout-spacing">
+            <div class="card">
+                <div class="card-header">
+                    <h3>About <%= @streamer.displayname %>'s Stream</h3>
+                </div>
+                <div class="card-body user-content-body">
+                    <%= if @streamer.profile_content_html do %>
+                    <%= raw(@streamer.profile_content_html) %>
+                    <% else %>
+                    <p>
+                        <%= gettext("Welcome to my profile! I haven't customized it yet, but I can easily do that by clicking my username up in the right hand corner!") %>
+                    </p>
+                    <% end %>
+                </div>
             </div>
-            <div class="col-4 align-self-center">
-              <div class="float-right mr-sm-2">
-                <%= live_render(@socket, GlimeshWeb.UserLive.Components.ReportButton, id: "report-button", session: %{"user" => @user, "streamer" => @streamer}) %>
-              </div>
+        </div>
+        <div class="col-lg-3 layout-spacing">
+            <div class="card">
+                <div class="card-body user-content-body">
+                    <%= if @channel.chat_rules_html do %>
+                    <%= raw(@channel.chat_rules_html) %>
+                    <% else %>
+                    <h3>Chat Rules</h3>
+                    <p>1. <strong>Hate Speech</strong> - Hate Speech is not tolerated by Glimesh under any circumstances. Any
+                        message that promotes, encourages, or facilitates discrimination, denigration, objectification, harassment,
+                        or violence based on race, age, sexuality, physical characteristics, gender identity, disability, military
+                        service, religion and/or nationality will be considered hate speech is prohibited. We also don't allow for
+                        the hateful use of racial or misogynistic slurs. If you have to question whether your message violates this
+                        rule, don't send it.</p>
+                    <p>2. <strong>Harassment</strong> - We want you, as a member of our community, to feel safe and respected so
+                        you can engage and connect with others. Harassment or bullying of other community members or the streamer
+                        will not be tolerated. Harassment is considered any message or activity with the intention to intimidate,
+                        degrade, abuse, or bully others, or creates a hostile environment for others. Telling the streamer or
+                        another user to "kill yourself" is unacceptable. If the streamer or another community member asks you not to
+                        make certain remarks, and you continue, that is harassment. If the streamer's rules say such comments are
+                        not welcome, it is harassment.</p>
+                    <p>3. <strong>Threats & Violence</strong> - All threats will be taken seriously by the moderators and Glimesh
+                        team. This includes threats of harm to others, threats of swatting, threats of doxing, threats of DDoS and
+                        threats of harassment.</p>
+                    <p>4. <strong>Spam</strong> - No one likes spam. Spam is considered posting large amounts of repetitive,
+                        unwanted messages in a short amount of time.</p>
+                    <p>5. <strong>Personal Information</strong> - Posting personal information about others without their consent
+                        (“doxxing") is not allowed. It is prohibited to share content that may reveal private personal information
+                        about individuals, or their private property, without permission.</p>
+
+                    <p>Any violation to the above rules will result in your comment being removed from the chat and an automatic
+                        <strong>ban for the remainder of the charity stream event</strong>. Serious violations may result in a ban
+                        from future events.</p>
+                    <% end %>
+                </div>
             </div>
-          </div>
         </div>
-      </div>
     </div>
-
-    <div id="chat-column" class="col-lg-3 d-flex flex-column position-relative layout-spacing">
-      <div class="chat-flex">
-        <div class="chat-absolute">
-          <%= live_render @socket, GlimeshWeb.ChatLive.Index, id: "chat", session: %{"user" => @user, "channel_id" => @channel.id} %>
-        </div>
-      </div>
-    </div>
-
-  </div>
-
-  <div class="row">
-    <div class="col-lg-9 layout-spacing">
-      <div class="card">
-        <div class="card-header">
-          <h3>About <%= @streamer.displayname %>'s Stream</h3>
-        </div>
-        <div class="card-body user-content-body">
-          <%= if @streamer.profile_content_html do %>
-          <%= raw(@streamer.profile_content_html) %>
-          <% else %>
-          <p>
-            <%= gettext("Welcome to my profile! I haven't customized it yet, but I can easily do that by clicking my username up in the right hand corner!") %>
-          </p>
-          <% end %>
-        </div>
-      </div>
-    </div>
-    <div class="col-lg-3 layout-spacing">
-      <div class="card">
-        <div class="card-body user-content-body">
-          <%= if @channel.chat_rules_html do %>
-          <%= raw(@channel.chat_rules_html) %>
-          <% else %>
-          <h3>Chat Rules</h3>
-          <p>1. <strong>Hate Speech</strong> - Hate Speech is not tolerated by Glimesh under any circumstances. Any
-            message that promotes, encourages, or facilitates discrimination, denigration, objectification, harassment,
-            or violence based on race, age, sexuality, physical characteristics, gender identity, disability, military
-            service, religion and/or nationality will be considered hate speech is prohibited. We also don't allow for
-            the hateful use of racial or misogynistic slurs. If you have to question whether your message violates this
-            rule, don't send it.</p>
-          <p>2. <strong>Harassment</strong> - We want you, as a member of our community, to feel safe and respected so
-            you can engage and connect with others. Harassment or bullying of other community members or the streamer
-            will not be tolerated. Harassment is considered any message or activity with the intention to intimidate,
-            degrade, abuse, or bully others, or creates a hostile environment for others. Telling the streamer or
-            another user to "kill yourself" is unacceptable. If the streamer or another community member asks you not to
-            make certain remarks, and you continue, that is harassment. If the streamer's rules say such comments are
-            not welcome, it is harassment.</p>
-          <p>3. <strong>Threats & Violence</strong> - All threats will be taken seriously by the moderators and Glimesh
-            team. This includes threats of harm to others, threats of swatting, threats of doxing, threats of DDoS and
-            threats of harassment.</p>
-          <p>4. <strong>Spam</strong> - No one likes spam. Spam is considered posting large amounts of repetitive,
-            unwanted messages in a short amount of time.</p>
-          <p>5. <strong>Personal Information</strong> - Posting personal information about others without their consent
-            (“doxxing") is not allowed. It is prohibited to share content that may reveal private personal information
-            about individuals, or their private property, without permission.</p>
-
-          <p>Any violation to the above rules will result in your comment being removed from the chat and an automatic
-            <strong>ban for the remainder of the charity stream event</strong>. Serious violations may result in a ban
-            from future events.</p>
-          <% end %>
-        </div>
-      </div>
-    </div>
-  </div>
 
 </div>

--- a/lib/glimesh_web/live/user_live/stream.html.leex
+++ b/lib/glimesh_web/live/user_live/stream.html.leex
@@ -56,6 +56,12 @@
                         No video player backend specified.
                         <% end %>
                     </div>
+
+                    <%= if @player_error do %>
+                    <div class="alert alert-danger mt-2" role="alert">
+                        <%= @player_error %>
+                    </div>
+                    <% end %>
                     <% end %>
                 </div>
                 <div class="card-footer p-1 d-none d-sm-block">

--- a/lib/glimesh_web/plugs/cf_country_plug.ex
+++ b/lib/glimesh_web/plugs/cf_country_plug.ex
@@ -1,0 +1,20 @@
+defmodule GlimeshWeb.Plugs.CfCountryPlug do
+  import Plug.Conn
+
+  def init(_opts), do: nil
+
+  def call(conn, _opts) do
+    case get_req_header(conn, "cf-ipcountry") do
+      [country] when is_binary(country) ->
+        persist_country(conn, country)
+
+      _ ->
+        conn
+    end
+  end
+
+  defp persist_country(conn, country) do
+    conn
+    |> put_session(:country, String.upcase(country))
+  end
+end

--- a/lib/glimesh_web/router.ex
+++ b/lib/glimesh_web/router.ex
@@ -12,6 +12,7 @@ defmodule GlimeshWeb.Router do
     plug :put_secure_browser_headers
     plug :fetch_current_user
     plug GlimeshWeb.Plugs.Locale
+    plug GlimeshWeb.Plugs.CfCountryPlug
     plug GlimeshWeb.Plugs.Ban
   end
 

--- a/priv/repo/migrations/20210211144828_add_edge_locations.exs
+++ b/priv/repo/migrations/20210211144828_add_edge_locations.exs
@@ -1,0 +1,15 @@
+defmodule Glimesh.Repo.Migrations.AddEdgeLocations do
+  use Ecto.Migration
+
+  def change do
+    create table(:janus_edge_routes) do
+      add :hostname, :string
+      add :url, :string
+      add :priority, :float, default: 1.00
+      add :available, :boolean
+      add :country_codes, {:array, :string}
+
+      timestamps()
+    end
+  end
+end

--- a/test/glimesh/janus_test.exs
+++ b/test/glimesh/janus_test.exs
@@ -1,0 +1,40 @@
+defmodule Glimesh.JanusTest do
+  use Glimesh.DataCase
+
+  alias Glimesh.Janus
+
+  def create_good_edge(hostname, countries, priority \\ 1.0, available \\ true) do
+    Janus.create_edge_route(%{
+      hostname: hostname,
+      url: "https://#{hostname}/janus",
+      priority: priority,
+      available: available,
+      country_codes: countries
+    })
+  end
+
+  describe "Edge Routing" do
+    test "closest_edge_location/1 routes to a close edge location" do
+      create_good_edge("not-new-york", ["AU"])
+      create_good_edge("new-york", ["US"])
+
+      assert Janus.get_closest_edge_location("US").hostname == "new-york"
+      assert Janus.get_closest_edge_location("AU").hostname == "not-new-york"
+      assert length(Janus.all_edge_routes()) == 2
+    end
+
+    test "closest_edge_location/1 respects priority and availability" do
+      create_good_edge("near-new-york", ["US"], 0.9)
+      create_good_edge("new-york", ["US"], 1.0)
+      create_good_edge("super-new-york", ["US"], 1.1, false)
+
+      assert Janus.get_closest_edge_location("US").hostname == "new-york"
+    end
+
+    test "closest_edge_location/1 falls back to a safe default always" do
+      create_good_edge("new-york", ["US"])
+
+      assert Janus.get_closest_edge_location("DE").hostname == "new-york"
+    end
+  end
+end

--- a/test/glimesh_web/live/user_live/stream_test.exs
+++ b/test/glimesh_web/live/user_live/stream_test.exs
@@ -42,4 +42,46 @@ defmodule GlimeshWeb.UserLive.StreamTest do
       assert page =~ "<video"
     end
   end
+
+  describe "Edge Routing" do
+    setup do
+      Glimesh.Janus.create_edge_route(%{
+        hostname: "some-de-server",
+        url: "https://some-de-server/janus",
+        priority: 1.0,
+        available: true,
+        country_codes: ["DE", "AT"]
+      })
+
+      Glimesh.Janus.create_edge_route(%{
+        hostname: "some-us-server",
+        url: "https://some-us-server/janus",
+        priority: 1.1,
+        available: true,
+        country_codes: ["US", "MX"]
+      })
+
+      streamer = streamer_fixture()
+
+      %{
+        channel: streamer.channel,
+        streamer: streamer
+      }
+    end
+
+    test "gets sent to the correct edge location", %{conn: conn, streamer: streamer} do
+      conn =
+        conn
+        |> Plug.Conn.put_req_header(
+          "cf-ipcountry",
+          "DE"
+        )
+
+      {:ok, view, _} = live(conn, Routes.user_stream_path(conn, :index, streamer.username))
+
+      send(view.pid, {:load_stream, "DE"})
+      assert render(view) =~ "some-de-server"
+      assert render(view) =~ "https://some-de-server/janus"
+    end
+  end
 end


### PR DESCRIPTION
The absolute basics of this PR basically implements a way for us to dynamically route viewers to different edges. At this time I am only focused on routing a viewer to their closest region and then using round-robin DNS to hopefully put them on a distributed number of servers. This PR also adds functionality for us to:

1. Point viewers to a region based on their incoming country code
2. Disable entire regions for routing
3. Prioritize certain regions over others without deactivating them

The next logical iteration of this would be to allow a user to (or do it in the background) run a speed test against our edge regions and remember which location is closest latency wise to them. 

We still don't know exactly how we're going to load balance viewers, but that's a problem for the future us!