### PR TITLE
Deletes Copy to Clipboard button when clipboard unavailable

### DIFF
--- a/lib/glimesh_web/templates/user_settings/stream.html.eex
+++ b/lib/glimesh_web/templates/user_settings/stream.html.eex
@@ -39,6 +39,11 @@
 <script>
     var clicksToCopy = document.querySelectorAll(".click-to-copy")
     for (var button of clicksToCopy) {
+        if (navigator.clipboard === undefined) {
+            button.remove();
+            continue;
+        }
+
         button.addEventListener('click', function (event) {
             var oldText = event.target.innerText;
             var copiedText = event.target.dataset.copiedText;


### PR DESCRIPTION
My local dev doesn't work so I can't test this, but I'm pretty sure it's good. Tested what the page looks like when I manually delete the buttons and it handles it fine.

![image](https://user-images.githubusercontent.com/18214951/109554298-f1e1f800-7acb-11eb-969a-85a0ce03b8af.png)


Fixes https://github.com/Glimesh/glimesh.tv/issues/496