### PR TITLE
Create blog migration utils to move us to Hugo

### DIFF
--- a/lib/glimesh/blog_migration.ex
+++ b/lib/glimesh/blog_migration.ex
@@ -1,0 +1,77 @@
+defmodule Glimesh.BlogMigration do
+  @moduledoc """
+  Utility functions to help us migrate to a Hugo hosted blog.
+  """
+
+  require Logger
+
+  def should_redirect(slug) do
+    slug in get_historical_posts()
+  end
+
+  def list_recent_posts do
+    Glimesh.QueryCache.get_and_store!("Glimesh.BlogMigration.list_recent_posts()", fn ->
+      case get_recent_posts(5) do
+        {:ok, posts} ->
+          {:ok, posts}
+
+        {:error, message} ->
+          Logger.error("Error grabbing latest blog posts: #{message}")
+          {:ok, []}
+      end
+    end)
+  end
+
+  defp get_historical_posts do
+    [
+      "2020-08-11-staff-meeting",
+      "2020-08-13-glimesh-alpha-roadmap",
+      "2020-08-18-staff-meeting",
+      "2020-08-26-august-feature-update",
+      "2020-09-15-staff-meeting",
+      "2020-11-14-security-incident-oauth-key-exposure",
+      "2020-12-16-december-roadmap-and-feature-update",
+      "2021-01-29-the-glimcap-part-one",
+      "2021-02-02-the-glimcap-week-two",
+      "2021-02-11-the-glimcap-week-three",
+      "2021-02-18-the-glimcap-week-four",
+      "2021-02-23-the-glimcap-week-five",
+      "2021-03-09-the-glimcap-week-six",
+      "2021-03-16-the-glimcap-week-seven",
+      "2021-03-23-the-glimcap-week-eight",
+      "2021-03-30-the-glimcap-week-nine",
+      "2021-04-06-the-glimcap-week-ten"
+    ]
+  end
+
+  defp get_recent_posts(limit) do
+    case HTTPoison.get("https://blog.glimesh.tv/index.xml") do
+      {:ok, %HTTPoison.Response{status_code: 200, body: body}} ->
+        {doc, []} = body |> :erlang.binary_to_list() |> :xmerl_scan.string()
+
+        titles =
+          :xmerl_xpath.string('/rss/channel/item/title/text()', doc)
+          |> Enum.map(&parse_xml_text/1)
+
+        urls =
+          :xmerl_xpath.string('/rss/channel/item/link/text()', doc)
+          |> Enum.map(&parse_xml_text/1)
+
+        {:ok, Enum.zip(titles, urls) |> Enum.slice(0, limit)}
+
+      {:ok, %HTTPoison.Response{status_code: 404}} ->
+        {:error, "Unexpected response from API."}
+
+      _ ->
+        {:error, "Unexpected response from API."}
+    end
+  end
+
+  defp parse_xml_text({:xmlText, _, _, _, text, :text}) do
+    text
+  end
+
+  defp parse_xml_text(_) do
+    raise "Unknown input."
+  end
+end

--- a/lib/glimesh_web/controllers/blog_migration_controller.ex
+++ b/lib/glimesh_web/controllers/blog_migration_controller.ex
@@ -1,0 +1,16 @@
+defmodule GlimeshWeb.BlogMigrationController do
+  use GlimeshWeb, :controller
+
+  def redirect_blog(conn, _params) do
+    conn |> redirect(external: "https://blog.glimesh.tv/")
+  end
+
+  # General Routes
+  def redirect_post(conn, %{"slug" => slug}) do
+    if Glimesh.BlogMigration.should_redirect(slug) do
+      conn |> redirect(external: "https://blog.glimesh.tv/posts/#{slug}")
+    else
+      conn |> redirect(to: "/")
+    end
+  end
+end

--- a/lib/glimesh_web/router.ex
+++ b/lib/glimesh_web/router.ex
@@ -213,8 +213,8 @@ defmodule GlimeshWeb.Router do
     live "/about/open-data/subscriptions", About.OpenDataLive, :subscriptions
     live "/about/open-data/streams", About.OpenDataLive, :streams
 
-    get "/blog", ArticleController, :index
-    get "/blog/:slug", ArticleController, :show
+    get "/blog", BlogMigrationController, :redirect_blog
+    get "/blog/:slug", BlogMigrationController, :redirect_post
 
     live "/", HomepageLive, :index
     live "/streams", StreamsLive.Index, :index

