### PR TITLE
Added live tag to profile page

### DIFF
--- a/lib/glimesh_web/live/user_live/profile.ex
+++ b/lib/glimesh_web/live/user_live/profile.ex
@@ -20,7 +20,7 @@ defmodule GlimeshWeb.UserLive.Profile do
 
         streamer_share_text = Profile.streamer_share_text(streamer, profile_url)
         viewer_share_text = Profile.viewer_share_text(streamer, profile_url)
-        maybe_channel = if Glimesh.ChannelLookups.get_channel_for_user(streamer), do: Glimesh.ChannelLookups.get_channel_for_user(streamer), else: nil
+        maybe_channel = if channel =  Glimesh.ChannelLookups.get_channel_for_user(streamer), do: channel, else: nil
 
         {:ok,
          socket

--- a/lib/glimesh_web/live/user_live/profile.ex
+++ b/lib/glimesh_web/live/user_live/profile.ex
@@ -20,6 +20,7 @@ defmodule GlimeshWeb.UserLive.Profile do
 
         streamer_share_text = Profile.streamer_share_text(streamer, profile_url)
         viewer_share_text = Profile.viewer_share_text(streamer, profile_url)
+        maybe_channel = if Glimesh.ChannelLookups.get_channel_for_user(streamer), do: Glimesh.ChannelLookups.get_channel_for_user(streamer), else: nil
 
         {:ok,
          socket
@@ -31,6 +32,7 @@ defmodule GlimeshWeb.UserLive.Profile do
          |> assign(:streamer_share_text, streamer_share_text)
          |> assign(:viewer_share_text, viewer_share_text)
          |> assign(:streamer, streamer)
+         |> assign(:channel, maybe_channel)
          |> assign(:user, maybe_user)}
 
       nil ->

--- a/lib/glimesh_web/live/user_live/profile.html.leex
+++ b/lib/glimesh_web/live/user_live/profile.html.leex
@@ -14,7 +14,12 @@
 
                     <%= live_render(@socket, GlimeshWeb.UserLive.Components.SocialButtons, id: "social-buttons", container: {:ul, class: "list-inline"}, session: %{"user_id" => @streamer.id}) %>
 
-                    <%= if Glimesh.ChannelLookups.get_channel_for_user(@streamer) do %>
+                    <%= if @channel do %>
+                    <%= if @channel.status == "live" do %>
+                    <div>
+                        <h4><span class="badge badge-danger">Live!</span></h4>
+                    </div>
+                    <% end %>
                     <div>
                         <%= live_redirect gettext("View Channel"), class: "btn btn-primary", to: Routes.user_stream_path(@socket, :index, @streamer.username) %>
                     </div>


### PR DESCRIPTION
Adds the live badge to the profile page when the channel is live. This goes right above the view channel button:

![image](https://user-images.githubusercontent.com/11252574/110214113-11cd3f00-7e71-11eb-93fe-3f914c5b2fb8.png)
