### PR TITLE
Correct unsubscribe logic for subscriptions

### DIFF
--- a/lib/glimesh/formatters.ex
+++ b/lib/glimesh/formatters.ex
@@ -8,16 +8,15 @@ defmodule Glimesh.Formatters do
   def format_price(nil), do: "0.00"
   def format_price(iprice), do: :erlang.float_to_binary(iprice / 100, decimals: 2)
 
-  def format_datetime(nil), do: "Unknown"
-
   def format_datetime(timestamp) when is_integer(timestamp) do
-    d = DateTime.from_unix!(timestamp)
-    "#{d.year}/#{d.month}/#{d.day}"
+    format_datetime(DateTime.from_unix!(timestamp))
   end
 
-  def format_datetime(%{year: year, month: month, day: day}) do
-    "#{year}/#{month}/#{day}"
+  def format_datetime(%{year: _, month: _, day: _y} = datetime) do
+    Calendar.strftime(datetime, "%b %d %Y")
   end
+
+  def format_datetime(_), do: "Unknown"
 
   def format_page_title(nil) do
     "Glimesh"

--- a/lib/glimesh/payment_providers/stripe/stripe.ex
+++ b/lib/glimesh/payment_providers/stripe/stripe.ex
@@ -174,11 +174,12 @@ defmodule Glimesh.PaymentProviders.StripeProvider do
     potential_payout_amount = total_amount - glimesh_cut
 
     # Withholding is calculated from the potential payout amount, not the full amount
+    # Rounded UP in the event the withholding is a fractional percent eg 2.50 - 0.125 = 2.38
     withholding_amount =
       if streamer.tax_withholding_percent,
         do:
           Decimal.to_integer(
-            Decimal.mult(potential_payout_amount, streamer.tax_withholding_percent)
+            Decimal.round(Decimal.mult(potential_payout_amount, streamer.tax_withholding_percent))
           ),
         else: 0
 

--- a/lib/glimesh/payment_providers/stripe/webhooks.ex
+++ b/lib/glimesh/payment_providers/stripe/webhooks.ex
@@ -80,6 +80,22 @@ defmodule Glimesh.PaymentProviders.StripeProvider.Webhooks do
     end
   end
 
+  def handle_webhook(%{
+        type: "customer.subscription.deleted",
+        data: %{object: %Stripe.Subscription{} = subscription}
+      }) do
+    case subscription.status do
+      "canceled" ->
+        Payments.process_unsuccessful_renewal(subscription.id)
+
+      "unpaid" ->
+        Payments.process_unsuccessful_renewal(subscription.id)
+
+      _ ->
+        {:ok, ""}
+    end
+  end
+
   def handle_webhook(%{type: type} = webhook) do
     #   Fall through webhook handler for stripe events, logging into prod for now so we can figure
     # out the right methods to implement.

--- a/lib/glimesh/payments.ex
+++ b/lib/glimesh/payments.ex
@@ -207,13 +207,63 @@ defmodule Glimesh.Payments do
     end
   end
 
-  def unsubscribe(subscription) do
-    with {:ok, _} <- Stripe.Subscription.delete(subscription.stripe_subscription_id),
-         {:ok, sub} <- update_subscription(subscription, %{is_active: false}) do
+  @doc """
+  Resubscribe to the subscription.
+  Only allowed if the stripe subscription is not cancelled
+  """
+  def resubscribe(%Subscription{is_active: true} = subscription) do
+    with {:ok, stripe_sub} <-
+           Stripe.Subscription.update(subscription.stripe_subscription_id, %{
+             cancel_at_period_end: false
+           }),
+         {:ok, sub} <-
+           update_subscription(subscription, %{
+             is_canceling: false,
+             ended_at:
+               stripe_sub.current_period_end |> DateTime.from_unix!() |> DateTime.to_naive()
+           }) do
       {:ok, sub}
     else
       {:error, %Stripe.Error{} = error} -> {:error, error.user_message || error.message}
       {:error, %Ecto.Changeset{errors: errors}} -> {:error, errors}