--- a/lib/glimesh_web/templates/layout/_navbar.html.leex
+++ b/lib/glimesh_web/templates/layout/_navbar.html.leex
@@ -46,7 +46,7 @@
                     <i class="fas fa-user fa-fw"></i>
                     <%= gettext("User List") %>
                     <% end %>
-                    <%= link class: "dropdown-item", to: Routes.article_path(@conn, :index) do %>
+                    <%= link class: "dropdown-item", to: "https://blog.glimesh.tv/" do %>
                     <i class="fas fa-newspaper fa-fw"></i>
                     <%= gettext("Blog") %>
                     <% end %>

--- a/lib/glimesh_web/templates/layout/root.html.leex
+++ b/lib/glimesh_web/templates/layout/root.html.leex
@@ -102,9 +102,8 @@
                     <div class="col-8">
                         <h6><%= gettext("BLOG") %></h6>
                         <ul class="list-unstyled text-small">
-                            <%= for article <- Glimesh.Blog.list_some_articles(4) do %>
-                            <li><%= link article.title, to: Routes.article_path(@conn, :show, article.slug) %>
-                            </li>
+                            <%= for {title, url} <- Glimesh.BlogMigration.list_recent_posts() do %>
+                            <li><%= link title, to: url %></li>
                             <% end %>
                         </ul>
                     </div>

--- a/test/glimesh_web/controllers/article_controller_test.exs
+++ b/test/glimesh_web/controllers/article_controller_test.exs
@@ -1,100 +1,100 @@
 defmodule GlimeshWeb.ArticleControllerTest do
   use GlimeshWeb.ConnCase
 
-  alias Glimesh.Blog
-  import Glimesh.AccountsFixtures
+  # Commenting out for now
+  # alias Glimesh.Blog
+  # import Glimesh.AccountsFixtures
+  # @create_attrs %{
+  #   body_md: "some body_md",
+  #   description: "some description",
+  #   published: true,
+  #   slug: "some-slug",
+  #   title: "some title"
+  # }
+  # @update_attrs %{
+  #   body_md: "some updated body_md",
+  #   description: "some updated description",
+  #   published: false,
+  #   slug: "some-updated-slug",
+  #   title: "some updated title"
+  # }
+  # @invalid_attrs %{
+  #   body_html: nil,
+  #   body_md: nil,
+  #   description: nil,
+  #   published: nil,
+  #   slug: nil,
+  #   title: nil
+  # }
 
-  @create_attrs %{
-    body_md: "some body_md",
-    description: "some description",
-    published: true,
-    slug: "some-slug",
-    title: "some title"
-  }
-  @update_attrs %{
-    body_md: "some updated body_md",
-    description: "some updated description",
-    published: false,
-    slug: "some-updated-slug",
-    title: "some updated title"
-  }
-  @invalid_attrs %{
-    body_html: nil,
-    body_md: nil,
-    description: nil,
-    published: nil,
-    slug: nil,
-    title: nil
-  }
+  # def fixture(:article) do
+  #   {:ok, article} = Blog.create_article(admin_fixture(), @create_attrs)
+  #   article
+  # end
 
-  def fixture(:article) do
-    {:ok, article} = Blog.create_article(admin_fixture(), @create_attrs)
-    article
-  end
+  # describe "index" do
+  #   test "lists all articles", %{conn: conn} do
+  #     conn = get(conn, Routes.article_path(conn, :index))
+  #     assert html_response(conn, 200) =~ "Glimesh Blog"
+  #   end
+  # end
 
-  describe "index" do
-    test "lists all articles", %{conn: conn} do
-      conn = get(conn, Routes.article_path(conn, :index))
-      assert html_response(conn, 200) =~ "Glimesh Blog"
-    end
-  end
+  # describe "new article" do
+  #   setup :register_and_log_in_admin_user
 
-  describe "new article" do
-    setup :register_and_log_in_admin_user
+  #   test "renders form", %{conn: conn} do
+  #     conn = get(conn, Routes.article_path(conn, :new))
+  #     assert html_response(conn, 200) =~ "New Article"
+  #   end
+  # end
 
-    test "renders form", %{conn: conn} do
-      conn = get(conn, Routes.article_path(conn, :new))
-      assert html_response(conn, 200) =~ "New Article"
-    end
-  end
+  # describe "create article" do
+  #   setup :register_and_log_in_admin_user
 
