### PR TITLE
Adding full search to your followers page, showing all following users

### DIFF
--- a/assets/css/glimesh/components/stream.scss
+++ b/assets/css/glimesh/components/stream.scss
@@ -9,7 +9,7 @@
     padding-left: 0;
     padding-right: 0;
     // Needed for container padding we're removing
-    overflow-x: hidden;
+    overflow: hidden
 }
 
 .container-stream {

--- a/lib/glimesh/account_follows.ex
+++ b/lib/glimesh/account_follows.ex
@@ -97,7 +97,23 @@ defmodule Glimesh.AccountFollows do
   end
 
   def list_following(user) do
-    Repo.all(from f in Follower, where: f.user_id == ^user.id)
+    Repo.all(from f in Follower, where: f.user_id == ^user.id) |> Repo.preload(:streamer)
+  end
+
+  def search_following(user, query, current_page, per_page) do
+    like = "%#{query}%"
+
+    Repo.all(
+      from u in User,
+        inner_join: f in Follower,
+        on: f.user_id == ^user.id,
+        where: u.id == f.streamer_id,
+        where: ilike(u.username, ^like),
+        where: u.is_banned == false,
+        order_by: [asc: u.id],
+        offset: ^((current_page - 1) * per_page),
+        limit: ^per_page
+    )
   end
 
   defp sent_follow_message_recently?(channel, user) do

--- a/lib/glimesh_web/live/components/user_card.ex
+++ b/lib/glimesh_web/live/components/user_card.ex
@@ -1,0 +1,47 @@
+defmodule GlimeshWeb.Components.UserCard do
+  use GlimeshWeb, :live_component
+
+  def render(assigns) do
+    user = assigns.user
+
+    ~L"""
+      <div class="card">
+        <div class="card-body">
+            <h4 class="<%= Glimesh.Chat.Effects.get_username_color(user, "text-color-link") %>">
+                <%= user.displayname %></h4>
+            <div class="media flex-wrap">
+                <img src="<%= Glimesh.Avatar.url({user.avatar, user}, :original) %>" alt="<%= user.displayname %>" height="128" class="mr-3 img-avatar <%= if Glimesh.Accounts.can_receive_payments?(user), do: "img-verified-streamer", else: "" %>">
+                <div class="media-body">
+                    <ul class="list-unstyled">
+                        <li>
+                            <strong><%= gettext("Joined:") %></strong>
+                            <%= format_datetime(user.inserted_at) %>
+                        </li>
+                        <li>
+                            <strong><%= gettext("Followers:") %></strong>
+                            <%= Glimesh.AccountFollows.count_followers(user) %>
+                        </li>
+                        <li>
+                            <strong><%= gettext("Following:") %></strong>
+                            <%= Glimesh.AccountFollows.count_following(user) %>
+                        </li>
+                        <li>
+                            <%= if twitter_user = Glimesh.Socials.get_social(user, "twitter") do %>
+                            <span class="fa-stack" data-toggle="tooltip" title="<%= gettext("Linked Twitter Account @%{username}", username: twitter_user.username) %>">
+                                <i class="fas fa-certificate fa-stack-2x" style="color:#007bff"></i>
+                                <i class="fab fa-twitter fa-stack-1x"></i>
+                            </span>
+                            <% else %>
+                            <br>
+                            <% end %>
+                        </li>
+                    </ul>
+
+                    <%= live_redirect gettext("Profile"), to: Routes.user_profile_path(@socket, :index, user.username), class: "btn btn-primary btn-sm" %>
+                </div>
+            </div>
+        </div>
+    </div>
+    """
+  end
+end

--- a/lib/glimesh_web/live/streams_live/following.ex
+++ b/lib/glimesh_web/live/streams_live/following.ex
@@ -1,56 +1,8 @@
 defmodule GlimeshWeb.StreamsLive.Following do
   use GlimeshWeb, :live_view
 
+  alias Glimesh.AccountFollows
   alias Glimesh.Accounts
-
-  @impl true
-  def render(assigns) do
-    ~L"""
-    <div class="container container-stream-list">
-      <div class="position-relative overflow-hidden p-3 p-md-5 m-md-3 text-center">
-          <div class="col-md-12 mx-auto ">
-              <h1 class="display-4 font-weight-normal">
-                  <%= gettext("Followed Streams") %>
-              </h1>
-              <%= if length(@channels) == 0 do %>
-              <p><%= gettext("None of the streams you follow are live.") %></p>
-              <% end %>
-          </div>
-      </div>
-      <div class="row">
-        <%= for channel <- @channels do %>
-          <div class="col-sm-12 col-md-6 col-xl-4 mt-4">
-              <%= link to: Routes.user_stream_path(@socket, :index, channel.user.username), class: "text-color-link" do %>
-              <div class="card card-stream">
-                  <img src="<%= Glimesh.StreamThumbnail.url({channel.stream.thumbnail, channel.stream}, :original) %>" alt="<%= channel.title %>" class="card-img" height="468" width="832">
-                  <div class="card-img-overlay h-100 d-flex flex-column justify-content-between">
-
-                      <div class="card-stream-tags">
-
-                          <%= if channel.subcategory do %>
-                          <span class="badge badge-info"><%= channel.subcategory.name %></span>
-                          <% end %>
-                          <%= for tag <- channel.tags do %>
-                          <span class="badge badge-primary"><%= tag.name %></span>
-                          <% end %>
-                      </div>
-
-                      <div class="media card-stream-streamer">
-                          <img src="<%= Glimesh.Avatar.url({channel.user.avatar, channel.user}, :original) %>" alt="<%= channel.user.displayname%>" width="48" height="48" class="img-avatar mr-2 <%= if Glimesh.Accounts.can_receive_payments?(channel.user), do: "img-verified-streamer", else: "" %>">
-                          <div class="media-body">
-                              <h6 class="mb-0 mt-1 card-stream-title"><%= channel.title %></h6>
-                              <p class="mb-0 card-stream-username"><%= channel.user.displayname %> <span class="badge badge-info"><%= Glimesh.Streams.get_channel_language(channel) %></span></p>
-                          </div>
-                      </div>
-                  </div>
-              </div>
-              <% end %>
-          </div>
-          <% end %>
-      </div>
-    </div>
-    """
-  end
 
   @impl true
   def mount(_params, session, socket) do
@@ -63,11 +15,31 @@ defmodule GlimeshWeb.StreamsLive.Following do
         {:ok,
          socket
          |> put_page_title(gettext("Followed Streams"))
+         |> assign(:query, "")
+         |> assign(page: 1, per_page: 12, update_mode: "append")
          |> assign(:current_user, user)
-         |> assign(:channels, live_streams)}
+         |> search_followed_users()
+         |> assign(:channels, live_streams), temporary_assigns: [users: []]}
 
       nil ->
         {:ok, redirect(socket, to: "/")}
     end
