### PR TITLE
Fix invoking remote function within guard

### DIFF
--- a/lib/glimesh/payment_providers/stripe/stripe.ex
+++ b/lib/glimesh/payment_providers/stripe/stripe.ex
@@ -162,8 +162,8 @@ defmodule Glimesh.PaymentProviders.StripeProvider do
     end
   end
 
-  defp create_subscription_invoice(%Subscription{streamer_id: streamer_id} = subscription, %Stripe.Invoice{} = invoice)
-       when not is_nil(streamer_id) do
+  defp create_subscription_invoice(%Subscription{} = subscription, %Stripe.Invoice{} = invoice)
+       when subscription.streamer_id != nil do
     # Channel Subscription
     # Create invoice for this subscription
     user = Accounts.get_user!(subscription.user_id)

--- a/lib/glimesh/payment_providers/stripe/stripe.ex
+++ b/lib/glimesh/payment_providers/stripe/stripe.ex
@@ -162,8 +162,8 @@ defmodule Glimesh.PaymentProviders.StripeProvider do
     end
   end
 
-  defp create_subscription_invoice(%Subscription{} = subscription, %Stripe.Invoice{} = invoice)
-       when not is_nil(subscription.streamer_id) do
+  defp create_subscription_invoice(%Subscription{} = subscription, %Stripe.Invoice{} = invoice, %Subscription{streamer_id: streamer_id})
+       when not is_nil(streamer_id) do
     # Channel Subscription
     # Create invoice for this subscription
     user = Accounts.get_user!(subscription.user_id)

--- a/lib/glimesh/payment_providers/stripe/stripe.ex
+++ b/lib/glimesh/payment_providers/stripe/stripe.ex
@@ -162,8 +162,8 @@ defmodule Glimesh.PaymentProviders.StripeProvider do
     end
   end
 
-  defp create_subscription_invoice(%Subscription{} = subscription, %Stripe.Invoice{} = invoice, %Subscription{streamer_id: streamer_id})
-       when not is_nil(streamer_id) do
+  defp create_subscription_invoice(%Subscription{streamer_id: streamer_id} = subscription, %Stripe.Invoice{} = invoice)
+       when not is_nil(streamer_id: streamer_id) do
     # Channel Subscription
     # Create invoice for this subscription
     user = Accounts.get_user!(subscription.user_id)

--- a/lib/glimesh/payment_providers/stripe/stripe.ex
+++ b/lib/glimesh/payment_providers/stripe/stripe.ex
@@ -163,7 +163,7 @@ defmodule Glimesh.PaymentProviders.StripeProvider do
   end
 
   defp create_subscription_invoice(%Subscription{streamer_id: streamer_id} = subscription, %Stripe.Invoice{} = invoice)
-       when not is_nil(streamer_id: streamer_id) do
+       when not is_nil(streamer_id) do
     # Channel Subscription
     # Create invoice for this subscription
     user = Accounts.get_user!(subscription.user_id)

--- a/lib/glimesh/payment_providers/stripe/stripe.ex
+++ b/lib/glimesh/payment_providers/stripe/stripe.ex
@@ -162,8 +162,8 @@ defmodule Glimesh.PaymentProviders.StripeProvider do
     end
   end
 
-  defp create_subscription_invoice(%Subscription{} = subscription, %Stripe.Invoice{} = invoice)
-       when streamer_id = subscription.streamer_id and streamer_id != nil do
+  defp create_subscription_invoice(%Subscription{streamer_id: streamer_id} = subscription, %Stripe.Invoice{} = invoice)
+       when not is_nil(streamer_id) do
     # Channel Subscription
     # Create invoice for this subscription
     user = Accounts.get_user!(subscription.user_id)

--- a/lib/glimesh/payment_providers/stripe/stripe.ex
+++ b/lib/glimesh/payment_providers/stripe/stripe.ex
@@ -163,7 +163,7 @@ defmodule Glimesh.PaymentProviders.StripeProvider do
   end
 
   defp create_subscription_invoice(%Subscription{} = subscription, %Stripe.Invoice{} = invoice)
-       when subscription.streamer_id != nil do
+       when streamer_id = subscription.streamer_id and streamer_id != nil do
     # Channel Subscription
     # Create invoice for this subscription
     user = Accounts.get_user!(subscription.user_id)


### PR DESCRIPTION
This fixes an issue where stripe.ex was unable to compile due to the create_subscription_invoice function.