### PR TITLE
Adds plug for opting out of Google FLoC

### DIFF
--- a/lib/glimesh_web/plugs/floc_plug.ex
+++ b/lib/glimesh_web/plugs/floc_plug.ex
@@ -1,0 +1,11 @@
+defmodule GlimeshWeb.Plugs.Floc do
+  @moduledoc """
+  Pluggable header to opt out of Google FLoC
+  """
+
+  def init(_opts), do: nil
+
+  def call(conn, _opts \\ []) do
+    Plug.Conn.put_resp_header(conn, "permissions-policy", "interest-cohort=()")
+  end
+end

--- a/lib/glimesh_web/router.ex
+++ b/lib/glimesh_web/router.ex
@@ -11,6 +11,7 @@ defmodule GlimeshWeb.Router do
     plug :protect_from_forgery
     plug :put_secure_browser_headers
     plug :fetch_current_user
+    plug GlimeshWeb.Plugs.Floc
     plug GlimeshWeb.Plugs.Locale
     plug GlimeshWeb.Plugs.CfCountryPlug
     plug GlimeshWeb.Plugs.Ban

--- a/test/glimesh_web/plugs/floc_plug_test.exs
+++ b/test/glimesh_web/plugs/floc_plug_test.exs
@@ -1,0 +1,10 @@
+defmodule GlimeshWeb.Plugs.FlocTest do
+  use GlimeshWeb.ConnCase
+  use ExUnit.Case
+
+  test "adds a permission policy header to its conn", %{conn: conn} do
+    assert conn
+           |> GlimeshWeb.Plugs.Floc.call()
+           |> Plug.Conn.get_resp_header("permissions-policy") == ["interest-cohort=()"]
+  end
+end


### PR DESCRIPTION
I have not provided a location for the plug, but this can be added by pipe-lining it into `:browser` or on any controllers directly. 
If there is a preference, I'd be glad to add it in this PR

By using a plug, this header can be provided to resources that require it, and avoid adding it to API's where should not be needed. 

This can also be done by Ops, but as a feature it becomes a little less clear.

closes #621 