### PR TITLE
Adding option to hide mod icons

### DIFF
--- a/assets/css/glimesh/components/chat.scss
+++ b/assets/css/glimesh/components/chat.scss
@@ -77,6 +77,16 @@
             display: none;
         }
 
+        .chat-mod-icon {
+            display: none;
+        }
+
+        &.show-mod-icons {
+            .chat-mod-icon {
+                display: inline-block;
+            }
+        }
+
         &.show-timestamps {
             .chat-timestamp {
                 display: inline-block;

--- a/assets/js/hooks/Chat.js
+++ b/assets/js/hooks/Chat.js
@@ -109,6 +109,14 @@ export default {
             }
             this.maybeScrollToBottom(chatMessages);
         });
+        this.handleEvent("toggle_mod_icons", (e) => {
+            if (e["show_mod_icons"]) {
+                chatMessages.classList.add("show-mod-icons");
+            } else {
+                chatMessages.classList.remove("show-mod-icons");
+            }
+            this.maybeScrollToBottom(chatMessages);
+        });
 
         this.handleEvent("remove_timed_out_user_messages", (e) => {
             let offendingUserID = e["bad_user_id"];

--- a/lib/glimesh/accounts/user_preference.ex
+++ b/lib/glimesh/accounts/user_preference.ex
@@ -11,6 +11,7 @@ defmodule Glimesh.Accounts.UserPreference do
     field :locale, :string, default: "en"
     field :site_theme, :string, default: "dark"
     field :show_timestamps, :boolean, default: false
+    field :show_mod_icons, :boolean, default: true
     field :show_mature_content, :boolean
 
     timestamps()
@@ -25,7 +26,8 @@ defmodule Glimesh.Accounts.UserPreference do
       :locale,
       :site_theme,
       :show_timestamps,
-      :show_mature_content
+      :show_mature_content,
+      :show_mod_icons
     ])
     |> unique_constraint(:user_id)
   end

--- a/lib/glimesh_web/live/chat_live/index.ex
+++ b/lib/glimesh_web/live/chat_live/index.ex
@@ -24,7 +24,8 @@ defmodule GlimeshWeb.ChatLive.Index do
           Accounts.get_user_preference!(session["user"])
         else
           %{
-            show_timestamps: false
+            show_timestamps: false,
+            show_mod_icons: false
           }
         end
 
@@ -56,6 +57,7 @@ defmodule GlimeshWeb.ChatLive.Index do
         |> assign(:chat_messages, list_chat_messages(channel))
         |> assign(:chat_message, %ChatMessage{})
         |> assign(:show_timestamps, user_preferences.show_timestamps)
+        |> assign(:show_mod_icons, user_preferences.show_mod_icons)
         |> assign(:user_preferences, user_preferences)
 
       {:ok, new_socket, temporary_assigns: [chat_messages: []]}
@@ -137,6 +139,24 @@ defmodule GlimeshWeb.ChatLive.Index do
      |> assign(:user_preferences, user_preferences)
      |> push_event("toggle_timestamps", %{
        show_timestamps: timestamp_state
+     })}
+  end
+
+  @impl true
+  def handle_event("toggle_mod_icons", %{"user" => _username}, socket) do
+    mod_icon_state = Kernel.not(socket.assigns.show_mod_icons)
+
+    {:ok, user_preferences} =
+      Accounts.update_user_preference(socket.assigns.user_preferences, %{
+        show_mod_icons: mod_icon_state
+      })
+
+    {:noreply,
+     socket
+     |> assign(:show_mod_icons, mod_icon_state)
+     |> assign(:user_preferences, user_preferences)
+     |> push_event("toggle_mod_icons", %{
+       show_mod_icons: mod_icon_state
      })}
   end
 

--- a/lib/glimesh_web/live/chat_live/index.html.leex
+++ b/lib/glimesh_web/live/chat_live/index.html.leex
@@ -1,4 +1,4 @@
-<div id="chat-messages" class="chat-messages <%= if @show_timestamps, do: "show-timestamps" %>" phx-update="<%= @update_action %>" style="<%= background_style(@channel) %>">
+<div id="chat-messages" class="chat-messages <%= if @show_mod_icons, do: "show-mod-icons" %> <%= if @show_timestamps, do: "show-timestamps" %>" phx-update="<%= @update_action %>" style="<%= background_style(@channel) %>">
     <div id="channel-header" class="channel-header">
         <span><%= gettext("Welcome to chat! Follow the rules.") %></span>
     </div>
