### PR TITLE
Formatting the password reset form from email

### DIFF
--- a/lib/glimesh_web/templates/user_reset_password/edit.html.eex
+++ b/lib/glimesh_web/templates/user_reset_password/edit.html.eex
@@ -1,26 +1,32 @@
-<h1><%= gettext("Reset password") %></h1>
+<div class="container mt-4">
+  <div class="row align-items-center justify-content-md-center">
+    <div class="col-md-7 col-lg-5">
 
-<%= form_for @changeset, Routes.user_reset_password_path(@conn, :update, @token), fn f -> %>
-  <%= if @changeset.action do %>
-    <div class="alert alert-danger">
-      <p><%= gettext("Oops, something went wrong! Please check the errors below.") %></p>
+      <div class="card">
+        <div class="card-body">
+        <h3><%= gettext("Reset password") %></h1>
+
+        <%= form_for @changeset, Routes.user_reset_password_path(@conn, :update, @token), fn f -> %>
+          <%= if @changeset.action do %>
+            <div class="alert alert-danger">
+              <p><%= gettext("Oops, something went wrong! Please check the errors below.") %></p>
+            </div>
+          <% end %>
+
+          <%= label f, :password, gettext("New password") %>
+          <%= password_input f, :password, required: true, class: "form-control" %>
+          <%= error_tag f, :password %>
+
+          <%= label f, :password_confirmation, gettext("Confirm new password") %>
+          <%= password_input f, :password_confirmation, required: true, class: "form-control" %>
+          <%= error_tag f, :password_confirmation %>
+
+          <div>
+            <%= submit gettext("Reset password"), class: "btn btn-primary btn-block mt-2" %>
+          </div>
+        <% end %>
+        </div>
+      </div>
     </div>
-  <% end %>
-
-  <%= label f, :password, gettext("New password") %>
-  <%= password_input f, :password, required: true %>
-  <%= error_tag f, :password %>
-
-  <%= label f, :password_confirmation, gettext("Confirm new password") %>
-  <%= password_input f, :password_confirmation, required: true %>
-  <%= error_tag f, :password_confirmation %>
-
-  <div>
-    <%= submit gettext("Reset password") %>
   </div>
-<% end %>
-
-<p>
-  <%= link gettext("Register"), to: Routes.user_registration_path(@conn, :new) %> |
-  <%= link gettext("Sign in"), to: Routes.user_session_path(@conn, :new) %>
-</p>
+</div>

--- a/lib/glimesh_web/templates/user_reset_password/edit.html.eex
+++ b/lib/glimesh_web/templates/user_reset_password/edit.html.eex
@@ -17,7 +17,7 @@
           <%= password_input f, :password, required: true, class: "form-control" %>
           <%= error_tag f, :password %>
 
-          <%= label f, :password_confirmation, gettext("Confirm new password") %>
+          <%= label f, :password_confirmation, gettext("Confirm new password"), class: "mt-2" %>
           <%= password_input f, :password_confirmation, required: true, class: "form-control" %>
           <%= error_tag f, :password_confirmation %>
 

--- a/lib/glimesh_web/templates/user_reset_password/edit.html.eex
+++ b/lib/glimesh_web/templates/user_reset_password/edit.html.eex
@@ -4,7 +4,7 @@
 
       <div class="card">
         <div class="card-body">
-        <h3><%= gettext("Reset password") %></h1>
+        <h3><%= gettext("Reset password") %></h3>
 
         <%= form_for @changeset, Routes.user_reset_password_path(@conn, :update, @token), fn f -> %>
           <%= if @changeset.action do %>

--- a/test/glimesh_web/controllers/user_reset_password_controller_test.exs
+++ b/test/glimesh_web/controllers/user_reset_password_controller_test.exs
@@ -60,7 +60,7 @@ defmodule GlimeshWeb.UserResetPasswordControllerTest do
 
     test "renders reset password", %{conn: conn, token: token} do
       conn = get(conn, Routes.user_reset_password_path(conn, :edit, token))
-      assert html_response(conn, 200) =~ "<h1>Reset password</h1>"
+      assert html_response(conn, 200) =~ "<h3>Reset password</h3>"
     end
 
     test "does not render reset password with invalid token", %{conn: conn} do
@@ -105,7 +105,7 @@ defmodule GlimeshWeb.UserResetPasswordControllerTest do
         })
 
       response = html_response(conn, 200)
-      assert response =~ "<h1>Reset password</h1>"
+      assert response =~ "<h3>Reset password</h3>"
       assert response =~ "should be at least 8 character(s)"
       assert response =~ "Password does not match"
     end


### PR DESCRIPTION
Fixes the password reset form that comes from the password reset email. Before it didn't have any proper formatting or classes. Now it follows the design of the rest of the website. 

![image](https://user-images.githubusercontent.com/11252574/115072274-5bc03080-9ec5-11eb-9dd5-8c40bd391410.png)
