### PR TITLE
Add query string to redirect if exists

### DIFF
--- a/lib/glimesh_web/controllers/user_auth.ex
+++ b/lib/glimesh_web/controllers/user_auth.ex
@@ -210,7 +210,8 @@ defmodule GlimeshWeb.UserAuth do
   end
 
   defp maybe_store_return_to(%{method: "GET", request_path: request_path} = conn) do
-    put_session(conn, :user_return_to, request_path)
+    maybe_query_string = unless conn.query_string == "", do: "?#{conn.query_string}", else: ""
+    put_session(conn, :user_return_to, request_path <> maybe_query_string)
   end
 
   defp maybe_store_return_to(conn), do: conn

--- a/lib/glimesh_web/controllers/user_auth.ex
+++ b/lib/glimesh_web/controllers/user_auth.ex
@@ -210,7 +210,10 @@ defmodule GlimeshWeb.UserAuth do
   end
 
   defp maybe_store_return_to(%{method: "GET", request_path: request_path} = conn) do
-    maybe_query_string = unless conn.query_string == "", do: "?#{conn.query_string}", else: ""
+    maybe_query_string = case conn.query_string do
+      "" -> ""
+      _ -> "?#{conn.query_string}"
+    end
     put_session(conn, :user_return_to, request_path <> maybe_query_string)
   end
 


### PR DESCRIPTION
Fixes #432 

This basically passes the query string into the `user_return_to` session variable. It will only add in the string when it exists. 