### PR TITLE
Optimizing chat timestamps

### DIFF
--- a/assets/css/glimesh/components/chat.scss
+++ b/assets/css/glimesh/components/chat.scss
@@ -64,9 +64,15 @@
             border: 2px solid $red;
         }
 
-        // .bubble.you {
-        //     align-self: flex-end;
-        // }
+        .chat-timestamp {
+            display: none;
+        }
+
+        &.show-timestamps {
+            .chat-timestamp {
+                display: inline-block;
+            }
+        }
     }
 
 

--- a/assets/js/hooks/Chat.js
+++ b/assets/js/hooks/Chat.js
@@ -65,26 +65,16 @@ export default {
 
             // Apply a BS init to just the new chat message
             BSN.initCallback(document.getElementById(e.message_id));
-            
-            //Timestamp handler
-            if (e["show_timestamps"]) {
-                let timestamp = document.getElementById("small-" + e["message_id"]);
-                timestamp.classList.remove("d-none");
-            }
         });
 
         /* 
         For populating the initial X messages with the current timestamp state.
         */
-        this.handleEvent("update_previous_messages_with_timestamp_state", (e) => {
-            let childSmalls = chatMessages.getElementsByTagName("small");
-            for (let i = 0; i < childSmalls.length; i++) {
-                let childSmall = childSmalls[i];
-                if (e["show_timestamps"]) {
-                    childSmall.classList.remove("d-none");
-                } else {
-                    childSmall.classList.add("d-none");
-                }
+        this.handleEvent("toggle_timestamps", (e) => {
+            if (e["show_timestamps"]) {
+                chatMessages.classList.add("show-timestamps");
+            } else {
+                chatMessages.classList.remove("show-timestamps");
             }
             this.maybeScrollToBottom(chatMessages);
         });

--- a/lib/glimesh_web/live/chat_live/index.html.leex
+++ b/lib/glimesh_web/live/chat_live/index.html.leex
@@ -1,4 +1,4 @@
-<div id="chat-messages" class="chat-messages" phx-update="<%= @update_action %>" style="<%= background_style(@channel) %>">
+<div id="chat-messages" class="chat-messages <%= if @show_timestamps, do: "show-timestamps" %>" phx-update="<%= @update_action %>" style="<%= background_style(@channel) %>">
     <div id="channel-header" class="channel-header">
         <span><%= gettext("Welcome to chat! Follow the rules.") %></span>
     </div>
@@ -23,7 +23,7 @@
 
             <%= Glimesh.Chat.Effects.render_username_and_avatar(chat_message.user) %>
             <% end %>
-            <small id="small-<%= chat_message.id %>" class="text-muted d-none">
+            <small id="small-<%= chat_message.id %>" class="text-muted chat-timestamp">
                 <local-time id="timestamp-<%= chat_message.id %>" phx-update="ignore" datetime="<%= "#{chat_message.inserted_at}" <> "Z" %>" format="micro" hour="numeric" minute="2-digit" second="2-digit"><%= NaiveDateTime.to_time(chat_message.inserted_at) %>
                 </local-time>
             </small>


### PR DESCRIPTION
Previously the timestamps were slightly expensive to render, this changes it to a root class that is toggled depending on the users setting. 