+    end
+  end
+
+  def resubscribe(%Subscription{is_active: false}) do
+    {:error, "Cannot resubscribe a expired subscription."}
+  end
+
+  def unsubscribe(subscription) do
+    with {:ok, stripe_sub} <-
+           Stripe.Subscription.update(subscription.stripe_subscription_id, %{
+             cancel_at_period_end: true
+           }),
+         {:ok, sub} <-
+           update_subscription(subscription, %{
+             is_canceling: true,
+             ended_at:
+               stripe_sub.current_period_end |> DateTime.from_unix!() |> DateTime.to_naive()
+           }) do
+      {:ok, sub}
+    else
+      {:error, %Stripe.Error{} = error} -> {:error, error.user_message || error.message}
+      {:error, %Ecto.Changeset{errors: errors}} -> {:error, errors}
+    end
+  end
+
+  @doc """
+  Immediately cancel a subscription -- do not use unless working with Stripe webhooks
+  """
+  def cancel(subscription) do
+    case update_subscription(subscription, %{is_canceling: false, is_active: false}) do
+      {:ok, sub} ->
+        {:ok, sub}
+
+      {:error, %Stripe.Error{} = error} ->
+        {:error, error.user_message || error.message}
+
+      {:error, %Ecto.Changeset{errors: errors}} ->
+        {:error, errors}
     end
   end
 
@@ -233,7 +283,7 @@ defmodule Glimesh.Payments do
   def process_unsuccessful_renewal(stripe_subscription_id) do
     case get_subscription_by_stripe_id(stripe_subscription_id) do
       %Subscription{} = sub ->
-        unsubscribe(sub)
+        cancel(sub)
 
       _ ->
         {:error, "Unable to find subscription by stripe_subscription_id"}
@@ -249,7 +299,7 @@ defmodule Glimesh.Payments do
 
   def get_subscription_by_stripe_id(nil), do: nil
 
-  def get_platform_subscription!(user) do
+  def get_platform_subscription(user) do
     Repo.one(
       from s in Subscription,
         where: s.user_id == ^user.id and s.is_active == true and is_nil(s.streamer_id)
@@ -305,6 +355,11 @@ defmodule Glimesh.Payments do
       from s in Subscription,
         where: s.user_id == ^user.id and s.is_active == true and not is_nil(s.streamer_id)
     )
+    |> Repo.preload([:user, :streamer])
+  end
+
+  def get_channel_subscription(user, streamer) do
+    Repo.get_by(Subscription, user_id: user.id, is_active: true, streamer_id: streamer.id)
     |> Repo.preload([:user, :streamer])
   end
 

--- a/lib/glimesh/payments.ex
+++ b/lib/glimesh/payments.ex
@@ -230,7 +230,7 @@ defmodule Glimesh.Payments do
   end
 
   def resubscribe(%Subscription{is_active: false}) do
-    {:error, "Cannot resubscribe a expired subscription."}
+    {:error, "Cannot resubscribe an expired subscription."}
   end
 
   def unsubscribe(subscription) do

--- a/lib/glimesh/payments/subscription.ex
+++ b/lib/glimesh/payments/subscription.ex
@@ -32,6 +32,7 @@ defmodule Glimesh.Payments.Subscription do
     field :product_name, :string
 
     field :is_active, :boolean
+    field :is_canceling, :boolean
     field :started_at, :naive_datetime
     field :ended_at, :naive_datetime
 
@@ -76,7 +77,7 @@ defmodule Glimesh.Payments.Subscription do
   @doc false
   def update_changeset(subscription, attrs) do
     subscription
-    |> cast(attrs, [:stripe_current_period_end, :ended_at, :is_active])
+    |> cast(attrs, [:stripe_current_period_end, :ended_at, :is_active, :is_canceling])
     |> validate_required([:stripe_current_period_end, :ended_at, :is_active])
   end
 

--- a/lib/glimesh_web/controllers/user_payments_controller.ex
+++ b/lib/glimesh_web/controllers/user_payments_controller.ex
@@ -24,7 +24,7 @@ defmodule GlimeshWeb.UserPaymentsController do
       incoming: Payments.sum_incoming(user),
       outgoing: Payments.sum_outgoing(user),
       stripe_countries: countries,
