### PR TITLE
Add chat message validation

### DIFF
--- a/lib/glimesh/api.ex
+++ b/lib/glimesh/api.ex
@@ -8,4 +8,15 @@ defmodule Glimesh.Api do
   def error_not_found, do: {:error, @error_not_found}
 
   def error_access_denied, do: {:error, @error_access_denied}
+
+  @doc """
+  Parse a list of changset errors into actionable API errors
+  """
+  def parse_ecto_changeset_errors(%Ecto.Changeset{} = changeset) do
+    Ecto.Changeset.traverse_errors(changeset, fn {msg, opts} ->
+      Enum.reduce(opts, msg, fn {key, value}, acc ->
+        String.replace(acc, "%{#{key}}", to_string(value))
+      end)
+    end)
+  end
 end

--- a/lib/glimesh/api/resolvers/chat_resolver.ex
+++ b/lib/glimesh/api/resolvers/chat_resolver.ex
@@ -23,14 +23,7 @@ defmodule Glimesh.Api.ChatResolver do
           {:ok, message}
 
         {:error, %Ecto.Changeset{} = changeset} ->
-          messages =
-            Ecto.Changeset.traverse_errors(changeset, fn {msg, opts} ->
-              Enum.reduce(opts, msg, fn {key, value}, acc ->
-                String.replace(acc, "%{#{key}}", to_string(value))
-              end)
-            end)
-
-          {:error, messages}
+          {:error, Glimesh.Api.parse_ecto_changeset_errors(changeset)}
       end
     end
   end

--- a/lib/glimesh/chat/chat_message.ex
+++ b/lib/glimesh/chat/chat_message.ex
@@ -26,6 +26,7 @@ defmodule Glimesh.Chat.ChatMessage do
     chat_message
     |> cast(attrs, [:message, :is_visible, :is_followed_message, :is_subscription_message])
     |> validate_required([:channel, :user, :message])
+    |> validate_length(:message, min: 1, max: 255)
   end
 
   @doc false

--- a/lib/glimesh/graphql/resolvers/chat_resolver.ex
+++ b/lib/glimesh/graphql/resolvers/chat_resolver.ex
@@ -23,14 +23,7 @@ defmodule Glimesh.Resolvers.ChatResolver do
           {:ok, message}
 
         {:error, %Ecto.Changeset{} = changeset} ->
-          messages =
-            Ecto.Changeset.traverse_errors(changeset, fn {msg, opts} ->
-              Enum.reduce(opts, msg, fn {key, value}, acc ->
-                String.replace(acc, "%{#{key}}", to_string(value))
-              end)
-            end)
-
-          {:error, messages}
+          {:error, Glimesh.Api.parse_ecto_changeset_errors(changeset)}
       end
     end
   end

--- a/lib/glimesh/graphql/resolvers/chat_resolver.ex
+++ b/lib/glimesh/graphql/resolvers/chat_resolver.ex
@@ -18,7 +18,20 @@ defmodule Glimesh.Resolvers.ChatResolver do
       # Force a refresh of the user just in case they are platform banned
       user = Accounts.get_user!(ua.user.id)
 
-      Chat.create_chat_message(user, channel, message_obj)
+      case Chat.create_chat_message(user, channel, message_obj) do
+        {:ok, message} ->
+          {:ok, message}
+
+        {:error, %Ecto.Changeset{} = changeset} ->
+          messages =
+            Ecto.Changeset.traverse_errors(changeset, fn {msg, opts} ->
+              Enum.reduce(opts, msg, fn {key, value}, acc ->
+                String.replace(acc, "%{#{key}}", to_string(value))
+              end)
+            end)
+
+          {:error, messages}
+      end
     end
   end
 


### PR DESCRIPTION
We get a fatal error whenever createChatMessage is called with a message longer than 255 characters (since that's our DB limit).

This PR shows ecto that limit, and tells Absinthe how to translate it into an error message. Ideally we should just drop in something like: https://hex.pm/packages/absinthe_error_payload in the future.