### PR TITLE
Adding 6 hour cooldown to follow messages in chat

### DIFF
--- a/lib/glimesh/account_follows.ex
+++ b/lib/glimesh/account_follows.ex
@@ -100,7 +100,7 @@ defmodule Glimesh.AccountFollows do
     Repo.all(from f in Follower, where: f.user_id == ^user.id)
   end
 
-  defp no_follow_message_recently(channel, user) do
+  defp sent_follow_message_recently?(channel, user) do
     follow_message = List.first(Chat.get_follow_chat_message_for_user(channel, user))
 
     time_since_last_follow_message =

--- a/lib/glimesh/account_follows.ex
+++ b/lib/glimesh/account_follows.ex
@@ -49,7 +49,7 @@ defmodule Glimesh.AccountFollows do
     broadcast(results, :followers)
 
     if !is_nil(channel) and Glimesh.Chat.can_create_chat_message?(channel, user) and
-         no_follow_message_recently(channel, user) do
+         sent_follow_message_recently?(channel, user) do
       Chat.create_chat_message(user, channel, %{
         message: " just followed the stream!",
         is_followed_message: true

--- a/lib/glimesh/account_follows.ex
+++ b/lib/glimesh/account_follows.ex
@@ -101,7 +101,7 @@ defmodule Glimesh.AccountFollows do
   end
 
   defp sent_follow_message_recently?(channel, user) do
-    follow_message = List.first(Chat.get_follow_chat_message_for_user(channel, user))
+    follow_message = Chat.get_follow_chat_message_for_user(channel, user)
 
     time_since_last_follow_message =
       case follow_message do

--- a/lib/glimesh/account_follows.ex
+++ b/lib/glimesh/account_follows.ex
@@ -46,7 +46,7 @@ defmodule Glimesh.AccountFollows do
 
     channel = ChannelLookups.get_channel_for_user(streamer)
 
-    if no_follow_message_recently(channel, user), do: broadcast(results, :followers)
+    broadcast(results, :followers)
 
     if !is_nil(channel) and Glimesh.Chat.can_create_chat_message?(channel, user) and
          no_follow_message_recently(channel, user) do

--- a/lib/glimesh/account_follows.ex
+++ b/lib/glimesh/account_follows.ex
@@ -105,12 +105,12 @@ defmodule Glimesh.AccountFollows do
 
     time_since_last_follow_message =
       case follow_message do
-        nil -> 99999
+        nil -> 99_999
         _ -> NaiveDateTime.diff(NaiveDateTime.utc_now(), follow_message.inserted_at)
       end
 
     # Checking if the last follow message is older than 6 hours
-    if time_since_last_follow_message > 21600 do
+    if time_since_last_follow_message > 21_600 do
       true
     else
       false

--- a/lib/glimesh/chat.ex
+++ b/lib/glimesh/chat.ex
@@ -203,7 +203,6 @@ defmodule Glimesh.Chat do
       order_by: [desc: :inserted_at],
       limit: 1
     )
-    |> Enum.reverse()
   end
 
   @doc """

--- a/lib/glimesh/chat.ex
+++ b/lib/glimesh/chat.ex
@@ -197,7 +197,7 @@ defmodule Glimesh.Chat do
   Gets the latest follower message from a channel for a user
   """
   def get_follow_chat_message_for_user(channel, user) do
-    Repo.all(
+    Repo.one(
       from m in ChatMessage,
       where: m.channel_id == ^channel.id and m.user_id == ^user.id and m.is_followed_message == true,
       order_by: [desc: :inserted_at],

--- a/lib/glimesh/chat.ex
+++ b/lib/glimesh/chat.ex
@@ -192,6 +192,20 @@ defmodule Glimesh.Chat do
   """
   def get_chat_message!(id), do: Repo.get!(ChatMessage, id) |> Repo.preload([:user, :channel])
 
+
+  @doc """
+  Gets the latest follower message from a channel for a user
+  """
+  def get_follow_chat_message_for_user(channel, user) do
+    Repo.all(
+      from m in ChatMessage,
+      where: m.channel_id == ^channel.id and m.user_id == ^user.id and m.is_followed_message == true,
+      order_by: [desc: :inserted_at],
+      limit: 1
+    )
+    |> Enum.reverse()
+  end
+
   @doc """
   Returns an `%Ecto.Changeset{}` for tracking chat_message changes.
 


### PR DESCRIPTION
Checks the last follow message sent, if it's more than 6 hours ago it'll send a new message, if the message doesn't exist it'll send a new one, otherwise it just silently follows the streamer. 