### PR TITLE
Mobile Chat Layout Changes

### DIFF
--- a/lib/glimesh_web/live/chat_live/index.html.leex
+++ b/lib/glimesh_web/live/chat_live/index.html.leex
@@ -1,4 +1,4 @@
-<div id="chat-messages" class="chat-messages <%= if @show_timestamps, do: "show-timestamps" %>" phx-update="<%= @update_action %>" style="<%= background_style(@channel) %>">
+<div id="chat-messages" class="chat-messages order-2 <%= if @show_timestamps, do: "show-timestamps" %>" phx-update="<%= @update_action %>" style="<%= background_style(@channel) %>">
     <div id="channel-header" class="channel-header">
         <span><%= gettext("Welcome to chat! Follow the rules.") %></span>
     </div>
@@ -34,7 +34,7 @@
     </div>
     <% end %>
 </div>
-<div class="chat-form">
+<div class="chat-form order-lg-2">
     <%= live_component @socket, GlimeshWeb.ChatLive.MessageForm,
             id: :new,
             action: :new,

--- a/lib/glimesh_web/live/chat_live/message_form.html.leex
+++ b/lib/glimesh_web/live/chat_live/message_form.html.leex
@@ -1,4 +1,4 @@
-<div id="chat-form " phx-hook="Chat" data-emotes="<%= @emotes %>" data-theme="<%= @theme %>">
+<div id="chat-form" phx-hook="Chat" data-emotes="<%= @emotes %>" data-theme="<%= @theme %>">
     <%= if @disabled do %>
     <div id="channel-footer" class="channel-footer">
         <span>You must be logged in to chat. <%= link "Register", to: Routes.user_registration_path(@socket, :new) %></span>

--- a/lib/glimesh_web/live/chat_live/message_form.html.leex
+++ b/lib/glimesh_web/live/chat_live/message_form.html.leex
@@ -1,4 +1,4 @@
-<div id="chat-form" phx-hook="Chat" data-emotes="<%= @emotes %>" data-theme="<%= @theme %>">
+<div id="chat-form " phx-hook="Chat" data-emotes="<%= @emotes %>" data-theme="<%= @theme %>">
     <%= if @disabled do %>
     <div id="channel-footer" class="channel-footer">
         <span>You must be logged in to chat. <%= link "Register", to: Routes.user_registration_path(@socket, :new) %></span>
@@ -28,13 +28,16 @@
 
         <%= text_input f, :message, class: "mail-write-box form-control", placeholder: gettext("Send a message"), autocomplete: "off", maxlength: "255", disabled: @disabled %>
 
-        <div id="chat-settings" class="input-group-append dropup">
+        <div id="chat-settings" class="input-group-append dropup d-none d-lg-flex">
             <button type="button" class="input-group-text dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><i class="fas fa-cog"></i></button>
             <div class="dropdown-menu dropdown-menu-right">
                 <a class="dropdown-item" href="#" onclick="window.open('<%= Routes.chat_pop_out_url(@socket, :index, @channel_username) %>', '_blank', 'width=400,height=600,location=no,menubar=no,toolbar=no')"><%= gettext("Pop-out Chat") %></a>
                 <a id="toggle-timestamps" class="dropdown-item" , href="#" phx-click="toggle_timestamps" <%= if @user, do: 'phx-value-user=#{@user.username}' %>><%= if @show_timestamps, do: gettext("Disable Timestamps"), else: gettext("Enable Timestamps") %>
                 </a>
             </div>
+        </div>
+        <div class="d-block d-lg-none">
+            <a class="btn btn-link" href="#" onclick="window.open('<%= Routes.chat_pop_out_url(@socket, :index, @channel_username) %>', '_blank', 'width=400,height=600,location=no,menubar=no,toolbar=no')"><%= gettext("Pop-out Chat") %></a>
         </div>
 
     </div>


### PR DESCRIPTION
Changes placement of chat messages and chat input based on screen/display size. This should allow users to view stream and chat on mobile devices (although due to differences in screens and the [quirkiness of iOS](https://blog.opendigerati.com/the-eccentric-ways-of-ios-safari-with-the-keyboard-b5aa3f34228d), it's not 100% perfect).

![image](https://user-images.githubusercontent.com/1784580/113755812-9a840880-96c5-11eb-8684-e4a94848ea36.png)
**Desktop view**

![image](https://user-images.githubusercontent.com/1784580/113755976-c43d2f80-96c5-11eb-892c-08b551b834a2.png)
**Mobile view** - input moved above messages