### PR TITLE
Optimizing image upload for DO

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -43,7 +43,8 @@ config :glimesh,
 
 config :waffle,
   storage: Waffle.Storage.Local,
-  storage_dir: "uploads"
+  storage_dir: "uploads",
+  version_timeout: 4_000
 
 # Configures the endpoint
 config :glimesh, GlimeshWeb.Endpoint,

--- a/lib/glimesh/accounts.ex
+++ b/lib/glimesh/accounts.ex
@@ -349,6 +349,9 @@ defmodule Glimesh.Accounts do
     user
     |> User.profile_changeset(attrs)
     |> Repo.update()
+  catch
+    :exit, _ ->
+      {:error, "Failed to upload avatar"}
   end
 
   @doc """

--- a/lib/glimesh/streams.ex
+++ b/lib/glimesh/streams.ex
@@ -79,6 +79,9 @@ defmodule Glimesh.Streams do
           broadcast({:ok, broadcast_message}, :channel)
       end
     end
+  catch
+    :exit, _ ->
+      {:error, "Failed to upload channel images"}
   end
 
   def rotate_stream_key(%User{} = user, %Channel{} = channel) do
@@ -223,6 +226,9 @@ defmodule Glimesh.Streams do
     stream
     |> Glimesh.Streams.Stream.changeset(attrs)
     |> Repo.update()
+  catch
+    :exit, _ ->
+      {:error, "Failed to upload thumbnail"}
   end
 
   def get_last_stream_metadata(%Glimesh.Streams.Stream{} = stream) do

--- a/lib/glimesh_web/uploaders/app_logo.ex
+++ b/lib/glimesh_web/uploaders/app_logo.ex
@@ -25,6 +25,13 @@ defmodule Glimesh.AppLogo do
     "uploads/applications"
   end
 
+  def s3_object_headers(_version, {file, _scope}) do
+    [
+      cache_control: "public, max-age=604800",
+      content_type: MIME.from_path(file.file_name)
+    ]
+  end
+
   # # Provide a default URL if there hasn't been a file uploaded
   def default_url(_version, _scope) do
     "/images/200x200.jpg"

--- a/lib/glimesh_web/uploaders/avatar.ex
+++ b/lib/glimesh_web/uploaders/avatar.ex
@@ -30,6 +30,13 @@ defmodule Glimesh.Avatar do
     "uploads/avatars"
   end
 
+  def s3_object_headers(_version, {file, _scope}) do
+    [
+      cache_control: "public, max-age=604800",
+      content_type: MIME.from_path(file.file_name)
+    ]
+  end
+
   # Provide a default URL if there hasn't been a file uploaded
   def default_url(_version, scope) do
     hash = :crypto.hash(:md5, String.downcase(scope.email)) |> Base.encode16(case: :lower)

--- a/lib/glimesh_web/uploaders/channel_poster.ex
+++ b/lib/glimesh_web/uploaders/channel_poster.ex
@@ -28,6 +28,13 @@ defmodule Glimesh.ChannelPoster do
     "uploads/channel-posters"
   end
 
+  def s3_object_headers(_version, {file, _scope}) do
+    [
+      cache_control: "public, max-age=604800",
+      content_type: MIME.from_path(file.file_name)
+    ]
+  end
+
   # Provide a default URL if there hasn't been a file uploaded
   def default_url(_version, _scope) do
     "/images/stream-not-started.jpg"

--- a/lib/glimesh_web/uploaders/chat_background.ex
+++ b/lib/glimesh_web/uploaders/chat_background.ex
@@ -33,6 +33,13 @@ defmodule Glimesh.ChatBackground do
     "uploads/chat-backgrounds"
   end
 
+  def s3_object_headers(_version, {file, _scope}) do
+    [
+      cache_control: "public, max-age=604800",
+      content_type: MIME.from_path(file.file_name)
+    ]
+  end
+
   # Provide a default URL if there hasn't been a file uploaded
   def default_url(_version, _scope) do
     "/images/bg.png"

--- a/lib/glimesh_web/uploaders/stream_thumbnail.ex
+++ b/lib/glimesh_web/uploaders/stream_thumbnail.ex
@@ -29,6 +29,13 @@ defmodule Glimesh.StreamThumbnail do
     "uploads/stream-thumbnails"
   end
 
+  def s3_object_headers(_version, {file, _scope}) do
+    [
+      cache_control: "public, max-age=604800",
+      content_type: MIME.from_path(file.file_name)
+    ]
+  end
+
   # Provide a default URL if there hasn't been a file uploaded
   def default_url(_version, _scope) do
     GlimeshWeb.Router.Helpers.static_url(GlimeshWeb.Endpoint, "/images/stream-not-started.jpg")


### PR DESCRIPTION
This should do three major things:

1. Ensure DO uploads process within 4 seconds (before erroring gracefully to the user or API)
2. Upload images with correct content type
3. Cache images forever, until Waffle cache busts them﻿
