### PR TITLE
Counting semi-unique viewers

### DIFF
--- a/lib/glimesh_web/endpoint.ex
+++ b/lib/glimesh_web/endpoint.ex
@@ -8,6 +8,7 @@ defmodule GlimeshWeb.Endpoint do
   @session_options [
     store: :cookie,
     key: "_glimesh_key",
+    same_site: "Lax",
     signing_salt:
       Application.compile_env(:glimesh, [GlimeshWeb.Endpoint, :live_view, :signing_salt])
   ]

--- a/lib/glimesh_web/live/user_live/components/viewer_count.ex
+++ b/lib/glimesh_web/live/user_live/components/viewer_count.ex
@@ -30,14 +30,11 @@ defmodule GlimeshWeb.UserLive.Components.ViewerCount do
   def handle_info(
         %{
           event: "presence_diff",
-          topic: "streams:viewers:" <> _streamer,
-          payload: %{joins: joins, leaves: leaves}
+          topic: "streams:viewers:" <> _streamer = topic
         },
-        %{assigns: %{viewer_count: count}} = socket
+        socket
       ) do
-    viewer_count = count + map_size(joins) - map_size(leaves)
-
-    {:noreply, socket |> assign(:viewer_count, viewer_count)}
+    {:noreply, socket |> assign(:viewer_count, Presence.list_presences(topic) |> Enum.count())}
   end
 
   @impl true

--- a/lib/glimesh_web/live/user_live/stream.ex
+++ b/lib/glimesh_web/live/user_live/stream.ex
@@ -27,6 +27,7 @@ defmodule GlimeshWeb.UserLive.Stream do
          socket
          |> put_page_title(channel.title)
          |> assign(:show_bottom, true)
+         |> assign(:unique_user, Map.get(session, "unique_user"))
          |> assign(:country, Map.get(session, "country"))
          |> assign(:prompt_mature, Streams.prompt_mature_content(channel, maybe_user))
          |> assign(:custom_meta, Profile.meta_tags(streamer, avatar_url))
@@ -51,7 +52,7 @@ defmodule GlimeshWeb.UserLive.Stream do
         Presence.track_presence(
           self(),
           Streams.get_subscribe_topic(:viewers, socket.assigns.channel_id),
-          socket.id,
+          socket.assigns.unique_user,
           %{
             janus_edge_id: janus_edge_id
           }

--- a/lib/glimesh_web/plugs/unique_user_plug.ex
+++ b/lib/glimesh_web/plugs/unique_user_plug.ex
@@ -1,0 +1,35 @@
+defmodule GlimeshWeb.UniqueUserPlug do
+  @moduledoc """
+  The intention of this module is to provide us a semi-identifying hash for an actual unique user.any()
+
+  Currently if the user is not logged in, it defaults to the IP Address.
+  If the user is logged in, it combines the IP Address with the User ID to support shared households / colleges.
+  """
+  import Plug.Conn
+
+  def init(_opts), do: nil
+
+  def call(conn, _opts) do
+    conn
+    |> put_unique_token()
+  end
+
+  def put_unique_token(conn) do
+    current_user = Map.get(conn.assigns, :current_user, %{})
+    ip_address = conn.remote_ip |> :inet.ntoa() |> to_string()
+
+    case current_user do
+      %{id: id} ->
+        conn |> put_session(:unique_user, hash(ip_address, id))
+
+      _ ->
+        conn |> put_session(:unique_user, hash(ip_address, 0))
+    end
+  end
+
+  defp hash(ip_address, user_id) do
+    :crypto.hash(:sha256, "#{ip_address}-#{user_id}")
+    |> Base.encode16()
+    |> String.downcase()
+  end
+end

--- a/lib/glimesh_web/router.ex
+++ b/lib/glimesh_web/router.ex
@@ -14,6 +14,7 @@ defmodule GlimeshWeb.Router do
     plug GlimeshWeb.Plugs.Locale
     plug GlimeshWeb.Plugs.CfCountryPlug
     plug GlimeshWeb.Plugs.Ban
+    plug GlimeshWeb.UniqueUserPlug
   end
 
   pipeline :api do


### PR DESCRIPTION
Not a perfect solution, but will prevent basic "view botting" by calculating a unique user hash per IP + logged in user combo. 

In the future this will actually be a count of WebRTC video consumers.﻿