-  describe "create article" do
-    setup :register_and_log_in_admin_user
+  #   test "redirects to show when data is valid", %{conn: conn} do
+  #     conn = post(conn, Routes.article_path(conn, :create), article: @create_attrs)
 
-    test "redirects to show when data is valid", %{conn: conn} do
-      conn = post(conn, Routes.article_path(conn, :create), article: @create_attrs)
+  #     assert %{slug: slug} = redirected_params(conn)
+  #     assert redirected_to(conn) == Routes.article_path(conn, :show, slug)
 
-      assert %{slug: slug} = redirected_params(conn)
-      assert redirected_to(conn) == Routes.article_path(conn, :show, slug)
+  #     conn = get(conn, Routes.article_path(conn, :show, slug))
+  #     assert html_response(conn, 200) =~ "some title"
+  #   end
 
-      conn = get(conn, Routes.article_path(conn, :show, slug))
-      assert html_response(conn, 200) =~ "some title"
-    end
+  #   test "renders errors when data is invalid", %{conn: conn} do
+  #     conn = post(conn, Routes.article_path(conn, :create), article: @invalid_attrs)
+  #     assert html_response(conn, 200) =~ "New Article"
+  #   end
+  # end
 
-    test "renders errors when data is invalid", %{conn: conn} do
-      conn = post(conn, Routes.article_path(conn, :create), article: @invalid_attrs)
-      assert html_response(conn, 200) =~ "New Article"
-    end
-  end
+  # describe "edit article" do
+  #   setup [:register_and_log_in_admin_user, :create_article]
 
-  describe "edit article" do
-    setup [:register_and_log_in_admin_user, :create_article]
+  #   test "renders form for editing chosen article", %{conn: conn, article: article} do
+  #     conn = get(conn, Routes.article_path(conn, :edit, article.slug))
+  #     assert html_response(conn, 200) =~ "Edit Article"
+  #   end
+  # end
 
-    test "renders form for editing chosen article", %{conn: conn, article: article} do
-      conn = get(conn, Routes.article_path(conn, :edit, article.slug))
-      assert html_response(conn, 200) =~ "Edit Article"
-    end
-  end
+  # describe "update article" do
+  #   setup [:register_and_log_in_admin_user, :create_article]
 
-  describe "update article" do
-    setup [:register_and_log_in_admin_user, :create_article]
+  #   test "redirects when data is valid", %{conn: conn, article: article} do
+  #     conn = put(conn, Routes.article_path(conn, :update, article.slug), article: @update_attrs)
+  #     assert redirected_to(conn) == Routes.article_path(conn, :show, @update_attrs.slug)
 
-    test "redirects when data is valid", %{conn: conn, article: article} do
-      conn = put(conn, Routes.article_path(conn, :update, article.slug), article: @update_attrs)
-      assert redirected_to(conn) == Routes.article_path(conn, :show, @update_attrs.slug)
+  #     conn = get(conn, Routes.article_path(conn, :show, @update_attrs.slug))
+  #     assert html_response(conn, 200) =~ "<p>\nsome updated body_md</p>\n"
+  #   end
 
-      conn = get(conn, Routes.article_path(conn, :show, @update_attrs.slug))
-      assert html_response(conn, 200) =~ "<p>\nsome updated body_md</p>\n"
-    end
+  #   test "renders errors when data is invalid", %{conn: conn, article: article} do
+  #     conn = put(conn, Routes.article_path(conn, :update, article.slug), article: @invalid_attrs)
+  #     assert html_response(conn, 200) =~ "Edit Article"
+  #   end
+  # end
 
-    test "renders errors when data is invalid", %{conn: conn, article: article} do
-      conn = put(conn, Routes.article_path(conn, :update, article.slug), article: @invalid_attrs)
-      assert html_response(conn, 200) =~ "Edit Article"
-    end
-  end
-
-  defp create_article(_) do
-    article = fixture(:article)
-    %{article: article}
-  end
+  # defp create_article(_) do
+  #   article = fixture(:article)
+  #   %{article: article}
+  # end
 end


### PR DESCRIPTION
Hosting our own blog is getting tedious, and it's not our primary business focus. This PR starts the work to move away from our own hosted blog pages to almost the same thing hosted in [Glimesh/blog.glimesh.tv](https://github.com/Glimesh/blog.glimesh.tv) 

You can see the new blog site here: https://blog.glimesh.tv/