### PR TITLE
Popped out & mobile chat fixes

### DIFF
--- a/lib/glimesh_web/live/chat_live/index.ex
+++ b/lib/glimesh_web/live/chat_live/index.ex
@@ -59,7 +59,7 @@ defmodule GlimeshWeb.ChatLive.Index do
         |> assign(:show_timestamps, user_preferences.show_timestamps)
         |> assign(:show_mod_icons, user_preferences.show_mod_icons)
         |> assign(:user_preferences, user_preferences)
-        |> assign(:popped_out, session["popped_out"])
+        |> assign(:popped_out, Map.get(session, "popped_out", false))
 
       {:ok, new_socket, temporary_assigns: [chat_messages: []]}
     end)

--- a/lib/glimesh_web/live/chat_live/index.ex
+++ b/lib/glimesh_web/live/chat_live/index.ex
@@ -59,6 +59,7 @@ defmodule GlimeshWeb.ChatLive.Index do
         |> assign(:show_timestamps, user_preferences.show_timestamps)
         |> assign(:show_mod_icons, user_preferences.show_mod_icons)
         |> assign(:user_preferences, user_preferences)
+        |> assign(:popped_out, session["popped_out"])
 
       {:ok, new_socket, temporary_assigns: [chat_messages: []]}
     end)

--- a/lib/glimesh_web/live/chat_live/index.html.leex
+++ b/lib/glimesh_web/live/chat_live/index.html.leex
@@ -6,7 +6,7 @@
     <div id="<%= chat_message.id %>" data-user-id="<%= chat_message.user.id %>" class="<%=if Glimesh.Chat.Effects.user_in_message(@user, chat_message), do: "bubble mention", else: "bubble you"%>
         <%= if chat_message.is_subscription_message, do: "bg-secondary" %>
         <%= if chat_message.is_followed_message, do: "border border-info" %>">
-        <div class="user-message-header d-inline d-md-block">
+        <div class="user-message-header <%= unless @popped_out, do: 'd-inline d-md-block'%>">
             <%= if Map.get(@permissions, :can_delete, false)  do %>
             <i class="delete-message fas fa-trash fa-fw chat-mod-icon" phx-click="delete_message" phx-value-user="<%= chat_message.user.username %>" phx-value-message="<%= chat_message.id %>" data-toggle="tooltip" title="<%= gettext("Delete message.") %>"></i>
             <% end %>
@@ -23,14 +23,14 @@
             <%= Glimesh.Chat.Effects.render_global_badge(chat_message.user) %>
             <%= Glimesh.Chat.Effects.render_channel_badge(@channel, chat_message.user) %>
 
-            <%= Glimesh.Chat.Effects.render_username_and_avatar(chat_message.user) %><span class="d-inline d-md-none">:</span>
+            <%= Glimesh.Chat.Effects.render_username_and_avatar(chat_message.user) %><%= unless @popped_out do%><span class="d-inline d-md-none">:</span><% end %>
             <% end %>
             <small id="small-<%= chat_message.id %>" class="text-muted chat-timestamp">
                 <local-time id="timestamp-<%= chat_message.id %>" phx-update="ignore" datetime="<%= "#{chat_message.inserted_at}" <> "Z" %>" format="micro" hour="numeric" minute="2-digit" second="2-digit"><%= NaiveDateTime.to_time(chat_message.inserted_at) %>
                 </local-time>
             </small>
         </div>
-        <div class="user-message d-inline d-md-block">
+        <div class="user-message <%= unless @popped_out, do: 'd-inline d-md-block'%>">
             <%= if chat_message.is_followed_message or chat_message.is_subscription_message, do: Glimesh.Chat.Effects.render_username_and_avatar(chat_message.user) %>
             <%= raw(Glimesh.Chat.Renderer.render(chat_message.tokens)) %>
         </div>

