### PR TITLE
Adding optimizations to the video player and debugging tools

### DIFF
--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -55,8 +55,9 @@ $fa-font-path: "~@fortawesome/fontawesome-free/webfonts";
 @import "glimesh/components/nav";
 @import "glimesh/components/tagify";
 @import "glimesh/components/scrollbar";
-@import "glimesh/components/follow-button.scss";
-@import "glimesh/components/apex-charts.scss";
+@import "glimesh/components/follow-button";
+@import "glimesh/components/apex-charts";
+@import "glimesh/components/video";
 
 @import "glimesh/pages/dmca";
 

--- a/assets/css/glimesh/components/video.scss
+++ b/assets/css/glimesh/components/video.scss
@@ -1,0 +1,60 @@
+#video-loading-container {
+    &.loading {
+        pointer-events: none;
+
+        background: rgba(0, 0, 0, 0.3);
+        position: absolute;
+        bottom: 0;
+        top: 0;
+        left: 0;
+        right: 0;
+
+        display: flex;
+        align-items: center;
+        justify-content: center;
+
+
+        .lds-ring {
+            display: inline-block;
+            position: relative;
+            width: 80px;
+            height: 80px;
+        }
+
+        .lds-ring div {
+            box-sizing: border-box;
+            display: block;
+            position: absolute;
+            width: 64px;
+            height: 64px;
+            margin: 8px;
+            border: 8px solid #fff;
+            border-radius: 50%;
+            animation: lds-ring 1.2s cubic-bezier(0.5, 0, 0.5, 1) infinite;
+            border-color: #fff transparent transparent transparent;
+        }
+
+        .lds-ring div:nth-child(1) {
+            animation-delay: -0.45s;
+        }
+
+        .lds-ring div:nth-child(2) {
+            animation-delay: -0.3s;
+        }
+
+        .lds-ring div:nth-child(3) {
+            animation-delay: -0.15s;
+        }
+
+        @keyframes lds-ring {
+            0% {
+                transform: rotate(0deg);
+            }
+
+            100% {
+                transform: rotate(360deg);
+            }
+        }
+
+    }
+}

--- a/assets/js/hooks/FtlVideo.js
+++ b/assets/js/hooks/FtlVideo.js
@@ -6,13 +6,25 @@ let player;
 
 export default {
     mounted() {
+        let parent = this;
         let container = this.el;
+        let videoLoadingContainer = document.getElementById("video-loading-container");
 
         this.handleEvent("load_video", ({janus_url, channel_id}) => {
-            player = new FtlPlayer(container, janus_url);
+            player = new FtlPlayer(container, janus_url, {
+                hooks: {
+                    janusSlowLink(uplink, lostPackets) {
+                        parent.pushEvent("lost_packets", {
+                            uplink: uplink,
+                            lostPackets: lostPackets
+                        });
+                        console.debug(`GLIMESH.TV LOST PACKETS uplink=${uplink} lostPackets=${lostPackets}`)
+                    }
+                }
+            }); 
             console.debug(`load_video event for janus_url=${janus_url} channel_id=${channel_id}`)
             player.init(channel_id);
-        });
+        }); 
 
         let lastVolume = localStorage.getItem("player-volume");
         if (lastVolume) {
@@ -35,7 +47,19 @@ export default {
                     container.play();
                 });
               }
