### PR TITLE
Tests ignore translations

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -45,3 +45,7 @@ config :glimesh, :stripe_config,
   channel_sub_base_price: 500
 
 config :appsignal, :config, active: false
+
+config :glimesh, GlimeshWeb.Gettext,
+  default_locale: "glim-en",
+  locales: ~w(glim-en)

--- a/test/glimesh/accounts_test.exs
+++ b/test/glimesh/accounts_test.exs
@@ -337,7 +337,7 @@ defmodule Glimesh.AccountsTest do
           displayname: "SomethingDifferent"
         })
 
-      assert %{displayname: ["Display name must match username"]} = errors_on(changeset)
+      assert %{displayname: ["Display name must match Username"]} = errors_on(changeset)
     end
   end
 

--- a/test/glimesh_web/controllers/quick_preference_controller_test.exs
+++ b/test/glimesh_web/controllers/quick_preference_controller_test.exs
@@ -51,7 +51,7 @@ defmodule GlimeshWeb.QuickPreferenceControllerTest do
       assert redirected_to(conn) == Routes.homepage_path(conn, :index)
 
       assert get_flash(conn, :info) =~
-               "Preferences updated successfully."
+               "Preferences updates successfully."
 
       conn = get(conn, Routes.homepage_path(conn, :index))
       assert html_response(conn, 200) =~ "de ☀️"

--- a/test/glimesh_web/controllers/quick_preference_controller_test.exs
+++ b/test/glimesh_web/controllers/quick_preference_controller_test.exs
@@ -51,7 +51,7 @@ defmodule GlimeshWeb.QuickPreferenceControllerTest do
       assert redirected_to(conn) == Routes.homepage_path(conn, :index)
 
       assert get_flash(conn, :info) =~
-               "Preferences updates successfully."
+               "Preferences updated successfully."
 
       conn = get(conn, Routes.homepage_path(conn, :index))
       assert html_response(conn, 200) =~ "de ☀️"

--- a/test/glimesh_web/controllers/user_confirmation_controller_test.exs
+++ b/test/glimesh_web/controllers/user_confirmation_controller_test.exs
@@ -28,7 +28,7 @@ defmodule GlimeshWeb.UserConfirmationControllerTest do
       assert redirected_to(conn) == "/"
 
       assert get_flash(conn, :info) =~
-               "If your email is in our system and it has not been confirmed yet, you will receive an email with instructions shortly."
+               "If your e-mail is in our system and it has not been confirmed yet, you will receive an e-mail with instructions shortly."
 
       assert Repo.get_by!(Accounts.UserToken, user_id: user.id).context == "confirm"
     end
@@ -44,7 +44,7 @@ defmodule GlimeshWeb.UserConfirmationControllerTest do
       assert redirected_to(conn) == "/"
 
       assert get_flash(conn, :info) =~
-               "If your email is in our system and it has not been confirmed yet, you will receive an email with instructions shortly."
+               "If your e-mail is in our system and it has not been confirmed yet, you will receive an e-mail with instructions shortly."
 
       refute Repo.get_by(Accounts.UserToken, user_id: user.id)
     end
@@ -58,7 +58,7 @@ defmodule GlimeshWeb.UserConfirmationControllerTest do
       assert redirected_to(conn) == "/"
 
       assert get_flash(conn, :info) =~
-               "If your email is in our system and it has not been confirmed yet, you will receive an email with instructions shortly."
+               "If your e-mail is in our system and it has not been confirmed yet, you will receive an e-mail with instructions shortly."
 
       assert Repo.all(Accounts.UserToken) == []
     end

--- a/test/glimesh_web/controllers/user_registration_controller_test.exs
+++ b/test/glimesh_web/controllers/user_registration_controller_test.exs
@@ -89,7 +89,7 @@ defmodule GlimeshWeb.UserRegistrationControllerTest do
       response = html_response(conn, 200)
       assert response =~ "<h3>Register for our Alpha!</h3>"
       assert response =~ "must have the @ sign and no spaces"
-      assert response =~ "Must be at least 8 characters"
+      assert response =~ "should be at least 8 character(s)"
     end
 
     test "render errors if hcaptcha is invalid", %{conn: conn} do