+  end
+
+  @impl true
+  def handle_event("search", %{"q" => query}, socket) do
+    {:noreply,
+     assign(socket, update_mode: "replace", page: 1, per_page: 12, query: query)
+     |> search_followed_users()}
+  end
+
+  def handle_event("load-more", _, %{assigns: assigns} = socket) do
+    {:noreply,
+     assign(socket, update_mode: "append", page: assigns.page + 1) |> search_followed_users()}
+  end
+
+  def search_followed_users(%{assigns: %{query: query, page: page, per_page: per}} = socket) do
+    user = socket.assigns.current_user
+    assign(socket, users: AccountFollows.search_following(user, query, page, per))
   end
 end

--- a/lib/glimesh_web/live/streams_live/following.html.leex
+++ b/lib/glimesh_web/live/streams_live/following.html.leex
@@ -1,0 +1,71 @@
+<div class="container container-stream-list">
+    <div class="position-relative overflow-hidden p-3 p-md-5 m-md-3 text-center">
+        <div class="col-md-12 mx-auto ">
+            <h1 class="display-4 font-weight-normal">
+                <%= gettext("Live Followed Streams") %>
+            </h1>
+            <%= if length(@channels) == 0 do %>
+            <p><%= gettext("None of the streams you follow are live.") %></p>
+            <% end %>
+        </div>
+    </div>
+    <div class="row">
+        <%= for channel <- @channels do %>
+        <div class="col-sm-12 col-md-6 col-xl-4 mt-4">
+            <%= link to: Routes.user_stream_path(@socket, :index, channel.user.username), class: "text-color-link" do %>
+            <div class="card card-stream">
+                <img src="<%= Glimesh.StreamThumbnail.url({channel.stream.thumbnail, channel.stream}, :original) %>" alt="<%= channel.title %>" class="card-img" height="468" width="832">
+                <div class="card-img-overlay h-100 d-flex flex-column justify-content-between">
+
+                    <div class="card-stream-tags">
+
+                        <%= if channel.subcategory do %>
+                        <span class="badge badge-info"><%= channel.subcategory.name %></span>
+                        <% end %>
+                        <%= for tag <- channel.tags do %>
+                        <span class="badge badge-primary"><%= tag.name %></span>
+                        <% end %>
+                    </div>
+
+                    <div class="media card-stream-streamer">
+                        <img src="<%= Glimesh.Avatar.url({channel.user.avatar, channel.user}, :original) %>" alt="<%= channel.user.displayname%>" width="48" height="48" class="img-avatar mr-2 <%= if Glimesh.Accounts.can_receive_payments?(channel.user), do: "img-verified-streamer", else: "" %>">
+                        <div class="media-body">
+                            <h6 class="mb-0 mt-1 card-stream-title"><%= channel.title %></h6>
+                            <p class="mb-0 card-stream-username"><%= channel.user.displayname %> <span class="badge badge-info"><%= Glimesh.Streams.get_channel_language(channel) %></span></p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <% end %>
+        </div>
+        <% end %>
+    </div>
+</div>
+<div class="container">
+    <div class="position-relative overflow-hidden p-3 p-md-5 m-md-3 text-center">
+        <div class="col-md-12 mx-auto ">
+            <h2 class="display-4 font-weight-normal">
+                <%= gettext("All Followed Streamers") %>
+            </h2>
+            <%= if length(@users) == 0 do %>
+            <p><%= gettext("You do not follow anyone who is offline.") %></p>
+            <% end %>
+        </div>
+    </div>
+    <div class="card">
+        <div class="card-body">
+            <form phx-change="search">
+                <div class="form-group mb-0">
+                    <input type="text" name="q" value="<%= @query %>" placeholder="<%= gettext("Search for usernames") %>" list="results" autocomplete="off" autofocus class="form-control form-control-lg" />
+                </div>
+            </form>
+        </div>
+    </div>
+    <div id="users" class="row mt-2" phx-update="<%= @update_mode %>" phx-hook="InfiniteScroll" data-page="<%= @page %>">
+        <%= for user <- @users do %>
+        <div id="user-<%= user.id %>" class="col-md-4 mb-4" phx-update="ignore">
+            <%= live_component(@socket, GlimeshWeb.Components.UserCard, user: user) %>
+        </div>
+        <% end %>
+    </div>
+</div>

