### PR TITLE
Adding a chat log for specific users

### DIFF
--- a/lib/glimesh/chat.ex
+++ b/lib/glimesh/chat.ex
@@ -187,6 +187,16 @@ defmodule Glimesh.Chat do
   end
 
   @doc """
+  Returns a list of all chat_messages for a user
+  """
+  def list_all_chat_messages_for_user(user) do
+    ChatMessage
+    |> order_by(desc: :inserted_at)
+    |> where([cm], cm.user_id == ^user.id)
+    |> preload([:user, :channel])
+  end
+
+  @doc """
   Gets a single chat_message.
 
   Raises `Ecto.NoResultsError` if the Chat message does not exist.

--- a/lib/glimesh_web/controllers/gct_controller.ex
+++ b/lib/glimesh_web/controllers/gct_controller.ex
@@ -20,7 +20,8 @@ defmodule GlimeshWeb.GctController do
     render(
       conn,
       "index.html",
-      can_view_audit_log: view_audit_log
+      can_view_audit_log: view_audit_log,
+      page_title: format_page_title("GCT Dashboard")
     )
   end
 
@@ -28,7 +29,7 @@ defmodule GlimeshWeb.GctController do
     current_user = conn.assigns.current_user
 
     with :ok <- Bodyguard.permit(Glimesh.CommunityTeam, :view_audit_log, current_user) do
-      render(conn, "audit_log.html")
+      render(conn, "audit_log.html", page_title: format_page_title("Audit Log"))
     end
   end
 
@@ -53,6 +54,7 @@ defmodule GlimeshWeb.GctController do
 
     with :ok <- Bodyguard.permit(Glimesh.CommunityTeam, :view_user, gct_user, user) do
       view_billing = Bodyguard.permit?(Glimesh.CommunityTeam, :view_billing_info, gct_user, user)
+      view_chat_log = Bodyguard.permit?(Glimesh.CommunityTeam, :view_chat_log, gct_user, user)
 
       if user do
         CommunityTeam.create_lookup_audit_entry(gct_user, user)
@@ -63,10 +65,29 @@ defmodule GlimeshWeb.GctController do
           user: user,
           payout_history: [],
           payment_history: Payments.list_payment_history(user),
-          view_billing?: view_billing
+          view_billing?: view_billing,
+          page_title: format_page_title("#{user.displayname}")
         )
       else
         render(conn, "invalid_user.html")
+      end
+    end
+  end
+
+  def user_chat_log(conn, %{"user_id" => user_id}) do
+    current_user = conn.assigns.current_user
+    user = Accounts.get_user!(user_id)
+
+    if user do
+      with :ok <-
+             Bodyguard.permit(Glimesh.CommunityTeam, :view_chat_logs, current_user, user) do
+        CommunityTeam.create_audit_entry(current_user, %{
+          action: "view user chat log",
+          target: user.username,
+          verbose_required: true
+        })
+
+        render(conn, "user_chat_log.html", user: user, page_title: format_page_title("Chat Log - #{user.displayname}"))
       end
     end
   end
@@ -91,7 +112,8 @@ defmodule GlimeshWeb.GctController do
           "edit_user_profile.html",
           user: user,
           user_changeset: user_changeset,
-          twitter_auth_url: twitter_auth_url
+          twitter_auth_url: twitter_auth_url,
+          page_title: format_page_title("Editing Profile - #{user.displayname}")
         )
       else
         render(conn, "invalid_user.html")
@@ -154,7 +176,8 @@ defmodule GlimeshWeb.GctController do
           "edit_user.html",
           user: user,
           user_changeset: user_changeset,
-          view_billing?: view_billing
+          view_billing?: view_billing,
+          page_title: format_page_title("Editing Profile - #{user.displayname}")
         )
       else
         render(conn, "invalid_user.html")
@@ -225,7 +248,8 @@ defmodule GlimeshWeb.GctController do
           conn,
           "lookup_channel.html",
           channel: channel,
-          categories: ChannelCategories.list_categories_for_select()
+          categories: ChannelCategories.list_categories_for_select(),
+          page_title: format_page_title("Channel Info - #{channel.user.displayname}")
         )
       else
         render(conn, "invalid_user.html")
@@ -246,7 +270,8 @@ defmodule GlimeshWeb.GctController do
           verbose_required: true
         })
 
-        render(conn, "channel_chat_log.html", channel: channel)
+        render(conn, "channel_chat_log.html", channel: channel,
+          page_title: format_page_title("Chat Log - #{channel.user.displayname}"))
       end
     end
   end
@@ -282,7 +307,8 @@ defmodule GlimeshWeb.GctController do
           channel: channel,
           channel_changeset: channel_changeset,
           categories: ChannelCategories.list_categories_for_select(),
-          channel_delete_disabled: disable_delete_button
+          channel_delete_disabled: disable_delete_button,
+          page_title: format_page_title("Edit Channel - #{channel.user.displayname}")
         )
       end
     else

--- a/lib/glimesh_web/controllers/gct_controller.ex
+++ b/lib/glimesh_web/controllers/gct_controller.ex
@@ -87,7 +87,10 @@ defmodule GlimeshWeb.GctController do
           verbose_required: true
         })
 
-        render(conn, "user_chat_log.html", user: user, page_title: format_page_title("Chat Log - #{user.displayname}"))
+        render(conn, "user_chat_log.html",
+          user: user,
+          page_title: format_page_title("Chat Log - #{user.displayname}")
+        )
       end
     end
   end
@@ -270,8 +273,10 @@ defmodule GlimeshWeb.GctController do
           verbose_required: true
         })
 
-        render(conn, "channel_chat_log.html", channel: channel,
-          page_title: format_page_title("Chat Log - #{channel.user.displayname}"))
+        render(conn, "channel_chat_log.html",
+          channel: channel,
+          page_title: format_page_title("Chat Log - #{channel.user.displayname}")
+        )
       end
     end
   end

--- a/lib/glimesh_web/live/gct_live/components/button_array.ex
+++ b/lib/glimesh_web/live/gct_live/components/button_array.ex
@@ -9,6 +9,7 @@ defmodule GlimeshWeb.GctLive.Components.ButtonArray do
     ~L"""
     <%= live_redirect gettext("Edit Profile"), class: (if @can_edit_profile, do: "btn btn-primary", else: "btn btn-primary disabled"), to: Routes.gct_path(@socket, :edit_user_profile, @user.username) %>
     <%= live_redirect gettext("Edit User"), class: (if @can_edit_user, do: "btn btn-primary", else: "btn btn-primary disabled"), to: Routes.gct_path(@socket, :edit_user, @user.username) %>
