### PR TITLE
Adding a modal for stream editing

### DIFF
--- a/lib/glimesh_web/live/chat_live/index.ex
+++ b/lib/glimesh_web/live/chat_live/index.ex
@@ -13,6 +13,7 @@ defmodule GlimeshWeb.ChatLive.Index do
   @impl true
   def mount(_params, %{"channel_id" => channel_id} = session, socket) do
     instrument(__MODULE__, "mount", socket, fn ->
+      if session["locale"], do: Gettext.put_locale(session["locale"])
       if connected?(socket), do: Streams.subscribe_to(:chat, channel_id)
 
       channel = ChannelLookups.get_channel!(channel_id)

--- a/lib/glimesh_web/live/chat_live/message_form.html.leex
+++ b/lib/glimesh_web/live/chat_live/message_form.html.leex
@@ -24,15 +24,14 @@
       </a>
     </div>
 
-    <%= text_input f, :message, class: "mail-write-box form-control", placeholder: "Send a message", autocomplete: "off", maxlength: "255", disabled: @disabled %>
+    <%= text_input f, :message, class: "mail-write-box form-control", placeholder: gettext("Send a message"), autocomplete: "off", maxlength: "255", disabled: @disabled %>
 
     <div id="chat-settings" class="input-group-append dropup">
       <a href="#" class="input-group-text dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true"
         aria-expanded="false"><i class="fas fa-cog"></i></a>
       <div class="dropdown-menu dropdown-menu-right">
         <a class="dropdown-item" href="#"
-          onclick="window.open('<%= Routes.chat_pop_out_url(@socket, :index, @channel_username) %>', '_blank', 'width=400,height=600,location=no,menubar=no,toolbar=no')">Pop-out
-          Chat</a>
+          onclick="window.open('<%= Routes.chat_pop_out_url(@socket, :index, @channel_username) %>', '_blank', 'width=400,height=600,location=no,menubar=no,toolbar=no')"><%= gettext("Pop-out Chat") %></a>
         <a id="toggle-timestamps" class="dropdown-item" , href="#" phx-click="toggle_timestamps"
           <%= if @user, do: 'phx-value-user=#{@user.username}' %>><%= if @show_timestamps, do: gettext("Disable Timestamps"), else: gettext("Enable Timestamps") %>
         </a>

--- a/lib/glimesh_web/live/user_live/components/channel_title.ex
+++ b/lib/glimesh_web/live/user_live/components/channel_title.ex
@@ -20,8 +20,8 @@ defmodule GlimeshWeb.UserLive.Components.ChannelTitle do
 
     <%= if @editing do %>
         <div id="channelEditor" class="live-modal"
-            phx-capture-click="hide_editing"
-            phx-window-keydown="hide_editing"
+            phx-capture-click="toggle-edit"
+            phx-window-keydown="toggle-edit"
             phx-key="escape"
             phx-target="#channelEditor"
             phx-page-loading>
@@ -29,7 +29,7 @@ defmodule GlimeshWeb.UserLive.Components.ChannelTitle do
                 <div class="modal-content">
                     <div class="modal-header">
                         <h5 class="modal-title"><%= gettext("Stream Info") %></h5>
-                        <button type="button" class="close" phx-click="hide_editing" aria-label="Close">
+                        <button type="button" class="close" phx-click="toggle-edit" aria-label="Close">
                         <span aria-hidden="true">&times;</span>
                         </button>
                     </div>

--- a/lib/glimesh_web/live/user_live/components/channel_title.ex
+++ b/lib/glimesh_web/live/user_live/components/channel_title.ex
@@ -1,6 +1,5 @@
 defmodule GlimeshWeb.UserLive.Components.ChannelTitle do
   use GlimeshWeb, :live_view
-  import Gettext, only: [with_locale: 2]
 
   alias Glimesh.ChannelCategories
   alias Glimesh.ChannelLookups
@@ -9,30 +8,57 @@ defmodule GlimeshWeb.UserLive.Components.ChannelTitle do
   @impl true
   def render(assigns) do
     ~L"""
-    <%= if @can_change do %>
-      <%= if !@editing do %>
-        <h5 class="mb-0"><%= render_badge(@channel) %> <span class="badge badge-primary"><%= @channel.category.name %></span> <%= @channel.title %> <a class="fas fa-edit" phx-click="toggle-edit" href="#" aria-label="<%= gettext("Edit") %>"></a></h5>
-      <% else %>
-        <%= f = form_for @changeset, "#", [phx_submit: :save] %>
-          <div class="input-group">
-
-          <%= select f, :category_id, @categories, [class: "form-control", "phx-hook": "Choices", "phx-update": "ignore"] %>
-          <%= text_input f, :title, [class: "form-control"] %>
-
-          <div class="input-group-append">
-          <%= with_locale(Glimesh.Accounts.get_user_locale(@user), fn -> %>
-            <%= submit gettext("Save Info"), class: "btn btn-primary" %>
-          <% end) %>
-          </div>
-
-          </div>
-        </form>
+    <h5 class="mb-0">
+      <%= render_badge(@channel) %> <span class="badge badge-primary"><%= @channel.category.name %></span> <%= @channel.title %>
+      <%= if @can_change do %>
+      <a class="fas fa-edit" phx-click="toggle-edit" href="#" aria-label="<%= gettext("Edit") %>"></a>
       <% end %>
-    <% else %>
-      <h5 class="mb-0"><%= render_badge(@channel) %> <span class="badge badge-primary"><%= @channel.category.name %></span> <%= @channel.title %> </h5>
-    <% end %>
+    </h5>
     <%= for tag <- @channel.tags do %>
       <%= live_patch tag.name, to: Routes.streams_list_path(@socket, :index, @channel.category.slug, tags: [tag.slug]), class: "badge badge-pill badge-primary" %>
+    <% end %>
+
+    <%= if @editing do %>
+        <div id="channelEditor" class="live-modal"
+            phx-capture-click="hide_editing"
+            phx-window-keydown="hide_editing"
+            phx-key="escape"
+            phx-target="#channelEditor"
+            phx-page-loading>
+            <div class="modal-dialog" role="document">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title"><%= gettext("Stream Info") %></h5>
+                        <button type="button" class="close" phx-click="hide_editing" aria-label="Close">
+                        <span aria-hidden="true">&times;</span>
+                        </button>
+                    </div>
+
+                    <div class="modal-body">
+                      <%= f = form_for @changeset, "#", [phx_submit: :save, phx_change: :change_channel] %>
+                          <div class="form-group">
+                              <%= label f, gettext("Title") %>
+                              <%= text_input f, :title, [class: "form-control", phx_update: "ignore"] %>
+                              <%= error_tag f, :title %>
+                          </div>
+                          <div class="form-group">
+                              <%= label f, gettext("Category") %>
+                              <%= select f, :category_id, @categories, [class: "form-control"] %>
+                              <%= error_tag f, :category_id %>
+                          </div>
+                          <div class="form-group">
+                              <%= label f, gettext("Tags") %>
+                              <%= live_component(@socket, GlimeshWeb.UserLive.Components.TagSelector, form: f, field: :tags, category_id: @current_category_id) %>
+                              <%= error_tag f, :tags %>
+                          </div>
+
+                          <button type="submit" class="btn btn-primary btn-block btn-lg"><%= gettext("Save") %></button>
+
+                      </form>
+                    </div>
+                </div>
+            </div>
+        </div>
     <% end %>
     """
   end
@@ -48,7 +74,8 @@ defmodule GlimeshWeb.UserLive.Components.ChannelTitle do
   end
 
   @impl true
-  def mount(_params, %{"channel_id" => channel_id, "user" => nil}, socket) do
+  def mount(_params, %{"channel_id" => channel_id, "user" => nil} = session, socket) do
+    if session["locale"], do: Gettext.put_locale(session["locale"])
     if connected?(socket), do: Streams.subscribe_to(:channel, channel_id)
     channel = ChannelLookups.get_channel!(channel_id)
 
@@ -62,7 +89,8 @@ defmodule GlimeshWeb.UserLive.Components.ChannelTitle do
   end
 
   @impl true
-  def mount(_params, %{"channel_id" => channel_id, "user" => user}, socket) do
+  def mount(_params, %{"channel_id" => channel_id, "user" => user} = session, socket) do
+    if session["locale"], do: Gettext.put_locale(session["locale"])
     if connected?(socket), do: Streams.subscribe_to(:channel, channel_id)
     channel = ChannelLookups.get_channel!(channel_id)
 
@@ -73,6 +101,7 @@ defmodule GlimeshWeb.UserLive.Components.ChannelTitle do
      |> assign(:user, user)
      |> assign(:channel, channel)
      |> assign(:changeset, Streams.change_channel(channel))
+     |> assign(:current_category_id, channel.category_id)
      |> assign(:can_change, Bodyguard.permit?(Glimesh.Streams, :update_channel, user, channel))
      |> assign(:editing, false)}
   end
