### PR TITLE
Allow GCT members to edit users

### DIFF
--- a/lib/glimesh/community_team/policy.ex
+++ b/lib/glimesh/community_team/policy.ex
@@ -76,6 +76,12 @@ defmodule Glimesh.CommunityTeam.Policy do
       else: true
   end
 
+  def authorize(:edit_user, %User{is_gct: true, gct_level: 2} = current_user, user) do
+    if is_self?(current_user, user) || is_user_higher_level?(current_user, user),
+      do: false,
+      else: true
+  end
+
   def authorize(:can_ban, %User{is_gct: true, gct_level: 2} = current_user, user) do
     if is_self?(current_user, user) || is_user_higher_level?(current_user, user),
       do: false,

--- a/lib/glimesh_web/templates/gct/edit_user.html.eex
+++ b/lib/glimesh_web/templates/gct/edit_user.html.eex
@@ -39,27 +39,17 @@
             </div>
             <div class="row mt-1">
                 <div class="col-sm-6">
-                    <%= label f, gettext("Admin") %>
-                    <%= select f, :is_admin, [Yes: true, No: false], [class: "form-control"] %>
-                    <%= error_tag f, :is_admin %>
-                </div>
-                <div class="col-sm-6">
-                    <%= label f, gettext("Can stream") %>
-                    <%= select f, :can_stream, [Yes: true, No: false], [class: "form-control"] %>
-                    <%= error_tag f, :can_stream %>
-                </div>
-            </div>
-            <div class="row mt-1">
-                <div class="col-sm-6">
                     <%= label f, gettext("2FA Token") %>
                     <%= text_input f, :tfa_token, [class: "form-control"] %>
                     <%= error_tag f, :tfa_token %>
                 </div>
+                <%= if @conn.assigns.current_user.gct_level >= 4 || @conn.assigns.current_user.is_admin do %>
                 <div class="col-sm-6">
                     <%= label f, gettext("Team Role") %>
                     <%= text_input f, :team_role, [class: "form-control"] %>
                     <%= error_tag f, :team_role %>
                 </div>
+                <% end %>
             </div>
             <!-- Billing section of the user -->
             <%= if @view_billing? do %>
@@ -90,7 +80,21 @@
                 </div>
             </div>
             <% end %>
-            <%= if @conn.assigns.current_user.gct_level >= 4 do %>
+            <%= if @conn.assigns.current_user.gct_level >= 4 || @conn.assigns.current_user.is_admin do %>
+            <hr>
+            <h5><%= gettext("Admin Settings")%></h5>
+            <div class="row mt-1">
+                <div class="col-sm-6">
+                    <%= label f, gettext("Admin") %>
+                    <%= select f, :is_admin, [Yes: true, No: false], [class: "form-control"] %>
+                    <%= error_tag f, :is_admin %>
+                </div>
+                <div class="col-sm-6">
+                    <%= label f, gettext("Can stream") %>
+                    <%= select f, :can_stream, [Yes: true, No: false], [class: "form-control"] %>
+                    <%= error_tag f, :can_stream %>
+                </div>
+            </div>
             <hr>
             <h5><%= gettext("GCT Settings") %></h5>
             <div class="row mt-1">
@@ -107,6 +111,7 @@
             </div>
             <% end %>
             <hr>
+            <h5><%= gettext("Ban Settings") %></h5>
             <div class="row mt-1">
                 <div class="col-sm-6">
                     <%= label f, gettext("Banned") %>

--- a/test/glimesh/community_team_test.exs
+++ b/test/glimesh/community_team_test.exs
@@ -12,7 +12,7 @@ defmodule Glimesh.CommunityTeamTest do
     end
 
     test "can't edit user if no permission" do
-      user = gct_fixture(%{gct_level: 2, tfa_token: "Fake 2fa token"})
+      user = gct_fixture(%{gct_level: 1, tfa_token: "Fake 2fa token"})
 
       assert Bodyguard.permit?(Glimesh.CommunityTeam, :edit_user, user, user_fixture()) == false
     end


### PR DESCRIPTION
This adds 2 new changes:
- GCT perm level 2(normal GCT members) can now access the edit users page
- Admins before were locked out of certain elements on the edit users page if they weren't assigned a GCT level, that is now fixed.