+    <%= live_redirect gettext("View Chat Logs"), class: (if @view_chat_logs, do: "btn btn-primary", else: "btn btn-primary disabled"), to: Routes.gct_path(@socket, :user_chat_log, @user.id) %>
     <%= unless @user.is_banned do %>
       <button class="btn btn-danger" phx-click="show_ban_modal" <%= unless @can_ban, do: "disabled" %> ><%= gettext("Ban User") %></button>
     <% else %>
@@ -64,6 +65,7 @@ defmodule GlimeshWeb.GctLive.Components.ButtonArray do
     can_ban = Bodyguard.permit?(Glimesh.CommunityTeam, :can_ban, admin, user)
     can_edit_user = Bodyguard.permit?(Glimesh.CommunityTeam, :edit_user, admin, user)
     can_edit_payments = Bodyguard.permit?(Glimesh.CommunityTeam, :view_billing_info, admin, user)
+    view_chat_logs = Bodyguard.permit?(Glimesh.CommunityTeam, :view_chat_logs, admin, user)
 
     can_edit_user_profile =
       Bodyguard.permit?(Glimesh.CommunityTeam, :edit_user_profile, admin, user)
@@ -76,6 +78,7 @@ defmodule GlimeshWeb.GctLive.Components.ButtonArray do
      |> assign(:can_ban, can_ban)
      |> assign(:can_edit_user, can_edit_user)
      |> assign(:can_edit_profile, can_edit_user_profile)
+     |> assign(:view_chat_logs, view_chat_logs)
      |> assign(:can_edit_payments, can_edit_payments)}
   end
 

--- a/lib/glimesh_web/live/gct_live/components/user_chat_log_table.ex
+++ b/lib/glimesh_web/live/gct_live/components/user_chat_log_table.ex
@@ -1,0 +1,60 @@
+defmodule GlimeshWeb.GctLive.Components.UserChatLogTable do
+  use GlimeshWeb, :live_view
+
+  alias Glimesh.Chat
+  alias Glimesh.CommunityTeam
+
+  @impl true
+  def mount(_params, %{"user" => user, "admin" => admin}, socket) do
+    Gettext.put_locale(Glimesh.Accounts.get_user_locale(admin))
+
+    %{
+      entries: entries,
+      page_number: page_number,
+      page_size: page_size,
+      total_entries: total_entries,
+      total_pages: total_pages
+    } =
+      if connected?(socket) do
+        CommunityTeam.paginate_chat_message(Chat.list_all_chat_messages_for_user(user))
+      else
+        %Scrivener.Page{}
+      end
+
+    assigns = [
+      conn: socket,
+      user: user,
+      chat_log: entries,
+      page_number: page_number || 0,
+      page_size: page_size || 0,
+      total_entries: total_entries || 0,
+      total_pages: total_pages || 0
+    ]
+
+    {:ok, assign(socket, assigns)}
+  end
+
+  @impl true
+  def handle_event("nav", %{"page" => page}, socket) do
+    {:noreply, assign(socket, get_and_assign_page(page, socket.assigns.user))}
+  end
+
+  def get_and_assign_page(page_number, user) do
+    %{
+      entries: entries,
+      page_number: page_number,
+      page_size: page_size,
+      total_entries: total_entries,
+      total_pages: total_pages
+    } =
+      CommunityTeam.paginate_chat_message(Chat.list_all_chat_messages_for_user(user), page: page_number)
+
+    [
+      chat_log: entries,
+      page_number: page_number,
+      page_size: page_size,
+      total_entries: total_entries,
+      total_pages: total_pages
+    ]
+  end
+end

