### PR TITLE
Show language and clean up image loading

### DIFF
--- a/assets/css/glimesh/components/card-stream.scss
+++ b/assets/css/glimesh/components/card-stream.scss
@@ -3,11 +3,20 @@
         transition: transform .2s;
     }
 
+    .card-img {
+        width: 100%;
+        height: auto;
+        text-align: center;
+    }
+
+    .card-img-overlay {
+        transition: opacity .2s;
+    }
+
     .card-stream-title {
         text-overflow: ellipsis;
-        // overflow: hidden;
-        // white-space: nowrap;
     }
+
     .card-stream-tags {
         text-align: right;
     }
@@ -23,6 +32,7 @@
         background: var(--stream-card-streamer-background);
         border-radius: 30px;
     }
+
     .card-stream-streamer.sub-ready {
         background: $color-secondary !important;
     }
@@ -30,6 +40,10 @@
     &:hover {
         img {
             transform: scale(1.03);
+        }
+
+        .card-img-overlay {
+            opacity: 0.2;
         }
 
         color: var(--body-color);

--- a/assets/css/glimesh/components/tagify.scss
+++ b/assets/css/glimesh/components/tagify.scss
@@ -15,6 +15,11 @@ $tags-focus-border-color : var(--input-border-color);
 }
 
 .tagify__input {
+    &:empty:before {
+        white-space: break-spaces;
+        overflow: hidden;
+    }
+
     &:focus {
         &:empty {
             &::before {

--- a/lib/glimesh/streams.ex
+++ b/lib/glimesh/streams.ex
@@ -258,6 +258,8 @@ defmodule Glimesh.Streams do
     {:ok, stream |> Repo.preload([:metadata])}
   end
 
+  # System API Calls
+
   def prompt_mature_content(%Channel{mature_content: true}, %User{} = user) do
     user_pref = Glimesh.Accounts.get_user_preference!(user)
 
@@ -269,10 +271,15 @@ defmodule Glimesh.Streams do
 
   def get_stream_key(%Channel{id: id, hmac_key: hmac_key}), do: "#{id}-#{hmac_key}"
 
-  # System API Calls
-
   def change_channel(%Channel{} = channel, attrs \\ %{}) do
     Channel.changeset(channel, attrs)
+  end
+
+  def get_channel_language(%Channel{language: locale}) do
+    case Application.get_env(:glimesh, :locales) |> List.keyfind(locale, 1) do
+      {name, _} -> Atom.to_string(name)
+      _ -> ""
+    end
   end
 
   def is_live?(%Channel{} = channel) do

--- a/lib/glimesh_web/live/streams_live/list.ex
+++ b/lib/glimesh_web/live/streams_live/list.ex
@@ -73,9 +73,12 @@ defmodule GlimeshWeb.StreamsLive.List do
         ""
       end
 
+    # prefilled_language = Map.get(params, "language", "Any Language")
+
     {:noreply,
      socket
      |> assign(:prefilled_tags, prefilled_tags)
+     #  |> assign(:prefilled_language, prefilled_language)
      |> assign(:original_channels, channels)
      |> filter_tags(Map.get(params, "tags", []))}
   end
@@ -89,6 +92,12 @@ defmodule GlimeshWeb.StreamsLive.List do
        to: Routes.streams_list_path(socket, :index, socket.assigns.category.slug, tags: tags)
      )}
   end
+
+  # def handle_event("filter_language", params, socket) do
+  #   IO.inspect(params, label: "filter_language")
+
+  #   {:noreply, socket |> filter_language("English")}
+  # end
 
   defp filter_tags(socket, []) do
     socket |> assign(:visible_channels, socket.assigns.original_channels)
@@ -111,21 +120,23 @@ defmodule GlimeshWeb.StreamsLive.List do
     end
   end
 
-  # def handle_event("filter_language", params, socket) do
-  #   IO.inspect(params, label: "filter_language")
-
-  #   {:noreply, socket |> filter_language("English")}
-  # end
-
   # defp filter_language(socket, "Any Language") do
   #   socket |> assign(:visible_channels, socket.assigns.original_channels)
   # end
-  # defp filter_language(socket, locale) do
-  #   channels = Enum.filter(socket.assigns.original_channels, fn channel ->
-  #     channel.language == locale
-  #   end)
 
-  #   socket |> assign(:visible_channels, channels)
+  # defp filter_language(socket, locale) do
+  #   channels =
+  #     Enum.filter(socket.assigns.original_channels, fn channel ->
+  #       channel.language == locale
+  #     end)
+
+  #   if length(channels) > 0 do
+  #     socket |> assign(:visible_channels, channels)
+  #   else
+  #     # No streams, probably bad lang or no live channels anymore
+  #     socket
+  #     |> push_patch(to: Routes.streams_list_path(socket, :index, socket.assigns.category.slug))
+  #   end
   # end
 
   defp category_background_url(slug) do

--- a/lib/glimesh_web/live/streams_live/list.html.leex
+++ b/lib/glimesh_web/live/streams_live/list.html.leex
@@ -51,11 +51,12 @@
                                         placeholder: gettext("Search for a stream by tags") %>
                                 </div>
                             </div>
-                            <%# <div class="col-md-6 mb-3">
+                            <%#
+                            <div class="col-md-6 mb-3">
                                 <label for="validationCustom02">Language</label>
-                                 select :form, :locale, @locales, [class: "custom-select", "phx-change": "filter_language"]
+                                select :form, :locale, @locales, [value: @prefilled_language, class: "custom-select", "phx-change": "filter_language"]
                             </div>
-                            %>
+                             %>
                         </div>
                     </form>
                 </div>
@@ -67,12 +68,14 @@
 
             <div class="row">
                 <%= for channel <- @visible_channels do %>
-                <div class="col-sm-12 col-md-6 col-lg-4 mt-4">
+                <div class="col-sm-12 col-md-6 col-xl-4 mt-4">
                     <%= link to: Routes.user_stream_path(@socket, :index, channel.user.username), class: "text-color-link" do %>
                     <div class="card card-stream">
-                        <img src="<%= Glimesh.StreamThumbnail.url({channel.stream.thumbnail, channel.stream}, :original) %>" alt="<%= channel.title %>" class="card-img">
+                        <img src="<%= Glimesh.StreamThumbnail.url({channel.stream.thumbnail, channel.stream}, :original) %>" alt="<%= channel.title %>" class="card-img" height="468" width="832">
                         <div class="card-img-overlay h-100 d-flex flex-column justify-content-between">
+
                             <div class="card-stream-tags">
+                                <span class="badge badge-info"><%= Glimesh.Streams.get_channel_language(channel) %></span>
                                 <%= for tag <- channel.tags do %>
                                 <span class="badge badge-primary"><%= tag.name %></span>
                                 <% end %>

--- a/lib/glimesh_web/live/user_live/components/channel_title.ex
+++ b/lib/glimesh_web/live/user_live/components/channel_title.ex
@@ -14,6 +14,7 @@ defmodule GlimeshWeb.UserLive.Components.ChannelTitle do
       <a class="fas fa-edit" phx-click="toggle-edit" href="#" aria-label="<%= gettext("Edit") %>"></a>
       <% end %>
     </h5>
+    <span class="badge badge-pill badge-info"><%= Glimesh.Streams.get_channel_language(@channel) %></span>
     <%= for tag <- @channel.tags do %>
       <%= live_patch tag.name, to: Routes.streams_list_path(@socket, :index, @channel.category.slug, tags: [tag.slug]), class: "badge badge-pill badge-primary" %>
     <% end %>


### PR DESCRIPTION
I almost added a filter for language again, but I still don't think we're ready for it.

This PR also sets a static size for the stream thumbnails so they don't collapse when they fail or are too slow to load.