### PR TITLE
Bumping Docker Dev Elixir version to 1.11.2 to match main

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM elixir:1.10.4
+FROM elixir:1.11.2
 
 # Install package dependencies
 RUN apt-get update


### PR DESCRIPTION
The main Dockerfile is 1.11.2, without upgrading you get the following error when trying to build Docker

```
app_1  | 12:06:35.640 [debug] AppSignal.Phoenix.View attached to Elixir.GlimeshWeb.Oauth2Provider.AuthorizationView
app_1  |
app_1  | == Compilation error in file lib/glimesh/payment_providers/stripe/stripe.ex ==
app_1  | ** (CompileError) lib/glimesh/payment_providers/stripe/stripe.ex:161: cannot invoke remote function subscription.streamer_id/0 inside guards
```