### PR TITLE
Edit profile link

### DIFF
--- a/lib/glimesh_web/live/user_live/profile.html.leex
+++ b/lib/glimesh_web/live/user_live/profile.html.leex
@@ -88,6 +88,11 @@
 
             <div class="card">
                 <div class="card-body user-content-body">
+                    <%= if @streamer == @user do %>
+                    <div class="float-right">
+                        <a href="<%= Routes.user_settings_path(@socket, :profile) %>"><i class="fas fa-edit" data-toggle="tooltip" data-placement="top" data-original-title="<%= gettext("Edit Profile") %>"></i></a>
+                    </div>
+                    <% end %>
                     <%= if @youtube_id do %>
                     <div class="embed-responsive embed-responsive-16by9 mb-4">
                         <iframe class="embed-responsive-item" src="https://www.youtube-nocookie.com/embed/<%= @youtube_id %>" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>


### PR DESCRIPTION
Small QoL feature to make it easier and more user friendly to edit their profile.

Adds in a small icon that links to a users profile settings page, see screenshot:
![image](https://user-images.githubusercontent.com/68715225/115062029-c8e1bf00-9ee1-11eb-8323-18ca4b448572.png)

Does not appear on a profile unless it is the logged in users profile.