--- a/lib/glimesh_web/live/gct_live/components/user_chat_log_table.ex
+++ b/lib/glimesh_web/live/gct_live/components/user_chat_log_table.ex
@@ -47,7 +47,9 @@ defmodule GlimeshWeb.GctLive.Components.UserChatLogTable do
       total_entries: total_entries,
       total_pages: total_pages
     } =
-      CommunityTeam.paginate_chat_message(Chat.list_all_chat_messages_for_user(user), page: page_number)
+      CommunityTeam.paginate_chat_message(Chat.list_all_chat_messages_for_user(user),
+        page: page_number
+      )
 
     [
       chat_log: entries,

--- a/lib/glimesh_web/live/gct_live/components/user_chat_log_table.html.leex
+++ b/lib/glimesh_web/live/gct_live/components/user_chat_log_table.html.leex
@@ -1,0 +1,32 @@
+<div class="card mt-4">
+    <div class="card-header">
+    </div>
+    <div class="card-body">
+        <table class="table">
+            <thead>
+            <tr>
+                <th><%= gettext("Target Channel")%></th>
+                <th><%= gettext("Message")%></th>
+                <th><%= gettext("Inserted At")%></th>
+            </tr>
+            </thead>
+            <tbody>
+            <%= for log <- @chat_log do %>
+                <tr>
+                    <td><%= link log.channel.id, to: Routes.gct_path(@conn, :channel_lookup, query: log.channel.id) %></td>
+                    <td><%= log.message%></td>
+                    <td><local-time id="timestamp-<%= log.id %>" phx-update="ignore" datetime="<%= "#{log.inserted_at}" <> "Z" %>" format="micro" day="2-digit" month="short" year="numeric" hour="numeric" minute="2-digit" second="2-digit"><%= NaiveDateTime.to_time(log.inserted_at) %>
+                </local-time></td>
+                </tr>
+            <%end %>
+            </tbody>
+        </table>
+        <button class="btn btn-primary btn-sm" phx-click="nav" phx-value-page="<%= @page_number - 1%>" <%= if @page_number <= 1, do: "disabled" %>><</button>
+        <%= for idx <- Enum.to_list(1..@total_pages) do %>
+        <%= unless idx > @page_number + 2 || idx < @page_number - 2 do %>
+            <button class="btn btn-primary btn-sm" phx-click="nav" phx-value-page="<%= idx %>" <%= if @page_number == idx, do: "disabled" %>><%= idx %></button>
+        <% end %>
+        <% end %>
+        <button class="btn btn-primary btn-sm" phx-click="nav" phx-value-page="<%= @page_number + 1%>" <%= if @page_number >= @total_pages, do: "disabled" %>>></button>
+    </div>
+</div>

--- a/lib/glimesh_web/router.ex
+++ b/lib/glimesh_web/router.ex
@@ -174,6 +174,7 @@ defmodule GlimeshWeb.Router do
     get "/lookup/user", GctController, :username_lookup
     get "/lookup/channel", GctController, :channel_lookup
     get "/lookup/channel/:channel_id/chat", GctController, :channel_chat_log
+    get "/lookup/user/:user_id/chat", GctController, :user_chat_log
 
     # Editing profile scopes
     get "/edit/profile/:username", GctController, :edit_user_profile

--- a/lib/glimesh_web/templates/gct/user_chat_log.html.eex
+++ b/lib/glimesh_web/templates/gct/user_chat_log.html.eex
@@ -1,0 +1,5 @@
+<div class="container">
+    <h2 class="text-center mt-4"><%= gettext("%{user}'s Chat Logs", user: @user.displayname)%></h2>
+
+    <%= live_render(@conn, GlimeshWeb.GctLive.Components.UserChatLogTable, id: "chat-log-button", session: %{"admin" => @conn.assigns.current_user, "user" => @user})%>
+</div>


### PR DESCRIPTION
This will show any message a user has posted across the platform. 

I also added page titles to the GCT dashboard so it's easier to navigate multiple tabs. 