--- a/lib/glimesh_web/live/chat_live/index.html.leex
+++ b/lib/glimesh_web/live/chat_live/index.html.leex
@@ -23,12 +23,12 @@
             <%= Glimesh.Chat.Effects.render_global_badge(chat_message.user) %>
             <%= Glimesh.Chat.Effects.render_channel_badge(@channel, chat_message.user) %>
 
-            <%= Glimesh.Chat.Effects.render_username_and_avatar(chat_message.user) %><%= unless @popped_out do%><span class="d-inline d-md-none">:</span><% end %>
+            <%= Glimesh.Chat.Effects.render_username_and_avatar(chat_message.user) %>
             <% end %>
             <small id="small-<%= chat_message.id %>" class="text-muted chat-timestamp">
                 <local-time id="timestamp-<%= chat_message.id %>" phx-update="ignore" datetime="<%= "#{chat_message.inserted_at}" <> "Z" %>" format="micro" hour="numeric" minute="2-digit" second="2-digit"><%= NaiveDateTime.to_time(chat_message.inserted_at) %>
                 </local-time>
-            </small>
+            </small><%= unless @popped_out or chat_message.is_followed_message or chat_message.is_subscription_message do %><span class="d-inline d-md-none">:</span><% end %>
         </div>
         <div class="user-message <%= unless @popped_out, do: 'd-inline d-md-block'%>">
             <%= if chat_message.is_followed_message or chat_message.is_subscription_message, do: Glimesh.Chat.Effects.render_username_and_avatar(chat_message.user) %>

--- a/lib/glimesh_web/live/chat_live/pop_out.html.leex
+++ b/lib/glimesh_web/live/chat_live/pop_out.html.leex
@@ -1,3 +1,3 @@
 <div class="pop-out-chat">
-    <%= live_render @socket, GlimeshWeb.ChatLive.Index, id: "chat", session: %{"user" => @user, "channel_id" => @channel_id} %>
+    <%= live_render @socket, GlimeshWeb.ChatLive.Index, id: "chat", session: %{"user" => @user, "channel_id" => @channel_id, "popped_out" => true} %>
 </div>

--- a/lib/glimesh_web/live/user_live/stream.html.leex
+++ b/lib/glimesh_web/live/user_live/stream.html.leex
@@ -153,7 +153,7 @@ updated_at: <%= @stream_metadata.updated_at %>
         <div id="chat-column" class="col-lg-3 d-flex flex-column position-relative layout-spacing">
             <div class="chat-flex">
                 <div class="chat-absolute">
-                    <%= live_render @socket, GlimeshWeb.ChatLive.Index, id: "chat", session: %{"user" => @user, "channel_id" => @channel.id} %>
+                    <%= live_render @socket, GlimeshWeb.ChatLive.Index, id: "chat", session: %{"user" => @user, "channel_id" => @channel.id, "popped_out" => false} %>
                 </div>
             </div>
         </div>

--- a/test/glimesh_web/live/chat_live_test.exs
+++ b/test/glimesh_web/live/chat_live_test.exs
@@ -50,7 +50,7 @@ defmodule GlimeshWeb.ChatLiveTest do
     test "can post a chat message", %{conn: conn, channel: channel, user: user} do
       {:ok, view, _html} =
         live_isolated(conn, GlimeshWeb.ChatLive.Index,
-          session: %{"user" => user, "channel_id" => channel.id}
+          session: %{"user" => user, "channel_id" => channel.id, "popped_out" => false}
         )
 
       view
@@ -80,7 +80,7 @@ defmodule GlimeshWeb.ChatLiveTest do
     } do
       {:ok, view, _html} =
         live_isolated(conn, GlimeshWeb.ChatLive.Index,
-          session: %{"user" => user, "channel_id" => channel.id}
+          session: %{"user" => user, "channel_id" => channel.id, "popped_out" => false}
         )
 
       # We want to test an async platform ban where the user's session is not rejected