--- a/lib/glimesh_web/live/user_live/followers.ex
+++ b/lib/glimesh_web/live/user_live/followers.ex
@@ -8,15 +8,25 @@ defmodule GlimeshWeb.UserLive.Followers do
 
     case Accounts.get_by_username(username) do
       %Glimesh.Accounts.User{} = streamer ->
-        followers = Glimesh.AccountFollows.list_followers(streamer)
-
         {:ok,
          socket
          |> assign(:streamer, streamer)
-         |> assign(:users, followers)}
+         |> handle_page()}
 
       nil ->
         {:ok, redirect(socket, to: "/")}
     end
+  end
+
+  def handle_page(%{assigns: %{live_action: :followers, streamer: streamer}} = socket) do
+    socket
+    |> assign(:page_title, gettext("%{username}'s Followers", username: streamer.displayname))
+    |> assign(:users, Glimesh.AccountFollows.list_followers(streamer))
+  end
+
+  def handle_page(%{assigns: %{live_action: :following, streamer: streamer}} = socket) do
+    socket
+    |> assign(:page_title, gettext("%{username}'s Following", username: streamer.displayname))
+    |> assign(:users, Glimesh.AccountFollows.list_following(streamer))
   end
 end

--- a/lib/glimesh_web/live/user_live/followers.html.leex
+++ b/lib/glimesh_web/live/user_live/followers.html.leex
@@ -1,26 +1,19 @@
 <div class="container">
 