@@ -8,22 +8,22 @@
         <%= if chat_message.is_followed_message, do: "border border-info" %>">
         <div class="user-message-header d-inline d-md-block">
             <%= if Map.get(@permissions, :can_delete, false)  do %>
-            <i class="delete-message fas fa-trash fa-fw" phx-click="delete_message" phx-value-user="<%= chat_message.user.username %>" phx-value-message="<%= chat_message.id %>" data-toggle="tooltip" title="<%= gettext("Delete message.") %>"></i>
+            <i class="delete-message fas fa-trash fa-fw chat-mod-icon" phx-click="delete_message" phx-value-user="<%= chat_message.user.username %>" phx-value-message="<%= chat_message.id %>" data-toggle="tooltip" title="<%= gettext("Delete message.") %>"></i>
             <% end %>
             <%= if Map.get(@permissions, :can_short_timeout, false) do %>
-            <i class="short-timeout fas fa-stopwatch fa-fw" phx-click="short_timeout_user" phx-value-user="<%= chat_message.user.username %>" data-toggle="tooltip" title="<%= gettext("Timeout user for 5 minutes.") %>"></i>
+            <i class="short-timeout fas fa-stopwatch fa-fw chat-mod-icon" phx-click="short_timeout_user" phx-value-user="<%= chat_message.user.username %>" data-toggle="tooltip" title="<%= gettext("Timeout user for 5 minutes.") %>"></i>
             <% end %>
             <%= if Map.get(@permissions, :can_long_timeout, false)  do %>
-            <i class="long-timeout fas fa-clock fa-fw" phx-click="long_timeout_user" phx-value-user="<%= chat_message.user.username %>" data-toggle="tooltip" title="<%= gettext("Timeout user for 15 minutes.") %>"></i>
+            <i class="long-timeout fas fa-clock fa-fw chat-mod-icon" phx-click="long_timeout_user" phx-value-user="<%= chat_message.user.username %>" data-toggle="tooltip" title="<%= gettext("Timeout user for 15 minutes.") %>"></i>
             <% end %>
             <%= if Map.get(@permissions, :can_ban, false)  do %>
-            <i class="ban fas fa-gavel fa-fw" phx-click="ban_user" phx-value-user="<%= chat_message.user.username %>" data-confirm="<%= gettext("Are you sure you wish to permanently ban %{username}?", username: chat_message.user.displayname) %>" data-toggle="tooltip" title="<%= gettext("Ban user from channel.") %>"></i>
+            <i class="ban fas fa-gavel fa-fw chat-mod-icon" phx-click="ban_user" phx-value-user="<%= chat_message.user.username %>" data-confirm="<%= gettext("Are you sure you wish to permanently ban %{username}?", username: chat_message.user.displayname) %>" data-toggle="tooltip" title="<%= gettext("Ban user from channel.") %>"></i>
             <% end %>
             <%= unless chat_message.is_followed_message or chat_message.is_subscription_message do %>
-                <%= Glimesh.Chat.Effects.render_global_badge(chat_message.user) %>
-                <%= Glimesh.Chat.Effects.render_channel_badge(@channel, chat_message.user) %>
+            <%= Glimesh.Chat.Effects.render_global_badge(chat_message.user) %>
+            <%= Glimesh.Chat.Effects.render_channel_badge(@channel, chat_message.user) %>
 
-                <%= Glimesh.Chat.Effects.render_username_and_avatar(chat_message.user) %><span class="d-inline d-md-none">:</span>
+            <%= Glimesh.Chat.Effects.render_username_and_avatar(chat_message.user) %><span class="d-inline d-md-none">:</span>
             <% end %>
             <small id="small-<%= chat_message.id %>" class="text-muted chat-timestamp">
                 <local-time id="timestamp-<%= chat_message.id %>" phx-update="ignore" datetime="<%= "#{chat_message.inserted_at}" <> "Z" %>" format="micro" hour="numeric" minute="2-digit" second="2-digit"><%= NaiveDateTime.to_time(chat_message.inserted_at) %>
@@ -45,6 +45,7 @@
             channel: @channel,
             user: @user,
             theme: @theme,
-            show_timestamps: @show_timestamps
+            show_timestamps: @show_timestamps,
+            show_mod_icons: @show_mod_icons
         %>
 </div>