@@ -80,6 +109,19 @@ defmodule GlimeshWeb.UserLive.Components.ChannelTitle do
   @impl true
   def handle_event("toggle-edit", _value, socket) do
     {:noreply, socket |> assign(:editing, socket.assigns.editing |> Kernel.not())}
+  end
+
+  @impl true
+  def handle_event(
+        "change_channel",
+        %{"_target" => ["channel", "category_id"], "channel" => channel},
+        socket
+      ) do
+    {:noreply, socket |> assign(:current_category_id, channel["category_id"])}
+  end
+
+  def handle_event("change_channel", _params, socket) do
+    {:noreply, socket}
   end
 
   @impl true

--- a/lib/glimesh_web/live/user_live/components/subscribe_button.ex
+++ b/lib/glimesh_web/live/user_live/components/subscribe_button.ex
@@ -99,7 +99,9 @@ defmodule GlimeshWeb.UserLive.Components.SubscribeButton do
   end
 
   @impl true
-  def mount(_params, %{"streamer" => streamer, "user" => nil}, socket) do
+  def mount(_params, %{"streamer" => streamer, "user" => nil} = session, socket) do
+    if session["locale"], do: Gettext.put_locale(session["locale"])
+
     {:ok,
      socket
      |> assign(:streamer, streamer)
@@ -112,7 +114,8 @@ defmodule GlimeshWeb.UserLive.Components.SubscribeButton do
   end
 
   @impl true
-  def mount(_params, %{"streamer" => streamer, "user" => user}, socket) do
+  def mount(_params, %{"streamer" => streamer, "user" => user} = session, socket) do
+    if session["locale"], do: Gettext.put_locale(session["locale"])
     subscription = Glimesh.Payments.get_channel_subscription(user, streamer)
 
     can_subscribe = if Accounts.can_use_payments?(user), do: user.id != streamer.id, else: false

--- a/lib/glimesh_web/live/user_live/components/viewer_count.ex
+++ b/lib/glimesh_web/live/user_live/components/viewer_count.ex
@@ -18,7 +18,8 @@ defmodule GlimeshWeb.UserLive.Components.ViewerCount do
   end
 
   @impl true
-  def mount(_params, %{"channel_id" => channel_id}, socket) do
+  def mount(_params, %{"channel_id" => channel_id} = session, socket) do
+    if session["locale"], do: Gettext.put_locale(session["locale"])
     {:ok, topic} = Streams.subscribe_to(:viewers, channel_id)
 
     viewer_count = Presence.list_presences(topic) |> Enum.count()


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/226638/110212632-5a352e80-7e6a-11eb-855a-77db73463d17.png)

Replaces the existing inline editor with a modal for editing tags as well. Should also be better on Mobile.