-    <h2 class="mt-4"><%= gettext("%{username}'s Followers", username: @streamer.displayname) %></h2>
+    <h2 class="mt-4"><%= @page_title %></h2>
+    <ul class="nav nav-pills mb-4">
+        <li class="nav-item">
+            <%= live_redirect "Followers", to: Routes.user_followers_path(@socket, :followers, @streamer.username), class: "nav-link " <> (if @live_action == :followers, do: "active", else: "") %>
+        </li>
+        <li class="nav-item">
+            <%= live_redirect "Following", to: Routes.user_followers_path(@socket, :following, @streamer.username), class: "nav-link " <> (if @live_action == :following, do: "active", else: "") %>
+        </li>
+    </ul>
     <div class="row layout-top-spacing">
         <%= for follower <- @users do %>
-
-        <div class="col-md-2 mb-4">
-            <%= live_redirect to: Routes.user_profile_path(@socket, :index, follower.user.username) do %>
-            <div class="card">
-                <div class="card-body">
-                    <div class="text-md-center">
-                        <h4><%= follower.user.displayname %></h2>
-                            <img src="<%= Glimesh.Avatar.url({follower.user.avatar, follower.user}, :original) %>" alt="Your Profile Picture" style="width: 80% !important;" class="img-fluid mb-2 img-avatar <%= if Glimesh.Accounts.can_receive_payments?(follower.user), do: "img-verified-streamer", else: "" %>">
-
-                            <%= if Glimesh.Accounts.can_receive_payments?(follower.user) do %>
-                            <div class="mb-4"><span class="badge badge-secondary"><%= gettext("Sub Ready!") %></span></div>
-                            <% end %>
-                    </div>
-                </div>
-            </div>
-            <% end %>
+        <div class="col-md-4 mb-4">
+            <%= live_component(@socket, GlimeshWeb.Components.UserCard, user: (if @live_action == :followers, do: follower.user, else: follower.streamer)) %>
         </div>
-
         <% end %>
     </div>
 </div>

--- a/lib/glimesh_web/live/user_live/index.html.leex
+++ b/lib/glimesh_web/live/user_live/index.html.leex
@@ -14,43 +14,7 @@
     <div id="users" class="row mt-2" phx-update="<%= @update_mode %>" phx-hook="InfiniteScroll" data-page="<%= @page %>">
         <%= for user <- @users do %>
         <div id="user-<%= user.id %>" class="col-md-4 mb-4" phx-update="ignore">
-            <div class="card">
-                <div class="card-body">
-                    <h4 class="<%= Glimesh.Chat.Effects.get_username_color(user, "text-color-link") %>">
-                        <%= user.displayname %></h4>
-                    <div class="media flex-wrap">
-                        <img src="<%= Glimesh.Avatar.url({user.avatar, user}, :original) %>" alt="<%= user.displayname %>" height="128" class="mr-3 img-avatar <%= if Glimesh.Accounts.can_receive_payments?(user), do: "img-verified-streamer", else: "" %>">
-                        <div class="media-body">
-                            <ul class="list-unstyled">
-                                <li>
-                                    <strong><%= gettext("Joined:") %></strong>
-                                    <%= format_datetime(user.inserted_at) %>
-                                </li>
-                                <li>
-                                    <strong><%= gettext("Followers:") %></strong>
-                                    <%= Glimesh.AccountFollows.count_followers(user) %>
-                                </li>
-                                <li>
-                                    <strong><%= gettext("Following:") %></strong>
-                                    <%= Glimesh.AccountFollows.count_following(user) %>
-                                </li>
-                                <li>
-                                    <%= if twitter_user = Glimesh.Socials.get_social(user, "twitter") do %>
-                                    <span class="fa-stack" data-toggle="tooltip" title="<%= gettext("Linked Twitter Account @%{username}", username: twitter_user.username) %>">
-                                        <i class="fas fa-certificate fa-stack-2x" style="color:#007bff"></i>
-                                        <i class="fab fa-twitter fa-stack-1x"></i>
-                                    </span>
-                                    <% else %>
-                                    <br>
-                                    <% end %>
-                                </li>
-                            </ul>
-
-                            <%= live_redirect gettext("Profile"), to: Routes.user_profile_path(@socket, :index, user.username), class: "btn btn-primary btn-sm" %>
-                        </div>
-                    </div>
-                </div>
-            </div>
+            <%= live_component(@socket, GlimeshWeb.Components.UserCard, user: user) %>
         </div>
         <% end %>
     </div>