-        })
+        });
+
+        container.addEventListener("waiting", function() {
+            videoLoadingContainer.classList.add("loading");
+        });
+        
+        container.addEventListener("abort", function() {
+            videoLoadingContainer.classList.add("loading");
+        });
+
+        container.addEventListener("playing", function() {
+            videoLoadingContainer.classList.remove("loading");
+        });
     },
     destroyed() {
         if(player) {

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -14,7 +14,7 @@
         "bootstrap.native": "^3.0.14",
         "bs-custom-file-input": "^1.3.4",
         "choices.js": "^9.0.1",
-        "janus-ftl-player": "0.0.3-alpha",
+        "janus-ftl-player": "0.0.7-alpha",
         "phoenix": "file:../deps/phoenix",
         "phoenix_html": "file:../deps/phoenix_html",
         "phoenix_live_view": "file:../deps/phoenix_live_view"
@@ -39,13 +39,15 @@
       }
     },
     "../deps/phoenix": {
-      "version": "0.0.1"
+      "version": "1.5.6",
+      "license": "MIT"
     },
     "../deps/phoenix_html": {
-      "version": "0.0.1"
+      "version": "2.14.2"
     },
     "../deps/phoenix_live_view": {
-      "version": "0.0.1"
+      "version": "0.14.8",
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.10.4",
@@ -5487,9 +5489,9 @@
       "dev": true
     },
     "node_modules/janus-ftl-player": {
-      "version": "0.0.3-alpha",
-      "resolved": "https://registry.npmjs.org/janus-ftl-player/-/janus-ftl-player-0.0.3-alpha.tgz",
-      "integrity": "sha512-boBG4l1cfsEZVOKCJkF8itrZ8KSJ723E8zssJBdLOqTnvGebonmo6XGgmf7H+sJxLF7rVf/h9TxpVStzbEfiCw==",
+      "version": "0.0.7-alpha",
+      "resolved": "https://registry.npmjs.org/janus-ftl-player/-/janus-ftl-player-0.0.7-alpha.tgz",
+      "integrity": "sha512-LiwJu+i6c7duiJBPQC0tMHY0hjeaf2si/MptkUg9kMVtiSfIThqtG5kk2rmKaNTt8qZwlN+gw2ANWupZuH+tuQ==",
       "dependencies": {
         "janus-gateway": "github:meetecho/janus-gateway"
       }
@@ -9962,6 +9964,7 @@
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
       "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
       "dev": true,
+      "hasInstallScript": true,
       "optional": true,
       "os": [
         "darwin"
@@ -15109,9 +15112,9 @@
       "dev": true
     },
     "janus-ftl-player": {
-      "version": "0.0.3-alpha",
-      "resolved": "https://registry.npmjs.org/janus-ftl-player/-/janus-ftl-player-0.0.3-alpha.tgz",
-      "integrity": "sha512-boBG4l1cfsEZVOKCJkF8itrZ8KSJ723E8zssJBdLOqTnvGebonmo6XGgmf7H+sJxLF7rVf/h9TxpVStzbEfiCw==",
+      "version": "0.0.7-alpha",
+      "resolved": "https://registry.npmjs.org/janus-ftl-player/-/janus-ftl-player-0.0.7-alpha.tgz",
+      "integrity": "sha512-LiwJu+i6c7duiJBPQC0tMHY0hjeaf2si/MptkUg9kMVtiSfIThqtG5kk2rmKaNTt8qZwlN+gw2ANWupZuH+tuQ==",
       "requires": {
         "janus-gateway": "github:meetecho/janus-gateway"
       }

--- a/assets/package.json
+++ b/assets/package.json
@@ -15,7 +15,7 @@
     "bootstrap.native": "^3.0.14",
     "bs-custom-file-input": "^1.3.4",
     "choices.js": "^9.0.1",
-    "janus-ftl-player": "0.0.3-alpha",
+    "janus-ftl-player": "0.0.7-alpha",
     "phoenix": "file:../deps/phoenix",
     "phoenix_html": "file:../deps/phoenix_html",
     "phoenix_live_view": "file:../deps/phoenix_live_view"

--- a/lib/glimesh/channel_lookups.ex
+++ b/lib/glimesh/channel_lookups.ex
@@ -151,7 +151,7 @@ defmodule Glimesh.ChannelLookups do
       end
 
     Repo.one(query)
-    |> Repo.preload([:category, :subcategory, :user, :tags])
+    |> Repo.preload([:category, :stream, :subcategory, :user, :tags])
   end
 
   def get_channel_by_hmac_key(hmac_key) do

--- a/lib/glimesh/graphql/schema/channel_types.ex
+++ b/lib/glimesh/graphql/schema/channel_types.ex
@@ -82,7 +82,7 @@ defmodule Glimesh.Schema.ChannelTypes do
     end
 
     @desc "Update a stream's metadata"
-    field :log_stream_metadata, type: :stream do
+    field :log_stream_metadata, type: :stream_metadata do
       arg(:stream_id, non_null(:id))
       arg(:metadata, non_null(:stream_metadata_input))
 

--- a/lib/glimesh_web/live/user_live/stream.html.leex
+++ b/lib/glimesh_web/live/user_live/stream.html.leex
@@ -49,12 +49,16 @@
                     </div>
 
                     <% else %>
-                    <div class="embed-responsive embed-responsive-16by9">
-                        <%= if @backend == "ftl" do %>
-                        <video id="video-player" class="embed-responsive-item" phx-hook="FtlVideo" poster="<%= Glimesh.ChannelPoster.url({@channel.poster, @channel}, :original) %>" controls playsinline></video>
-                        <% else %>
-                        No video player backend specified.
-                        <% end %>
+                    <div id="video-container" class="embed-responsive embed-responsive-16by9">
+                        <video id="video-player" class="embed-responsive-item" phx-hook="FtlVideo" controls playsinline poster="<%= @channel_poster %>"></video>
+                        <div id="video-loading-container" class="">
+                            <div class="lds-ring">
+                                <div></div>
+                                <div></div>
+                                <div></div>
+                                <div></div>
+                            </div>
+                        </div>
                     </div>
 
                     <%= if @player_error do %>
@@ -79,20 +83,55 @@
                             <span class="badge badge-pill badge-info ml-2"><%= Glimesh.Streams.get_channel_language(@channel) %></span>
 
                             <%= live_render(@socket, GlimeshWeb.UserLive.Components.SocialButtons, id: "social-buttons", container: {:ul, class: "list-inline ml-2 mb-0"}, session: %{"user_id" => @streamer.id}) %>
-
-                            <!--
-                            Video Edge Information
-                            Edge Hostname: <%= @janus_hostname %>
-                            Edge URL: <%= @janus_url %>
-                            -->
-                            <%# live_render(@socket, GlimeshWeb.UserLive.ViewerHeads, id: "viewer-heads", session: %{"user" => @user, "streamer" => @streamer.username, "fake_multiplier" => 12}) %>
                         </div>
                         <div class="col-4 align-self-center">
                             <div class="float-right mr-sm-2">
-                                <%= live_render(@socket, GlimeshWeb.UserLive.Components.ReportButton, id: "report-button", session: %{"user" => @user, "streamer" => @streamer}) %>
+                                <div class="d-inline-block mr-sm-2">
+                                    <a href="#" phx-click="toggle_debug" class="text-color-link">
+                                        <i class="fas fa-signal"></i>
+                                        <span class="sr-only">Debug</span>
+                                    </a>
+                                </div>
+                                <div class="d-inline-block">
+                                    <%= live_render(@socket, GlimeshWeb.UserLive.Components.ReportButton, id: "report-button", session: %{"user" => @user, "streamer" => @streamer}) %>
+                                </div>
                             </div>
                         </div>
                     </div>
+                    <%= if @show_debug do %>
+                    <div id="debug-info">
+                        <h3 class="mt-4">Debug Information</h3>
+                        <pre class="px-2">
+== Janus Edge Information ==
+Edge Hostname: <%= @janus_hostname %>
+Edge URL: <%= @janus_url %>
+Reported Lost Packets: <%= @lost_packets %>
+<br>
+== Stream Metadata ==
+ingest_server: <%= @stream_metadata.ingest_server %>
+ingest_viewers: <%= @stream_metadata.ingest_viewers %> // unused
+stream_time_seconds: <%= @stream_metadata.stream_time_seconds %>
+
+source_bitrate: <%= @stream_metadata.source_bitrate %>
+source_ping: <%= @stream_metadata.source_ping %> // unused
+
+recv_packets: <%= @stream_metadata.recv_packets %>
+lost_packets: <%= @stream_metadata.lost_packets %> // unused
+nack_packets: <%= @stream_metadata.nack_packets %> // unused
+
+vendor_name: <%= @stream_metadata.vendor_name %>
+vendor_version: <%= @stream_metadata.vendor_version %>
+
+audio_codec: <%= @stream_metadata.audio_codec %>
+video_codec: <%= @stream_metadata.video_codec %>
+video_height: <%= @stream_metadata.video_height %> // unused
+video_width: <%= @stream_metadata.video_width %> // unused
+
+inserted_at: <%= @stream_metadata.inserted_at %>
+updated_at: <%= @stream_metadata.updated_at %>
+</pre>
+                    </div>
+                    <% end %>
                 </div>
             </div>
         </div>
@@ -107,7 +146,6 @@
 
     </div>
 
-    <%= if @show_bottom do %>
     <div class="row">
         <div class="col-lg-9 layout-spacing">
             <div class="card">
@@ -158,6 +196,5 @@
             </div>
         </div>
     </div>
-    <% end %>
 
 </div>

--- a/test/glimesh_web/api/privileged_channel_test.exs
+++ b/test/glimesh_web/api/privileged_channel_test.exs
@@ -248,7 +248,8 @@ defmodule GlimeshWeb.Api.PrivilegedChannelTest do
           }
         })
 