--- a/lib/glimesh_web/live/chat_live/message_form.html.leex
+++ b/lib/glimesh_web/live/chat_live/message_form.html.leex
@@ -34,8 +34,10 @@
                 <a class="dropdown-item" href="#" onclick="window.open('<%= Routes.chat_pop_out_url(@socket, :index, @channel_username) %>', '_blank', 'width=400,height=600,location=no,menubar=no,toolbar=no')"><%= gettext("Pop-out Chat") %></a>
                 <a id="toggle-timestamps" class="dropdown-item" , href="#" phx-click="toggle_timestamps" <%= if @user, do: 'phx-value-user=#{@user.username}' %>><%= if @show_timestamps, do: gettext("Hide Timestamps"), else: gettext("Show Timestamps") %>
                 </a>
-                <a id="toggle-mod-icons" class="dropdown-item" , href="#" phx-click="toggle_mod_icons" <%= if @user, do: 'phx-value-user=#{@user.username}' %>><%= if @show_mod_icons, do: gettext("Hide Mod Icons"), else: gettext("Show Mod Icons") %>
+                <%= if @user do %>
+                <a id="toggle-mod-icons" class="dropdown-item" , href="#" phx-click="toggle_mod_icons" phx-value-user=#{@user.username}'><%= if @show_mod_icons, do: gettext("Hide Mod Icons"), else: gettext("Show Mod Icons") %>
                 </a>
+                <% end %>
             </div>
         </div>
 

--- a/lib/glimesh_web/live/chat_live/message_form.html.leex
+++ b/lib/glimesh_web/live/chat_live/message_form.html.leex
@@ -32,7 +32,9 @@
             <button type="button" class="input-group-text dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><i class="fas fa-cog"></i></button>
             <div class="dropdown-menu dropdown-menu-right">
                 <a class="dropdown-item" href="#" onclick="window.open('<%= Routes.chat_pop_out_url(@socket, :index, @channel_username) %>', '_blank', 'width=400,height=600,location=no,menubar=no,toolbar=no')"><%= gettext("Pop-out Chat") %></a>
-                <a id="toggle-timestamps" class="dropdown-item" , href="#" phx-click="toggle_timestamps" <%= if @user, do: 'phx-value-user=#{@user.username}' %>><%= if @show_timestamps, do: gettext("Disable Timestamps"), else: gettext("Enable Timestamps") %>
+                <a id="toggle-timestamps" class="dropdown-item" , href="#" phx-click="toggle_timestamps" <%= if @user, do: 'phx-value-user=#{@user.username}' %>><%= if @show_timestamps, do: gettext("Hide Timestamps"), else: gettext("Show Timestamps") %>
+                </a>
+                <a id="toggle-mod-icons" class="dropdown-item" , href="#" phx-click="toggle_mod_icons" <%= if @user, do: 'phx-value-user=#{@user.username}' %>><%= if @show_mod_icons, do: gettext("Hide Mod Icons"), else: gettext("Show Mod Icons") %>
                 </a>
             </div>
         </div>

--- a/lib/glimesh_web/templates/user_settings/preference.html.eex
+++ b/lib/glimesh_web/templates/user_settings/preference.html.eex
@@ -22,13 +22,11 @@
                 <%= label f, gettext("Mature Content Visibility:") %>
                 <div class="custom-control custom-switch">
                     <%= checkbox f, :show_mature_content, class: "custom-control-input" %>
-                    <label class="custom-control-label"
-                        for="<%= input_id(f, :show_mature_content) %>"><%= gettext("Bypass Mature Content Warning") %></label>
+                    <label class="custom-control-label" for="<%= input_id(f, :show_mature_content) %>"><%= gettext("Bypass Mature Content Warning") %></label>
                 </div>
                 <%= error_tag f, :show_mature_content %>
 
-                <small
-                    class="form-text text-muted"><%= gettext("Automatically bypass our Mature Content warning by enabling this preference.") %></small>
+                <small class="form-text text-muted"><%= gettext("Automatically bypass our Mature Content warning by enabling this preference.") %></small>
             </div>
 
 
@@ -39,18 +37,15 @@
                 <br>
                 <div class="custom-control custom-radio custom-control-inline">
                     <%= radio_button f, :site_theme, "dark", [checked: input_value(f, :site_theme) == "dark", class: "custom-control-input"] %>
-                    <label class="custom-control-label"
-                        for="<%= input_id(f, :site_theme, "dark") %>"><%= gettext("Dark") %></label>
+                    <label class="custom-control-label" for="<%= input_id(f, :site_theme, "dark") %>"><%= gettext("Dark") %></label>
                 </div>
                 <div class="custom-control custom-radio custom-control-inline">
                     <%= radio_button f, :site_theme, "light", [checked: input_value(f, :site_theme) == "light", class: "custom-control-input"] %>