--- a/test/glimesh_web/controllers/user_reset_password_controller_test.exs
+++ b/test/glimesh_web/controllers/user_reset_password_controller_test.exs
@@ -28,7 +28,7 @@ defmodule GlimeshWeb.UserResetPasswordControllerTest do
       assert redirected_to(conn) == "/"
 
       assert get_flash(conn, :info) =~
-               "If your email is in our system, you will receive instructions to reset your password shortly."
+               "If your e-mail is in our system, you will receive instructions to reset your password shortly."
 
       assert Repo.get_by!(Accounts.UserToken, user_id: user.id).context == "reset_password"
     end
@@ -42,7 +42,7 @@ defmodule GlimeshWeb.UserResetPasswordControllerTest do
       assert redirected_to(conn) == "/"
 
       assert get_flash(conn, :info) =~
-               "If your email is in our system, you will receive instructions to reset your password shortly."
+               "If your e-mail is in our system, you will receive instructions to reset your password shortly."
 
       assert Repo.all(Accounts.UserToken) == []
     end
@@ -60,7 +60,7 @@ defmodule GlimeshWeb.UserResetPasswordControllerTest do
 
     test "renders reset password", %{conn: conn, token: token} do
       conn = get(conn, Routes.user_reset_password_path(conn, :edit, token))
-      assert html_response(conn, 200) =~ "<h1>Reset Password</h1>"
+      assert html_response(conn, 200) =~ "<h1>Reset password</h1>"
     end
 
     test "does not render reset password with invalid token", %{conn: conn} do
@@ -105,8 +105,8 @@ defmodule GlimeshWeb.UserResetPasswordControllerTest do
         })
 
       response = html_response(conn, 200)
-      assert response =~ "<h1>Reset Password</h1>"
-      assert response =~ "Must be at least 8 characters"
+      assert response =~ "<h1>Reset password</h1>"
+      assert response =~ "should be at least 8 character(s)"
       assert response =~ "Password does not match"
     end
 

--- a/test/glimesh_web/live/category_live_test.exs
+++ b/test/glimesh_web/live/category_live_test.exs
@@ -50,7 +50,7 @@ defmodule GlimeshWeb.CategoryLiveTest do
 
       assert index_live
              |> form("#category-form", category: @invalid_attrs)
-             |> render_change() =~ "Cannot be blank"
+             |> render_change() =~ "be blank"
 
       new_input = %{name: "some new category"}
 
@@ -74,7 +74,7 @@ defmodule GlimeshWeb.CategoryLiveTest do
 
       assert index_live
              |> form("#category-form", category: @invalid_attrs)
-             |> render_change() =~ "Cannot be blank"
+             |> render_change() =~ "be blank"
 
       {:ok, _, html} =
         index_live
@@ -110,7 +110,7 @@ defmodule GlimeshWeb.CategoryLiveTest do
 
       assert show_live
              |> form("#category-form", category: @invalid_attrs)
-             |> render_change() =~ "Cannot be blank"
+             |> render_change() =~ "be blank"
 
       {:ok, _, html} =
         show_live

--- a/test/glimesh_web/live/tag_live_test.exs
+++ b/test/glimesh_web/live/tag_live_test.exs
@@ -46,7 +46,7 @@ defmodule GlimeshWeb.TagLiveTest do
 
       assert index_live
              |> form("#tag-form", tag: @invalid_attrs)
-             |> render_change() =~ "Cannot be blank"
+             |> render_change() =~ "be blank"
 
       {:ok, _, html} =
         index_live
@@ -68,7 +68,7 @@ defmodule GlimeshWeb.TagLiveTest do
 
       assert index_live
              |> form("#tag-form", tag: @invalid_attrs)
-             |> render_change() =~ "Cannot be blank"
+             |> render_change() =~ "be blank"
 
       {:ok, _, html} =
         index_live


### PR DESCRIPTION
Ignore the branch name. I forgot to rename it after testing. 

This gives a default locale of `glim-en` for tests. This locale doesn't exist/has empty translations so it defaults to the input string.