-      platform_subscription: Payments.get_platform_subscription!(user),
+      platform_subscription: Payments.get_platform_subscription(user),
       subscriptions: Payments.get_channel_subscriptions(user),
       default_payment_changeset: Accounts.change_stripe_default_payment(user),
       has_payment_method: !is_nil(user.stripe_payment_method),

--- a/lib/glimesh_web/live/platform_subscription_live/index.html.leex
+++ b/lib/glimesh_web/live/platform_subscription_live/index.html.leex
@@ -19,8 +19,7 @@
                     </ul>
 
                     <%= if @has_platform_subscription == false do %>
-                    <button phx-click="select-platform-supporter"
-                        class="button btn btn-primary btn-block mt-2"><%= gettext("Select") %></button>
+                    <button phx-click="select-platform-supporter" class="button btn btn-primary btn-block mt-2"><%= gettext("Select") %></button>
                     <% end %>
                 </div>
             </div>
@@ -40,8 +39,7 @@
                     </ul>
 
                     <%= if @has_platform_subscription == false do %>
-                    <button phx-click="select-platform-founder"
-                        class="button btn btn-primary btn-block mt-2"><%= gettext("Select") %></button>
+                    <button phx-click="select-platform-founder" class="button btn btn-primary btn-block mt-2"><%= gettext("Select") %></button>
                     <% end %>
                 </div>
             </div>
@@ -51,20 +49,22 @@
                 <div class="card-body">
                     <%= if @has_platform_subscription do %>
                     <h4><%= gettext("You're subscribed!") %></h4>
-                    <h6><%= gettext("Thanks for supporting Glimesh. Your genuine support is appreciated.") %></h6>
 
+
+                    <%= if @canceling do %>
+                    <p><%= gettext("Your subscription is set to be canceled automatically at the end of the billing cycle.") %></p>
+
+                    <button class="btn btn-primary btn-block btn-lg" phx-click="resubscribe" phx-throttle="5000"><%= gettext("Resubscribe") %></button>
+                    <% else %>
+                    <h6><%= gettext("Thanks for supporting Glimesh. Your genuine support is appreciated.") %></h6>
                     <div class="text-center mt-4">
                         <h4><%= @subscription.product_name %><br>
                             <small><strong>$<%= format_price(@subscription.price) %></strong> /
                                 <%= gettext("monthly") %></small></h4>
                     </div>
 
-                    <div class="text-center mt-4 mb-4">
-                        <img src="/images/glimcons/GlimberryPie.png" alt="" class="img-fluid">
-                    </div>
-
-                    <button class="btn btn-danger btn-block" phx-click="cancel-subscription"
-                        phx-throttle="1000"><%= gettext("Cancel Subscription") %></button>
+                    <button class="btn btn-danger btn-block" phx-click="cancel-subscription" phx-throttle="1000"><%= gettext("Cancel Subscription") %></button>
+                    <% end %>
 
                     <% else %>
 
@@ -76,8 +76,7 @@
 
                     <%= live_component @socket, GlimeshWeb.SubscriptionComponent, id: "subscription-component", type: :platform, user: @user, product_id: @product_id, price_id: @price_id, price: @price %>
 
-                    <img src="/images/stripe-badge-white.png"
-                        alt="<%= gettext("We use Stripe as our payment provider.") %>" class="img-fluid mt-4">
+                    <img src="/images/stripe-badge-white.png" alt="<%= gettext("We use Stripe as our payment provider.") %>" class="img-fluid mt-4">
                     <% end %>
                 </div>
             </div>

--- a/lib/glimesh_web/live/user_live/components/subscribe_button.ex
+++ b/lib/glimesh_web/live/user_live/components/subscribe_button.ex
@@ -11,7 +11,11 @@ defmodule GlimeshWeb.UserLive.Components.SubscribeButton do
         <%= if @user do %>
             <%= if @can_subscribe do %>
                 <%= if @subscribed do %>