@@ -101,7 +101,7 @@ defmodule GlimeshWeb.ChatLiveTest do
     } do
       {:ok, view, _html} =
         live_isolated(conn, GlimeshWeb.ChatLive.Index,
-          session: %{"user" => user, "channel_id" => channel.id}
+          session: %{"user" => user, "channel_id" => channel.id, "popped_out" => false}
         )
 
       # We want to test an async platform ban where the user's session is not rejected
@@ -126,7 +126,7 @@ defmodule GlimeshWeb.ChatLiveTest do
 
       {:ok, view, _html} =
         live_isolated(conn, GlimeshWeb.ChatLive.Index,
-          session: %{"user" => streamer, "channel_id" => channel.id}
+          session: %{"user" => streamer, "channel_id" => channel.id, "popped_out" => false}
         )
 
       target = "##{chat_message.id} > div.user-message-header > i.short-timeout"
@@ -147,7 +147,7 @@ defmodule GlimeshWeb.ChatLiveTest do
 
       {:ok, view, _html} =
         live_isolated(conn, GlimeshWeb.ChatLive.Index,
-          session: %{"user" => streamer, "channel_id" => channel.id}
+          session: %{"user" => streamer, "channel_id" => channel.id, "popped_out" => false}
         )
 
       target = "##{chat_message.id} > div.user-message-header > i.long-timeout"
@@ -168,7 +168,7 @@ defmodule GlimeshWeb.ChatLiveTest do
 
       {:ok, view, _html} =
         live_isolated(conn, GlimeshWeb.ChatLive.Index,
-          session: %{"user" => streamer, "channel_id" => channel.id}
+          session: %{"user" => streamer, "channel_id" => channel.id, "popped_out" => false}
         )
 
       target = "##{chat_message.id} > div.user-message-header > i.ban"
@@ -189,7 +189,7 @@ defmodule GlimeshWeb.ChatLiveTest do
 
       {:ok, view, _html} =
         live_isolated(conn, GlimeshWeb.ChatLive.Index,
-          session: %{"user" => streamer, "channel_id" => channel.id}
+          session: %{"user" => streamer, "channel_id" => channel.id, "popped_out" => false}
         )
 
       target = "##{chat_message.id} > div.user-message-header > i.delete-message"
@@ -209,7 +209,7 @@ defmodule GlimeshWeb.ChatLiveTest do
 
       {:ok, view, _html} =
         live_isolated(conn, GlimeshWeb.ChatLive.Index,
-          session: %{"user" => user, "channel_id" => channel.id}
+          session: %{"user" => user, "channel_id" => channel.id, "popped_out" => false}
         )
 
       assert render(view) =~ "Show Timestamps"
@@ -227,7 +227,7 @@ defmodule GlimeshWeb.ChatLiveTest do
 
       {:ok, view, _html} =
         live_isolated(conn, GlimeshWeb.ChatLive.Index,
-          session: %{"user" => user, "channel_id" => channel.id}
+          session: %{"user" => user, "channel_id" => channel.id, "popped_out" => false}
         )
 
       assert render(view) =~ "Hide Mod Icons"

--- a/test/glimesh_web/live/chat_live_test.exs
+++ b/test/glimesh_web/live/chat_live_test.exs
@@ -50,7 +50,7 @@ defmodule GlimeshWeb.ChatLiveTest do
     test "can post a chat message", %{conn: conn, channel: channel, user: user} do
       {:ok, view, _html} =
         live_isolated(conn, GlimeshWeb.ChatLive.Index,
-          session: %{"user" => user, "channel_id" => channel.id, "popped_out" => false}
+          session: %{"user" => user, "channel_id" => channel.id}
         )
 
       view
@@ -80,7 +80,7 @@ defmodule GlimeshWeb.ChatLiveTest do
     } do
       {:ok, view, _html} =
         live_isolated(conn, GlimeshWeb.ChatLive.Index,
-          session: %{"user" => user, "channel_id" => channel.id, "popped_out" => false}
+          session: %{"user" => user, "channel_id" => channel.id}
         )
 
       # We want to test an async platform ban where the user's session is not rejected
