### PR TITLE
Swapping preparred statements to unnamed

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -41,6 +41,9 @@ config :glimesh,
   run_stream_pruner: true,
   locales: locales
 
+config :glimesh, Glimesh.Repo,
+  prepare: :unnamed
+
 config :waffle,
   storage: Waffle.Storage.Local,
   storage_dir: "uploads",


### PR DESCRIPTION
In theory this fixes the error: `prepared statement "ecto_1234" does not exist` by making all prepared queries unnamed. This makes it so that it doesn't matter which backend the query goes to. 

I was following [this](https://elixirforum.com/t/can-someone-please-shed-some-light-on-this-error/33439/10) forum post and [this](https://hexdocs.pm/ecto_sql/Ecto.Adapters.Postgres.html#module-connection-options) docs page. 