-                    <button class="btn btn-secondary btn-responsive" phx-click="unsubscribe" phx-throttle="5000"><span class="d-none d-lg-block"><%= gettext("Unsubscribe") %></span><span class="d-lg-none"><i class="fas fa-star"></i></span></button>
+                    <%= if @canceling do %>
+                    <button class="btn btn-secondary btn-responsive" phx-click="show_resub_modal" phx-throttle="5000"><span class="d-none d-lg-block"><%= gettext("Resubscribe") %></span><span class="d-lg-none"><i class="fas fa-star"></i></span></button>
+                    <% else %>
+                    <button class="btn btn-secondary btn-responsive" phx-click="unsubscribe" phx-throttle="5000" data-confirm="<%= gettext("Are you sure you want to unsubscribe?") %>"><span class="d-none d-lg-block"><%= gettext("Unsubscribe") %></span><span class="d-lg-none"><i class="fas fa-star"></i></span></button>
+                    <% end %>
                 <% else %>
                     <button class="btn btn-secondary btn-responsive" phx-click="show_modal" phx-throttle="5000"><span class="d-none d-lg-block"><%= gettext("Subscribe") %></span><span class="d-lg-none"><i class="fas fa-star"></i></span></button>
                 <% end %>
@@ -54,6 +58,42 @@ defmodule GlimeshWeb.UserLive.Components.SubscribeButton do
             </div>
         </div>
         <% end %>