-      assert json_response(conn, 200)["data"]["logStreamMetadata"] == %{"id" => "#{stream.id}"}
+      metadata = Glimesh.Streams.get_last_stream_metadata(stream)
+      assert json_response(conn, 200)["data"]["logStreamMetadata"] == %{"id" => "#{metadata.id}"}
     end
 
     test "can upload stream thumbnails", %{conn: conn, channel: channel} do

--- a/test/glimesh_web/live/user_live/stream_test.exs
+++ b/test/glimesh_web/live/user_live/stream_test.exs
@@ -79,8 +79,11 @@ defmodule GlimeshWeb.UserLive.StreamTest do
 
       {:ok, view, _} = live(conn, Routes.user_stream_path(conn, :index, streamer.username))
 
-      assert render(view) =~ "some-de-server"
-      assert render(view) =~ "https://some-de-server/janus"
+      html = render_click(view, "toggle_debug")
+
+      assert html =~ "Debug Information"
+      assert html =~ "some-de-server"
+      assert html =~ "https://some-de-server/janus"
     end
   end
 end


### PR DESCRIPTION
Adds the following:

### Video Loading Indicator
The video loading indicator only shows up when the browser media events `waiting` or `abort` fire, generally during packet loss.

### Networking Problems Indicator
This new alert shows up whenever we're experiencing packet loss with the video, and as such the user can expect a sub-par video experience. 
![image](https://user-images.githubusercontent.com/226638/112690336-fa6ee980-8e51-11eb-97e8-fb0174b68104.png)

### Debugging Information 
Optionally shown by clicking the network icon below the stream. Contains information about the edge, lost packets, and the last metadata frame.
![image](https://user-images.githubusercontent.com/226638/112690400-12df0400-8e52-11eb-8654-cfaa3bcce919.png)

Also optimizes some our live view loading code.
