### PR TITLE
Return error from find_channel resolver instead of throwing

### DIFF
--- a/lib/glimesh/graphql/resolvers/channel_resolver.ex
+++ b/lib/glimesh/graphql/resolvers/channel_resolver.ex
@@ -30,7 +30,7 @@ defmodule Glimesh.Resolvers.ChannelResolver do
   end
 
   def find_channel(%{id: id}, _) do
-    if channel = ChannelLookups.get_channel!(id) do
+    if channel = ChannelLookups.get_channel(id) do
       {:ok, channel}
     else
       {:error, @error_not_found}


### PR DESCRIPTION
Thanks for the super fast turnaround on #503! While reviewing and testing it out I noticed one resolver was missed and we still get back a HTTP 404 that crashes ingest nodes.

Since this is the resolver that was causing https://github.com/Glimesh/janus-ftl-plugin/issues/91 this might actually be worth deploying before launch.