+        <%= if @show_resub_modal do %>
+        <div id="resubModal" class="live-modal"
+            phx-capture-click="hide_resub_modal"
+            phx-window-keydown="hide_resub_modal"
+            phx-key="escape"
+            phx-target="#resubModal"
+            phx-page-loading>
+            <div class="modal-dialog" role="document">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title"><%= gettext("Resubscribe") %></h5>
+                        <button type="button" class="close" phx-click="hide_resub_modal" aria-label="Close">
+                        <span aria-hidden="true">&times;</span>
+                        </button>
+                    </div>
+
+                    <div class="modal-body">
+                        <%= if @stripe_error do %>
+                          <div class="alert alert-danger" role="alert">
+                            <%= @stripe_error %>
+                          </div>
+                        <% end %>
+
+                        <p><%= gettext("Your subscription is currently set to automatically cancel at the end of your billing cycle.") %></p>
+                        <p><%= gettext("You can resubscribe by clicking the button below, and your subscription will be renewed until you cancel it.") %></p>
+
+                        <button class="btn btn-primary btn-block btn-lg" phx-click="resubscribe" phx-throttle="5000"><%= gettext("Resubscribe") %></button>
+
+                        <img src="/images/stripe-badge-white.png" alt="We use Stripe as our payment provider."
+                        class="img-fluid mt-4 mx-auto d-block">
+                    </div>
+
+                </div>
+            </div>
+        </div>
+        <% end %>
     </div>
     """
   end
@@ -66,12 +106,14 @@ defmodule GlimeshWeb.UserLive.Components.SubscribeButton do
      |> assign(:can_subscribe, false)
      |> assign(:user, nil)
      |> assign(:subscribed, false)
+     |> assign(:canceling, false)
+     |> assign(:show_resub_modal, false)
      |> assign(:show_subscription, false)}
   end
 
   @impl true
   def mount(_params, %{"streamer" => streamer, "user" => user}, socket) do
-    subscribed = Glimesh.Payments.has_channel_subscription?(user, streamer)
+    subscription = Glimesh.Payments.get_channel_subscription(user, streamer)
 
     can_subscribe = if Accounts.can_use_payments?(user), do: user.id != streamer.id, else: false
     can_receive_payments = Accounts.can_receive_payments?(streamer)
@@ -86,10 +128,12 @@ defmodule GlimeshWeb.UserLive.Components.SubscribeButton do
      |> assign(:price_id, Payments.get_channel_sub_base_price_id())
      |> assign(:price, Payments.get_channel_sub_base_price())
      |> assign(:show_subscription, false)
+     |> assign(:show_resub_modal, false)
      |> assign(:streamer, streamer)
      |> assign(:user, user)
      |> assign(:can_subscribe, can_subscribe && can_receive_payments && Glimesh.has_launched?())
-     |> assign(:subscribed, subscribed)}
+     |> assign(:canceling, if(subscription, do: subscription.is_canceling, else: false))
+     |> assign(:subscribed, !is_nil(subscription))}
   end
 
   @impl true
@@ -134,8 +178,22 @@ defmodule GlimeshWeb.UserLive.Components.SubscribeButton do
 
     case Payments.unsubscribe(subscription) do
       {:ok, _} ->
-        {:noreply,
-         socket |> assign(:subscribed, Payments.has_channel_subscription?(user, streamer))}
+        {:noreply, socket |> assign(:canceling, true)}
+
+      {:error, error_msg} ->
+        {:noreply, socket |> assign(:stripe_error, error_msg)}
+    end
+  end
+
+  @impl true
+  def handle_event("resubscribe", _value, socket) do
+    streamer = socket.assigns.streamer
+    user = socket.assigns.user
+    subscription = Payments.get_channel_subscription!(user, streamer)
+
+    case Payments.resubscribe(subscription) do
+      {:ok, _} ->
+        {:noreply, socket |> assign(:show_resub_modal, false) |> assign(:canceling, false)}
 
       {:error, error_msg} ->
         {:noreply, socket |> assign(:stripe_error, error_msg)}
@@ -150,5 +208,15 @@ defmodule GlimeshWeb.UserLive.Components.SubscribeButton do
   @impl true
   def handle_event("hide_modal", _value, socket) do
     {:noreply, socket |> assign(:show_subscription, false)}
+  end
+
+  @impl true
+  def handle_event("show_resub_modal", _value, socket) do
+    {:noreply, socket |> assign(:show_resub_modal, true)}
+  end
+
+  @impl true
+  def handle_event("hide_resub_modal", _value, socket) do
+    {:noreply, socket |> assign(:show_resub_modal, false)}
   end
 end

--- a/lib/glimesh_web/templates/user_payments/index.html.eex
+++ b/lib/glimesh_web/templates/user_payments/index.html.eex
@@ -103,10 +103,14 @@
             <div class="card">
                 <div class="card-body">
                     <h5 class="card-title"><%= @platform_subscription.product_name %></h5>
-                    <p class="card-text">
-                        <%= gettext("Subscribed since %{date}.", date: format_datetime(@platform_subscription.started_at)) %>
+                    <p>
+                        <%= gettext("Subscribed since %{date}", date: format_datetime(@platform_subscription.started_at)) %>
                     </p>
+                    <%= if @platform_subscription.is_canceling do %>
+                    <%= gettext("Canceling on %{date}", date: format_datetime(@platform_subscription.ended_at)) %>
+                    <% else %>
                     <%= link gettext("Unsubscribe"), to: Routes.platform_subscription_index_path(@conn, :index), class: "btn btn-danger btn-sm" %>
+                    <% end %>
                 </div>
             </div>
         </div>
@@ -116,9 +120,13 @@
             <div class="card">
                 <div class="card-body">
                     <h5 class="card-title"><%= sub.streamer.displayname %></h5>
-                    <p class="card-text">
+                    <p>
                         <%= gettext("Subscribed since %{date}", date: format_datetime(sub.started_at)) %></p>
+                    <%= if sub.is_canceling do %>
+                    <%= gettext("Canceling on %{date}", date: format_datetime(sub.ended_at)) %>
+                    <% else %>
                     <%= link "Unsubscribe", to: Routes.user_stream_path(@conn, :index, sub.streamer.displayname), class: "btn btn-danger btn-sm" %>
+                    <% end %>
                 </div>
             </div>
         </div>

--- a/priv/repo/migrations/20210227155636_add_is_cancelling_to_subs.exs
+++ b/priv/repo/migrations/20210227155636_add_is_cancelling_to_subs.exs
@@ -1,0 +1,9 @@
+defmodule Glimesh.Repo.Migrations.AddIsCancellingToSubs do
+  use Ecto.Migration
+
+  def change do
+    alter table(:subscriptions) do
+      add :is_canceling, :boolean
+    end
+  end
+end


### PR DESCRIPTION
Ensures that when subscriptions are unsubscribed from a user, that we keep their benefits until the end of the billing cycle. This will ensure you cannot spam sub / unsub and get charged a bunch of money, and makes sure subscribers get their full benefits.﻿
