### PR TITLE
Make coverage optional if service is down

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -55,3 +55,6 @@ jobs:
 
     - name: Code Coverage
       run: mix coveralls.github
+      # Sometimes Coveralls throws a 500 error, preventing us from being able to push code.
+      # Coverage is important, but not important enough to hold back a merge :)
+      continue-on-error: true


### PR DESCRIPTION
Not sure why, but randomly coveralls will fail to allow us to push a coverage report. Realistically for large PR's we'll want to wait until it's back online but for small things it makes it very annoying to force merges.