### PR TITLE
Feature/improve docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ These instructions serve as a reference for getting Glimesh running whatever typ
 
 ### General Dependencies
 
-You will need the following tools to clone, build, and run Glimesh: 
+You will need the following tools to clone, build, and run Glimesh:
 
 - **git**: Source control
 - **erlang**: Runtime
@@ -107,7 +107,7 @@ Enter it again:
 
 ### macOS Installation
 
-Installation is simple with [Homebrew](https://brew.sh). 
+Installation is simple with [Homebrew](https://brew.sh).
 
 ```sh
 # Required dependencies
@@ -184,11 +184,19 @@ Glimesh.tv can also be set up for **development use only** using [docker-compose
 
 To do so, run the following commands from the GitHub repository:
 
-1. `touch .env`
-2. `docker-compose -f docker-compose.yml -f docker-compose.dev.yml up`
+`docker-compose up`
+
+Then you can visit the site at: `http://localhost:4000`
+
+To run tests you can start a docker instance and run tests on them by doing the following
+
+```bash
+docker-compose run app bash
+app> mix test
+```
 
 ### Customizing your local environment
-You can create a `config/local.exs` config file to change any local settings to make development 
+You can create a `config/local.exs` config file to change any local settings to make development
 easier. This file is ignored from git, so you don't have to worry about committing any secrets.
 
 ```elixir
@@ -214,11 +222,11 @@ Most of the core code behind the project is located is clear directories, groupe
 | config                              |          |  ✅      | Configuration for local, testing, and production releases                                                                              |
 
 ### Modifying Code
-All code inside any known directory is automatically watched for changes and triggers the appropriate build. Some frontend code and live views will automatically refresh your browser, but for more complex domain logic you may be required to refresh your browser. 
+All code inside any known directory is automatically watched for changes and triggers the appropriate build. Some frontend code and live views will automatically refresh your browser, but for more complex domain logic you may be required to refresh your browser.
 
 ### Running Static Code Analysis
 Before submitting a pull request, be sure to run [Credo](https://github.com/rrrene/credo) which will run a static code analysis over the entire project.
-```sh 
+```sh
 mix code_quality
 ```
 
@@ -231,7 +239,7 @@ mix code_quality
 
 
 ## Testing
-Glimesh includes a comprehensive and very fast test suite, so you should be encouraged to run tests as frequently as possible. 
+Glimesh includes a comprehensive and very fast test suite, so you should be encouraged to run tests as frequently as possible.
 
 ```sh
 mix test

--- a/config/test.exs
+++ b/config/test.exs
@@ -12,7 +12,7 @@ config :glimesh, Glimesh.Repo,
   username: "postgres",
   password: "postgres",
   database: "glimesh_test#{System.get_env("MIX_TEST_PARTITION")}",
-  hostname: "localhost",
+  hostname: System.get_env("DATABASE_URL", "localhost"),
   pool: Ecto.Adapters.SQL.Sandbox
 
 # We don't run a server during test. If one is required,
@@ -26,9 +26,9 @@ config :glimesh, GlimeshWeb.Emails.Mailer, adapter: Bamboo.TestAdapter
 # Print only warnings and errors during test
 config :logger, level: :warn
 
-# Use a mock server for Stripe
-# https://github.com/stripe/stripe-mock
-config :stripity_stripe, :api_base_url, "http://localhost:12111/v1/"
+config :stripity_stripe,
+  api_key: "sk_test_thisisaboguskey",
+  api_base_url: System.get_env("STRIPE_MOCK_URL", "http://localhost:12111/v1/")
 
 config :hcaptcha,
   http_client: Hcaptcha.Http.MockClient,

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,32 @@
+version: '3.4'
+
+services:
+  app:
+    env_file:
+      - .env
+    build:
+      context: .
+      dockerfile: Dockerfile
+    environment:
+      - DATABASE_URL=${DATABASE_URL}
+      - SECRET_KEY_BASE=${SECRET_KEY_BASE}
+      - LIVE_VIEW_SIGNING_SALT=${LIVE_VIEW_SIGNING_SALT}
+      - URL_HOST=${URL_HOST}
+      - URL_PORT=${URL_PORT}
+      - HTTP_PORT=${HTTP_PORT}
+      - HTTPS_PORT=${HTTPS_PORT}
+      - HTTPS_KEY_FILE=${HTTPS_KEY_FILE}
+      - HTTPS_CERT_FILE=${HTTPS_CERT_FILE}
+      - MAILGUN_DOMAIN=${MAILGUN_DOMAIN}
+      - MAILGUN_API_KEY=${MAILGUN_API_KEY}
+      - STRIPE_PUBLIC_API_KEY=${STRIPE_PUBLIC_API_KEY}
+      - STRIPE_API_KEY=${STRIPE_API_KEY}
+      - STRIPE_CONNECT_CLIENT_ID=${STRIPE_CONNECT_CLIENT_ID}
+      - STRIPE_WEBHOOK_SECRET=${STRIPE_WEBHOOK_SECRET}
+    ports:
+      - 80:8080
+      - 443:8443
+      - 4000:4000
+    volumes:
+      - ./certs:/certs
+      - ./uploads:/app/uploads

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.4'
 
 services:
   db:
-    image: postgres:latest
+    image: postgres:12
     ports:
       - "5432:5432"
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,32 +1,26 @@
 version: '3.4'
 
 services:
+  db:
+    image: postgres:latest
+    ports:
+      - "5432:5432"
+    environment:
+      - POSTGRES_DB=postgres
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
   app:
-    env_file:
-      - .env
     build:
       context: .
-      dockerfile: Dockerfile
-    environment:
-      - DATABASE_URL=${DATABASE_URL}
-      - SECRET_KEY_BASE=${SECRET_KEY_BASE}
-      - LIVE_VIEW_SIGNING_SALT=${LIVE_VIEW_SIGNING_SALT}
-      - URL_HOST=${URL_HOST}
-      - URL_PORT=${URL_PORT}
-      - HTTP_PORT=${HTTP_PORT}
-      - HTTPS_PORT=${HTTPS_PORT}
-      - HTTPS_KEY_FILE=${HTTPS_KEY_FILE}
-      - HTTPS_CERT_FILE=${HTTPS_CERT_FILE}
-      - MAILGUN_DOMAIN=${MAILGUN_DOMAIN}
-      - MAILGUN_API_KEY=${MAILGUN_API_KEY}
-      - STRIPE_PUBLIC_API_KEY=${STRIPE_PUBLIC_API_KEY}
-      - STRIPE_API_KEY=${STRIPE_API_KEY}
-      - STRIPE_CONNECT_CLIENT_ID=${STRIPE_CONNECT_CLIENT_ID}
-      - STRIPE_WEBHOOK_SECRET=${STRIPE_WEBHOOK_SECRET}
+      dockerfile: Dockerfile.dev
+    command: ./run.sh
     ports:
-      - 80:8080
-      - 443:8443
-      - 4000:4000
+      - "4001:4001"
+    environment:
+      - DATABASE_URL=db
+    depends_on:
+      - db
     volumes:
-      - ./certs:/certs
-      - ./uploads:/app/uploads
+      - type: bind
+        source: .
+        target: /app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,17 +9,24 @@ services:
       - POSTGRES_DB=postgres
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres
+  stripemock:
+    image: stripemock/stripe-mock
+    ports:
+      - "12111:12111"
   app:
     build:
       context: .
       dockerfile: Dockerfile.dev
     command: ./run.sh
     ports:
+      - "4000:4000"
       - "4001:4001"
     environment:
       - DATABASE_URL=db
+      - STRIPE_MOCK_URL=http://stripemock:12111/v1/
     depends_on:
       - db
+      - stripemock
     volumes:
       - type: bind
         source: .


### PR DESCRIPTION
Outside of accidently purging whitespace from the readme, the following has been added and required testing:

Moved docker-compose.yml to docker-compose.prod.yml 
Updated docker-compose.yml to start all the necessary applications required to test on boot
Updated docker-compose to run the app minimally for local development - this can be exanded in the future to pull up the entire stack.

Required Changes:
- [x] Change development server from using docker-compose.yml to docker-compose.prod.yml

Required Docker-Compose Testing:
- [x] MacOS M1
- [x] WSL on windows
- [x] Windows Native (may work as well)
- [x] Linux Native (arch)

To test:

- Ensure you've brought all your containers and networks down by running `docker-compose down` twice
- Ensure you've created the database (might already exist)
```
docker-compose run app bash
app> mix ecto.create
```

run `docker-compose up` to make sure the server starts and the application is accesible from `localhost:4000` (use `docker-compose up --build` if you've built this container before)

To run tests:

run `docker-compose run app bash` and run `mix test` - there should be a complete passing suite with no errors

References Issue https://github.com/Glimesh/glimesh.tv/issues/632