--- a/lib/glimesh_web/live/user_live/profile.html.leex
+++ b/lib/glimesh_web/live/user_live/profile.html.leex
@@ -27,14 +27,16 @@
 
                     <div class="row mt-4">
                         <div class="col-6">
-                            <%= live_redirect to: Routes.user_followers_path(@socket, :index, @streamer.username), class: "text-color-link" do %>
+                            <%= live_redirect to: Routes.user_followers_path(@socket, :followers, @streamer.username), class: "text-color-link" do %>
                             <h5><%= @followers_count %></h5>
                             <p><%= gettext("Followers") %></p>
                             <% end %>
                         </div>
                         <div class="col-6">
+                        <%= live_redirect to: Routes.user_followers_path(@socket, :following, @streamer.username), class: "text-color-link" do %>
                             <h5><%= @following_count %></h5>
                             <p><%= gettext("Following") %></p>
+                            <% end %>
                         </div>
                     </div>
 

--- a/lib/glimesh_web/router.ex
+++ b/lib/glimesh_web/router.ex
@@ -232,7 +232,8 @@ defmodule GlimeshWeb.Router do
     # This must be the last route
     live "/:username", UserLive.Stream, :index
     live "/:username/profile", UserLive.Profile, :index
-    live "/:username/profile/followers", UserLive.Followers, :index
+    live "/:username/profile/followers", UserLive.Followers, :followers
+    live "/:username/profile/following", UserLive.Followers, :following
     live "/:username/chat", ChatLive.PopOut, :index
   end
 

--- a/test/glimesh_web/streams_live/following_test.exs
+++ b/test/glimesh_web/streams_live/following_test.exs
@@ -24,6 +24,8 @@ defmodule GlimeshWeb.StreamsLive.FollowingTest do
 
       assert html =~ "Followed Streams"
       assert html =~ "None of the streams you follow are live"
+      assert html =~ "All Followed Streamers"
+      assert html =~ "You do not follow anyone who is offline"
     end
 
     test "lists some followed streams", %{
@@ -39,6 +41,19 @@ defmodule GlimeshWeb.StreamsLive.FollowingTest do
       assert html =~ "Followed Streams"
       assert html =~ streamer.displayname
       assert html =~ channel.title
+    end
+
+    test "lists users that are offline", %{
+      conn: conn,
+      user: user
+    } do
+      streamer = streamer_fixture()
+      Glimesh.AccountFollows.follow(streamer, user)
+
+      {:ok, _, html} = live(conn, Routes.streams_list_path(conn, :index, "following"))
+
+      assert html =~ "All Followed Streamers"
+      assert html =~ streamer.displayname
     end
   end
 end


### PR DESCRIPTION
New Following page:
![image](https://user-images.githubusercontent.com/226638/113446379-b174e300-93c5-11eb-9ed9-bfddd4767503.png)

New Followers / Following page on user profiles:
![image](https://user-images.githubusercontent.com/226638/113446432-c782a380-93c5-11eb-9e5a-1bd8ce9e9991.png)

Links to both on the profile, and you can cycle between them with the tabs.
