### PR TITLE
Potential fix for chat scrolling

### DIFF
--- a/assets/css/glimesh/components/chat.scss
+++ b/assets/css/glimesh/components/chat.scss
@@ -11,6 +11,15 @@
 
     border-radius: 6px;
 
+    &.phx-error {
+        opacity: .25;
+        cursor: not-allowed;
+
+        * {
+            pointer-events: none;
+        }
+    }
+
     .chat-messages {
         flex: 1 1 90%;
         display: flex;

--- a/assets/js/hooks/Chat.js
+++ b/assets/js/hooks/Chat.js
@@ -30,6 +30,13 @@ export default {
     emotes() {
         return JSON.parse(this.el.dataset.emotes);
     },
+
+    updated() {
+        this.scrollToBottom(document.getElementById('chat-messages'));
+    },
+    reconnected() {
+        this.scrollToBottom(document.getElementById('chat-messages'));
+    },
     mounted() {
         const glimeshEmojis = this.emotes();
 
@@ -65,6 +72,9 @@ export default {
 
         const chat = document.getElementById('chat_message-form_message');
         const chatMessages = document.getElementById('chat-messages');
+
+        // Whenever the user changes their browser size, re-scroll them to the bottom
+        window.addEventListener('resize', () => this.scrollToBottom(chatMessages));
 
         picker.on('emoji', selection => {
             let value = '';


### PR DESCRIPTION
This change makes it so anytime the following events happen, your chat will scroll to the bottom:

- Chat or a parent live view crashes somehow
- You resize your browser window

It also adds a visible opacity change to the chat whenever it crashes so we can debug instances of these.