### PR TITLE
Gettext compilation changes

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -74,7 +74,8 @@ config :glimesh, GlimeshWeb.Emails.Mailer,
 
 config :glimesh, GlimeshWeb.Gettext,
   default_locale: "en",
-  locales: Enum.map(locales, fn {_, x} -> x end)
+  locales: Enum.map(locales, fn {_, x} -> x end),
+  one_module_per_locale: true
 
 config :ex_oauth2_provider, namespace: Glimesh
 

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -85,6 +85,9 @@ config :phoenix, :stacktrace_depth, 20
 # Initialize plugs at runtime for faster development compilation
 config :phoenix, :plug_init_mode, :runtime
 
+# Loads only the English and Spanish locales for development, which speeds up compilation time
+config :glimesh, GlimeshWeb.Gettext, allowed_locales: ["en", "es"]
+
 if File.exists?("config/local.exs") do
   import_config "local.exs"
 end

--- a/config/test.exs
+++ b/config/test.exs
@@ -49,4 +49,5 @@ config :appsignal, :config, active: false
 
 config :glimesh, GlimeshWeb.Gettext,
   default_locale: "glim-en",
-  locales: ~w(glim-en)
+  locales: ~w(glim-en),
+  allowed_locales: ["en"]


### PR DESCRIPTION
Sets 2 values in the config files:

For `config.exs` we now set `one_module_per_locale` to true, which helps with compilation times.
For `dev.exs` we set `allowed_locales` to `["en", "es"]` which limits the development versions to only compile the English and Spanish locale files, greatly speeding it up. 
For `test.exs` we do the same as above but only for English since we use a "custom" locale for testing.
