### PR TITLE
Using username instead of displayname for stream listing links

### DIFF
--- a/lib/glimesh_web/live/streams_live/list.html.leex
+++ b/lib/glimesh_web/live/streams_live/list.html.leex
@@ -49,7 +49,7 @@
     <div class="row">
         <%= for channel <- @channels do %>
         <div class="col-sm-12 col-md-6 col-lg-4 mt-4">
-            <%= live_redirect to: Routes.user_stream_path(@socket, :index, channel.user.displayname), class: "text-color-link" do %>
+            <%= live_redirect to: Routes.user_stream_path(@socket, :index, channel.user.username), class: "text-color-link" do %>
             <div class="card card-stream">
                 <img src="<%= Glimesh.StreamThumbnail.url({channel.stream.thumbnail, channel.stream}, :original) %>"
                     alt="<%= channel.title %>" class="card-img">


### PR DESCRIPTION
This doesn't break anything currently but if we ever allowed arbitrary display names it would instantly break. Ensuring it uses the username will make sure the URL will never be wonky and break. 