-                    <label class="custom-control-label"
-                        for="<%= input_id(f, :site_theme, "light") %>"><%= gettext("Light") %></label>
+                    <label class="custom-control-label" for="<%= input_id(f, :site_theme, "light") %>"><%= gettext("Light") %></label>
                 </div>
                 <%= error_tag f, :site_theme %>
 
-                <small
-                    class="form-text text-muted"><%= gettext("Change your Glimesh experience to feel a little lighter, or a little darker.") %></small>
+                <small class="form-text text-muted"><%= gettext("Change your Glimesh experience to feel a little lighter, or a little darker.") %></small>
             </div>
 
             <div class="form-group">
@@ -59,8 +54,16 @@
                     <%= checkbox f, :show_timestamps, class: "custom-control-input" %>
                     <%= label f, :show_timestamps, gettext("Show Chat Timestamps"), class: "custom-control-label" %>
                 </div>
-                <small
-                    class="form-text text-muted"><%= gettext("Show the time a message was posted in chat.") %></small>
+                <small class="form-text text-muted"><%= gettext("Show the time a message was posted in chat.") %></small>
+            </div>
+
+            <div class="form-group">
+                <%= label f, gettext("Mod Icons Visibility:") %>
+                <div class="custom-control custom-switch">
+                    <%= checkbox f, :show_mod_icons, class: "custom-control-input" %>
+                    <%= label f, :show_mod_icons, gettext("Show Action Mod Icons"), class: "custom-control-label" %>
+                </div>
+                <small class="form-text text-muted"><%= gettext("Shows the timeout / ban / etc icons on a chat message.") %></small>
             </div>
 
             <%= submit gettext("Update Settings"), class: "btn btn-primary mt-4" %>

--- a/priv/repo/migrations/20210410140532_add_show_mod_icons.exs
+++ b/priv/repo/migrations/20210410140532_add_show_mod_icons.exs
@@ -1,0 +1,9 @@
+defmodule Glimesh.Repo.Migrations.AddShowModIcons do
+  use Ecto.Migration
+
+  def change do
+    alter table(:user_preferences) do
+      add :show_mod_icons, :boolean, default: true
+    end
+  end
+end

--- a/test/glimesh/chat_test.exs
+++ b/test/glimesh/chat_test.exs
@@ -354,6 +354,17 @@ defmodule Glimesh.ChatTest do
 
       assert user_preferences.show_timestamps == true
     end
+
+    test "toggle mod icons button toggles mod icons" do
+      user = user_fixture()
+      user_preferences = Accounts.get_user_preference!(user)
+      assert user_preferences.show_mod_icons == true
+
+      {:ok, user_preferences} =
+        Accounts.update_user_preference(user_preferences, %{show_mod_icons: false})
+
+      assert user_preferences.show_mod_icons == false
+    end
   end
 
   describe "chat safety & security" do

--- a/test/glimesh_web/live/chat_live_test.exs
+++ b/test/glimesh_web/live/chat_live_test.exs
@@ -212,13 +212,31 @@ defmodule GlimeshWeb.ChatLiveTest do
           session: %{"user" => user, "channel_id" => channel.id}
         )
 
-      assert render(view) =~ "Enable Timestamps"
+      assert render(view) =~ "Show Timestamps"
 
       view
       |> element("#toggle-timestamps")
       |> render_click()
 
-      assert render(view) =~ "Disable Timestamps"
+      assert render(view) =~ "Hide Timestamps"
+    end
+
+    test "toggle mod icons button toggles mod icons", %{conn: conn} do
+      user = streamer_fixture()
+      channel = ChannelLookups.get_channel_for_user(user)
+
+      {:ok, view, _html} =
+        live_isolated(conn, GlimeshWeb.ChatLive.Index,
+          session: %{"user" => user, "channel_id" => channel.id}
+        )
+
+      assert render(view) =~ "Hide Mod Icons"
+
+      view
+      |> element("#toggle-mod-icons")
+      |> render_click()
+
+      assert render(view) =~ "Show Mod Icons"
     end
   end
 end


### PR DESCRIPTION
Now that we have ever so many mod icons, and timestamps, I feel like my interface is so cluttered!

This adds the ability to hide mod icons. I'm sure our GCT will find this useful as well.

![image](https://user-images.githubusercontent.com/226638/114273563-87847780-99e8-11eb-8e7e-018a861fd732.png)
