### PR TITLE
Always create a new oauth token

### DIFF
--- a/lib/glimesh/oauth/oauth_token_handler.ex
+++ b/lib/glimesh/oauth/oauth_token_handler.ex
@@ -62,7 +62,7 @@ defmodule Glimesh.OauthHandler.Token do
 
     result =
       {:ok, %{client: client, resource_owner: resource_owner, scopes: post_request["scope"]}}
-      |> maybe_create_access_token(config)
+      |> create_access_token(config)
 
     case result do
       {:ok, {:error, error}} -> Error.add_error({:ok, params}, error)
@@ -132,9 +132,9 @@ defmodule Glimesh.OauthHandler.Token do
   defp validate_redirect_uri({:ok, params}, _config),
     do: Error.add_error({:ok, params}, Error.invalid_request())
 
-  defp maybe_create_access_token({:error, _} = error, _config), do: error
+  defp create_access_token({:error, _} = error, _config), do: error
 
-  defp maybe_create_access_token(
+  defp create_access_token(
          {:ok, %{resource_owner: resource_owner, client: application, scopes: scopes}},
          config
        ) do
@@ -145,12 +145,7 @@ defmodule Glimesh.OauthHandler.Token do
       expires_in: 604_800
     }
 
-    resource_owner
-    |> AccessTokens.get_token_for(application, scopes, config)
-    |> case do
-      nil -> AccessTokens.create_token(resource_owner, token_params, config)
-      access_token -> {:ok, access_token}
-    end
+    AccessTokens.create_token(resource_owner, token_params, config)
   end
 
   def authorize_response({:ok, params}, config),


### PR DESCRIPTION
The [Oauth2 RFC ](https://tools.ietf.org/html/rfc6749#section-5.1) says every request to issue a token should get a new access token and the library being used here (https://github.com/danschultzer/ex_oauth2_provider) is designed around that assumption as well.

Because we return an existing token if there is one, we get crazy behavior like every single ingest node sharing the same access token (because they all send auth requests with the same client credentials). I don't have proof but I'd bet this causes strange behavior when the token is expiring. With this change ftl ingest servers will each get their own token, plus they will be able to request a new token before the current one expires and avoid any expiration races.

Fixes #547, see that issue for more context.

Might also help with https://github.com/Glimesh/janus-ftl-plugin/issues/112



Tested locally quick but probably could use some more validation, the main downside of this is the token table will grow a bit, and someone could potentially do a denial-of-service by creating a huge number of tokens.