### PR TITLE
Change the default  color to text-color-link

### DIFF
--- a/lib/glimesh/chat/effects.ex
+++ b/lib/glimesh/chat/effects.ex
@@ -19,7 +19,7 @@ defmodule Glimesh.Chat.Effects do
     ""
   end
 
-  def get_username_color(user, default \\ "text-white") do
+  def get_username_color(user, default \\ "text-color-link") do
     cond do
       user.is_admin -> "text-danger"
       user.is_gct -> "text-success"

--- a/lib/glimesh_web/live/user_live/profile.html.leex
+++ b/lib/glimesh_web/live/user_live/profile.html.leex
@@ -48,7 +48,7 @@
                 </div>
                 <%= if @streamer.team_role do %>
                 <div class="card-footer <%= Glimesh.Accounts.Profile.user_role_color(@streamer) %> rounded-bottom">
-                    <h5 class="card-title text-white mb-0"><%= @streamer.team_role %></h5>
+                    <h5 class="card-title text-color-link mb-0"><%= @streamer.team_role %></h5>
                 </div>
                 <% end %>
             </div>

--- a/test/glimesh/chat_effects_test.exs
+++ b/test/glimesh/chat_effects_test.exs
@@ -68,7 +68,7 @@ defmodule Glimesh.ChatEffectsTest do
       rendered_username = safe_to_string(Effects.render_username(user))
       rendered_avatar = safe_to_string(Effects.render_avatar(user))
 
-      assert rendered_username =~ "text-white"
+      assert rendered_username =~ "text-color-link"
       assert rendered_username =~ "Glimesh Supporter Subscriber"
       assert rendered_avatar =~ "avatar-ring platform-supporter-ring"
     end
@@ -99,7 +99,7 @@ defmodule Glimesh.ChatEffectsTest do
       rendered_username = safe_to_string(Effects.render_username(user))
       rendered_avatar = safe_to_string(Effects.render_avatar(user))
 
-      assert rendered_username =~ "text-white"
+      assert rendered_username =~ "text-color-link"
       assert rendered_username =~ user.displayname
       assert rendered_avatar =~ "avatar-ring"
     end


### PR DESCRIPTION
Without this, it looks like this in light mode.
![image](https://user-images.githubusercontent.com/11252574/109502589-2d96a680-7a67-11eb-87a9-52da565345b8.png)
Changing this to use `text-color-link` will match the color layout in our users list page. Which looks like this:
![image](https://user-images.githubusercontent.com/11252574/109502685-50c15600-7a67-11eb-8ce2-a8c0e1c865ad.png)