@@ -101,7 +101,7 @@ defmodule GlimeshWeb.ChatLiveTest do
     } do
       {:ok, view, _html} =
         live_isolated(conn, GlimeshWeb.ChatLive.Index,
-          session: %{"user" => user, "channel_id" => channel.id, "popped_out" => false}
+          session: %{"user" => user, "channel_id" => channel.id}
         )
 
       # We want to test an async platform ban where the user's session is not rejected
@@ -126,7 +126,7 @@ defmodule GlimeshWeb.ChatLiveTest do
 
       {:ok, view, _html} =
         live_isolated(conn, GlimeshWeb.ChatLive.Index,
-          session: %{"user" => streamer, "channel_id" => channel.id, "popped_out" => false}
+          session: %{"user" => streamer, "channel_id" => channel.id}
         )
 
       target = "##{chat_message.id} > div.user-message-header > i.short-timeout"
@@ -147,7 +147,7 @@ defmodule GlimeshWeb.ChatLiveTest do
 
       {:ok, view, _html} =
         live_isolated(conn, GlimeshWeb.ChatLive.Index,
-          session: %{"user" => streamer, "channel_id" => channel.id, "popped_out" => false}
+          session: %{"user" => streamer, "channel_id" => channel.id}
         )
 
       target = "##{chat_message.id} > div.user-message-header > i.long-timeout"
@@ -168,7 +168,7 @@ defmodule GlimeshWeb.ChatLiveTest do
 
       {:ok, view, _html} =
         live_isolated(conn, GlimeshWeb.ChatLive.Index,
-          session: %{"user" => streamer, "channel_id" => channel.id, "popped_out" => false}
+          session: %{"user" => streamer, "channel_id" => channel.id}
         )
 
       target = "##{chat_message.id} > div.user-message-header > i.ban"
@@ -189,7 +189,7 @@ defmodule GlimeshWeb.ChatLiveTest do
 
       {:ok, view, _html} =
         live_isolated(conn, GlimeshWeb.ChatLive.Index,
-          session: %{"user" => streamer, "channel_id" => channel.id, "popped_out" => false}
+          session: %{"user" => streamer, "channel_id" => channel.id}
         )
 
       target = "##{chat_message.id} > div.user-message-header > i.delete-message"
@@ -209,7 +209,7 @@ defmodule GlimeshWeb.ChatLiveTest do
 
       {:ok, view, _html} =
         live_isolated(conn, GlimeshWeb.ChatLive.Index,
-          session: %{"user" => user, "channel_id" => channel.id, "popped_out" => false}
+          session: %{"user" => user, "channel_id" => channel.id}
         )
 
       assert render(view) =~ "Show Timestamps"
@@ -227,7 +227,7 @@ defmodule GlimeshWeb.ChatLiveTest do
 
       {:ok, view, _html} =
         live_isolated(conn, GlimeshWeb.ChatLive.Index,
-          session: %{"user" => user, "channel_id" => channel.id, "popped_out" => false}
+          session: %{"user" => user, "channel_id" => channel.id}
         )
 
       assert render(view) =~ "Hide Mod Icons"


### PR DESCRIPTION
Two fixes/things in this PR. 

Popped out chat now completely ignores the device width, so no longer will it format like it's on mobile(should help when docking chat in OBS).

The second thing is the colon in the chat bubble for mobile has been moved to after the timestamp to help with reading flow. 

Before:
![image](https://user-images.githubusercontent.com/11252574/115419190-23239e00-a1c8-11eb-9b71-8b8686b3b29e.png)

After: 
![image](https://user-images.githubusercontent.com/11252574/115419292-36366e00-a1c8-11eb-83dd-d2e5f05136d3.png)

Desktop in stream(chat next to stream) chat has not been affected by any of these changes. Popout just now behaves like it did before #591 was merged.
