### PR TITLE
Social account username sanitization

### DIFF
--- a/lib/glimesh/accounts.ex
+++ b/lib/glimesh/accounts.ex
@@ -342,14 +342,14 @@ defmodule Glimesh.Accounts do
   end
 
   @doc """
-  Updates the user password.
+  Updates the user profile.
 
   ## Examples
 
-      iex> update_user_password(user, "valid password", %{password: ...})
+      iex> update_user_profile(user, %{display_name: "bacon123"})
       {:ok, %User{}}
 
-      iex> update_user_password(user, "invalid password", %{password: ...})
+      iex> update_user_profile(user, %{display_name: nil})
       {:error, %Ecto.Changeset{}}
 
   """

--- a/lib/glimesh/accounts/user.ex
+++ b/lib/glimesh/accounts/user.ex
@@ -5,6 +5,7 @@ defmodule Glimesh.Accounts.User do
   use Waffle.Ecto.Schema
   import GlimeshWeb.Gettext
   import Ecto.Changeset
+  alias Glimesh.Socials.Sanitizer
 
   @derive {Inspect, except: [:password, :hashed_password, :tfa_token]}
   schema "users" do
@@ -247,6 +248,9 @@ defmodule Glimesh.Accounts.User do
     |> validate_youtube_url(:youtube_intro_url)
     |> validate_displayname()
     |> strip_discord_invite()
+    |> strip_youtube()
+    |> strip_guilded()
+    |> strip_instagram()
     |> set_profile_content_html()
     |> cast_attachments(attrs, [:avatar])
   end
@@ -378,6 +382,36 @@ defmodule Glimesh.Accounts.User do
       changeset
     else
       add_error(changeset, :tfa, "Invalid 2FA code")
+    end
+  end
+
+  def strip_youtube(changeset) do
+    case changeset do
+      %Ecto.Changeset{valid?: true, changes: %{social_youtube: social}} ->
+        put_change(changeset, :social_youtube, Sanitizer.sanitize(social))
+
+      _ ->
+        changeset
+    end
+  end
+
+  def strip_guilded(changeset) do
+    case changeset do
+      %Ecto.Changeset{valid?: true, changes: %{social_guilded: social}} ->
+        put_change(changeset, :social_guilded, Sanitizer.sanitize(social, :guilded))
+
+      _ ->
+        changeset
+    end
+  end
+
+  def strip_instagram(changeset) do
+    case changeset do
+      %Ecto.Changeset{valid?: true, changes: %{social_instagram: social}} ->
+        put_change(changeset, :social_instagram, Sanitizer.sanitize(social))
+
+      _ ->
+        changeset
     end
   end
 

--- a/lib/glimesh/socials.ex
+++ b/lib/glimesh/socials.ex
@@ -9,6 +9,8 @@ defmodule Glimesh.Socials do
   alias Glimesh.Accounts.User
   alias Glimesh.Accounts.UserSocial
 
+  alias Glimesh.Socials.Sanitizer
+
   # User API Calls
   def get_social(%User{} = user, platform) do
     Repo.one(
@@ -25,10 +27,12 @@ defmodule Glimesh.Socials do
   end
 
   def connect_user_social(%User{} = user, platform, identifier, username) do
+    sanitized_username = Sanitizer.sanitize(username)
+
     create_user_social(user, %{
       platform: platform,
       identifier: identifier,
-      username: username
+      username: sanitized_username
     })
   end
 

--- a/lib/glimesh/socials/sanitizer.ex
+++ b/lib/glimesh/socials/sanitizer.ex
@@ -1,0 +1,16 @@
+defmodule Glimesh.Socials.Sanitizer do
+  @moduledoc """
+  Sanitizes social usernames
+  """
+
+  def sanitize(username) do
+    username
+    |> remove_at_symbol()
+    |> String.trim(" ")
+    |> String.trim("/")
+  end
+
+  defp remove_at_symbol(username) do
+    String.trim_leading(username, "@")
+  end
+end

--- a/lib/glimesh/socials/sanitizer.ex
+++ b/lib/glimesh/socials/sanitizer.ex
@@ -28,7 +28,6 @@ defmodule Glimesh.Socials.Sanitizer do
     case Regex.run(~r/[https?:\/\/]guilded.gg\/(.*)/, username, capture: :all_but_first) do
       nil -> username
       [match] -> match
-      _ -> username
     end
   end
 end

--- a/lib/glimesh/socials/sanitizer.ex
+++ b/lib/glimesh/socials/sanitizer.ex
@@ -3,6 +3,8 @@ defmodule Glimesh.Socials.Sanitizer do
   Sanitizes social usernames
   """
 
+  def sanitize(nil), do: nil
+
   def sanitize(username) do
     username
     |> remove_at_symbol()
@@ -10,7 +12,23 @@ defmodule Glimesh.Socials.Sanitizer do
     |> String.trim("/")
   end
 
+  def sanitize(username, :guilded) do
+    username
+    |> remove_guilded()
+    |> sanitize()
+  end
+
   defp remove_at_symbol(username) do
     String.trim_leading(username, "@")
+  end
+
+  defp remove_guilded(nil), do: nil
+
+  defp remove_guilded(username) do
+    case Regex.run(~r/[https?:\/\/]guilded.gg\/(.*)/, username, capture: :all_but_first) do
+      nil -> username
+      [match] -> match
+      _ -> username
+    end
   end
 end

--- a/lib/glimesh_web/live/user_live/components/social_buttons.ex
+++ b/lib/glimesh_web/live/user_live/components/social_buttons.ex
@@ -1,13 +1,15 @@
 defmodule GlimeshWeb.UserLive.Components.SocialButtons do
   use GlimeshWeb, :live_view
 
+  alias Glimesh.Socials.Sanitizer
+
   @impl true
   def render(assigns) do
     ~L"""
     <%= if @twitter_social  do %>
     <li rel="ugc" class="list-inline-item" data-toggle="tooltip"
         title="<%= gettext("Linked Twitter Account @%{username}", username: @twitter_social.username) %>">
-        <a href="https://twitter.com/<%= @twitter_social.username %>" target="_blank">
+        <a href="https://twitter.com/<%= Sanitizer.sanitize(@twitter_social.username) %>" target="_blank">
             <span class="fa-stack">
                 <i class="fas fa-certificate fa-stack-2x"></i>
                 <i class="fab fa-twitter fa-stack-1x" style="color:white"></i>
@@ -17,7 +19,7 @@ defmodule GlimeshWeb.UserLive.Components.SocialButtons do
     <% else %>
     <%= if @streamer.social_twitter do %>
     <li rel="ugc" class="list-inline-item">
-        <a href="https://twitter.com/<%= @streamer.social_twitter %>" target="_blank"
+        <a href="https://twitter.com/<%= Sanitizer.sanitize(@streamer.social_twitter) %>" target="_blank"
             class="social-icon">
             <i class="fab fa-twitter"></i>
         </a>
@@ -27,7 +29,7 @@ defmodule GlimeshWeb.UserLive.Components.SocialButtons do
 
     <%= if @streamer.social_youtube do %>
     <li rel="ugc" class="list-inline-item">
-        <a href="https://youtube.com/<%= @streamer.social_youtube %>" target="_blank"
+        <a href="https://youtube.com/<%= Sanitizer.sanitize(@streamer.social_youtube) %>" target="_blank"
             class="social-icon">
             <i class="fab fa-youtube"></i>
         </a>
@@ -35,7 +37,7 @@ defmodule GlimeshWeb.UserLive.Components.SocialButtons do
     <%  end %>
     <%= if @streamer.social_instagram do %>
     <li class="list-inline-item">
-        <a rel="ugc" href="https://instagram.com/<%= @streamer.social_instagram %>" target="_blank"
+        <a rel="ugc" href="https://instagram.com/<%= Sanitizer.sanitize(@streamer.social_instagram) %>" target="_blank"
             class="social-icon">
             <i class="fab fa-instagram"></i>
         </a>
@@ -43,7 +45,7 @@ defmodule GlimeshWeb.UserLive.Components.SocialButtons do
     <%  end %>
     <%= if @streamer.social_discord do %>
     <li class="list-inline-item">
-        <a rel="ugc" href="https://discord.gg/<%= @streamer.social_discord %>" target="_blank"
+        <a rel="ugc" href="https://discord.gg/<%= Sanitizer.sanitize(@streamer.social_discord) %>" target="_blank"
             class="social-icon">
             <i class="fab fa-discord"></i>
         </a>
@@ -51,7 +53,7 @@ defmodule GlimeshWeb.UserLive.Components.SocialButtons do
     <% end %>
     <%= if @streamer.social_guilded do %>
     <li class="list-inline-item">
-        <a rel="ugc" href="https://guilded.gg/<%= @streamer.social_guilded %>" target="_blank"
+        <a rel="ugc" href="https://guilded.gg/<%= Sanitizer.sanitize(@streamer.social_guilded) %>" target="_blank"
             class="social-icon">
             <i class="fab fa-guilded"></i>
         </a>

--- a/lib/glimesh_web/live/user_live/components/social_buttons.ex
+++ b/lib/glimesh_web/live/user_live/components/social_buttons.ex
@@ -53,7 +53,7 @@ defmodule GlimeshWeb.UserLive.Components.SocialButtons do
     <% end %>
     <%= if @streamer.social_guilded do %>
     <li class="list-inline-item">
-        <a rel="ugc" href="https://guilded.gg/<%= Sanitizer.sanitize(@streamer.social_guilded) %>" target="_blank"
+        <a rel="ugc" href="https://guilded.gg/<%= Sanitizer.sanitize(@streamer.social_guilded, :guilded) %>" target="_blank"
             class="social-icon">
             <i class="fab fa-guilded"></i>
         </a>

--- a/test/glimesh/accounts/user_test.exs
+++ b/test/glimesh/accounts/user_test.exs
@@ -1,0 +1,159 @@
+defmodule Glimesh.Accounts.UserTest do
+  use GlimeshWeb.ConnCase
+  import Glimesh.AccountsFixtures
+  alias Glimesh.Accounts.User
+  alias Glimesh.Repo
+
+  describe "profile_changeset/2" do
+    test "it strips invalid username prepended with @" do
+      attrs = %{social_instagram: "@glimesh"}
+
+      changeset =
+        user_fixture()
+        |> User.profile_changeset(attrs)
+
+      user = Repo.update!(changeset)
+
+      assert changeset.valid?
+      assert Map.get(user, :social_instagram) == "glimesh"
+    end
+
+    test "it strips invalid username prepended with spaces" do
+      attrs = %{social_instagram: "           glimesh"}
+
+      changeset =
+        user_fixture()
+        |> User.profile_changeset(attrs)
+
+      user = Repo.update!(changeset)
+
+      assert changeset.valid?
+      assert Map.get(user, :social_instagram) == "glimesh"
+    end
+
+    test "it strips invalid username with a bunch of spaces" do
+      attrs = %{social_instagram: "           glimesh          "}
+
+      changeset =
+        user_fixture()
+        |> User.profile_changeset(attrs)
+
+      user = Repo.update!(changeset)
+
+      assert changeset.valid?
+      assert Map.get(user, :social_instagram) == "glimesh"
+    end
+
+    test "it strips invalid username with a bunch of slashes" do
+      attrs = %{social_instagram: "////glimesh/////"}
+
+      changeset =
+        user_fixture()
+        |> User.profile_changeset(attrs)
+
+      user = Repo.update!(changeset)
+
+      assert changeset.valid?
+      assert Map.get(user, :social_instagram) == "glimesh"
+    end
+
+    test "it strips guilded.gg urls" do
+      attrs = %{social_guilded: "https://guilded.gg/glimesh"}
+
+      changeset =
+        user_fixture()
+        |> User.profile_changeset(attrs)
+
+      user = Repo.update!(changeset)
+
+      assert changeset.valid?
+      assert Map.get(user, :social_guilded) == "glimesh"
+    end
+
+    test "it strips unsecured guilded.gg urls" do
+      attrs = %{social_guilded: "http://guilded.gg/glimesh"}
+
+      changeset =
+        user_fixture()
+        |> User.profile_changeset(attrs)
+
+      user = Repo.update!(changeset)
+
+      assert changeset.valid?
+      assert Map.get(user, :social_guilded) == "glimesh"
+    end
+
+    test "it strips youtube username prepended with @" do
+      attrs = %{social_youtube: "@glimesh"}
+
+      changeset =
+        user_fixture()
+        |> User.profile_changeset(attrs)
+
+      user = Repo.update!(changeset)
+
+      assert changeset.valid?
+      assert Map.get(user, :social_youtube) == "glimesh"
+    end
+
+    test "it strips secure discord invite links" do
+      attrs = %{social_discord: "https://discord.gg/glimesh"}
+
+      changeset =
+        user_fixture()
+        |> User.profile_changeset(attrs)
+
+      user = Repo.update!(changeset)
+
+      assert changeset.valid?
+      assert Map.get(user, :social_discord) == "glimesh"
+    end
+
+    test "it strips insecure discord invite links" do
+      attrs = %{social_discord: "http://discord.gg/glimesh"}
+
+      changeset =
+        user_fixture()
+        |> User.profile_changeset(attrs)
+
+      user = Repo.update!(changeset)
+
+      assert changeset.valid?
+      assert Map.get(user, :social_discord) == "glimesh"
+    end
+
+    test "it strips lazy discord invite links" do
+      attrs = %{social_discord: "discord.gg/glimesh"}
+
+      changeset =
+        user_fixture()
+        |> User.profile_changeset(attrs)
+
+      user = Repo.update!(changeset)
+
+      assert changeset.valid?
+      assert Map.get(user, :social_discord) == "glimesh"
+    end
+
+    test "tests sanitizing many fields at once" do
+      attrs = %{
+        social_discord: "discord.gg/glimesh",
+        social_youtube: "@glimesh",
+        social_instagram: "@glimesh",
+        social_guilded: "http://guilded.gg/glimesh"
+      }
+
+      changeset =
+        user_fixture()
+        |> User.profile_changeset(attrs)
+
+      user = Repo.update!(changeset)
+
+      assert changeset.valid?
+      assert Map.get(user, :social_discord) == "glimesh"
+      assert Map.get(user, :social_youtube) == "glimesh"
+      assert Map.get(user, :social_instagram) == "glimesh"
+      assert Map.get(user, :social_guilded) == "glimesh"
+    end
+  end
+end

--- a/test/glimesh/socials/sanitizer_test.exs
+++ b/test/glimesh/socials/sanitizer_test.exs
@@ -1,0 +1,24 @@
+defmodule Glimesh.Socials.SanitizerTest do
+  use Glimesh.DataCase
+  alias Glimesh.Socials.Sanitizer
+
+  test "it removes @ from the beginning of a username" do
+    assert Sanitizer.sanitize("@username") == "username"
+  end
+
+  test "it does not removes @ from the end of a username" do
+    assert Sanitizer.sanitize("@username@") == "username@"
+  end
+
+  test "it removes multiple @ symbols from beginning of string" do
+    assert Sanitizer.sanitize("@@@@@@username") == "username"
+  end
+
+  test "it removes whitespace" do
+    assert Sanitizer.sanitize("     username     ") == "username"
+  end
+
+  test "it removes slashes" do
+    assert Sanitizer.sanitize("////username////") == "username"
+  end
+end

--- a/test/glimesh/socials/sanitizer_test.exs
+++ b/test/glimesh/socials/sanitizer_test.exs
@@ -21,4 +21,24 @@ defmodule Glimesh.Socials.SanitizerTest do
   test "it removes slashes" do
     assert Sanitizer.sanitize("////username////") == "username"
   end
+
+  test "it removes a guilded url" do
+    assert Sanitizer.sanitize("https://guilded.gg/TheKeep", :guilded) == "TheKeep"
+  end
+
+  test "it does not break when is nil" do
+    assert Sanitizer.sanitize(nil) == nil
+  end
+
+  test "it does not break a normal username" do
+    assert Sanitizer.sanitize("TheKeep", :guilded) == "TheKeep"
+  end
+
+  test "it does not break when guilded is nil" do
+    assert Sanitizer.sanitize(nil, :guilded) == nil
+  end
+
+  test "it does not break when someone puts the guilded url" do
+    assert Sanitizer.sanitize("https://guilded.gg/TheKeep", :guilded) == "TheKeep"
+  end
 end

--- a/test/glimesh/socials_test.exs
+++ b/test/glimesh/socials_test.exs
@@ -21,6 +21,16 @@ defmodule Glimesh.SocialsTest do
       assert found_social.identifier == "1234"
     end
 
+    test "get_social/2 gets a single sanitized social" do
+      user = user_fixture()
+
+      Socials.connect_user_social(user, "twitter", "1234", "@@@@@clone1018")
+
+      found_social = Socials.get_social(user, "twitter")
+      assert %UserSocial{} = found_social
+      assert found_social.identifier == "1234"
+    end
+
     test "get_social/2 returns nil on nothing" do
       user = user_fixture()
 

--- a/test/glimesh_web/live/user_live_components/social_buttons_test.exs
+++ b/test/glimesh_web/live/user_live_components/social_buttons_test.exs
@@ -4,6 +4,8 @@ defmodule GlimeshWeb.UserLive.Components.SocialButtonsTest do
   import Phoenix.LiveViewTest
   import Glimesh.AccountsFixtures
 
+  alias Glimesh.Accounts
+
   @component GlimeshWeb.UserLive.Components.SocialButtons
 
   defp create_channel(_) do
@@ -20,7 +22,7 @@ defmodule GlimeshWeb.UserLive.Components.SocialButtonsTest do
 
     test "render correctly", %{conn: conn, streamer: streamer} do
       {:ok, _} =
-        Glimesh.Accounts.update_user_profile(streamer, %{
+        Accounts.update_user_profile(streamer, %{
           "social_discord" => "glimesh"
         })
 
@@ -28,6 +30,50 @@ defmodule GlimeshWeb.UserLive.Components.SocialButtonsTest do
 
       assert html =~ "https://discord.gg/glimesh"
       assert String.contains?(html, "Twitter") == false
+    end
+
+    test "correctly strips @ symbols", %{conn: conn, streamer: streamer} do
+      {:ok, _} =
+        Accounts.update_user_profile(streamer, %{
+          "social_discord" => "@glimesh"
+        })
+
+      {:ok, _, html} = live_isolated(conn, @component, session: %{"user_id" => streamer.id})
+
+      assert html =~ "https://discord.gg/glimesh"
+    end
+
+    test "correctly strips multiple @ symbols", %{conn: conn, streamer: streamer} do
+      {:ok, _} =
+        Accounts.update_user_profile(streamer, %{
+          "social_discord" => "@@@@@glimesh"
+        })
+
+      {:ok, _, html} = live_isolated(conn, @component, session: %{"user_id" => streamer.id})
+
+      assert html =~ "https://discord.gg/glimesh"
+    end
+
+    test "correctly strips slashes", %{conn: conn, streamer: streamer} do
+      {:ok, _} =
+        Accounts.update_user_profile(streamer, %{
+          "social_discord" => "/////glimesh/////"
+        })
+
+      {:ok, _, html} = live_isolated(conn, @component, session: %{"user_id" => streamer.id})
+
+      assert html =~ "https://discord.gg/glimesh"
+    end
+
+    test "correctly trims spaces", %{conn: conn, streamer: streamer} do
+      {:ok, _} =
+        Accounts.update_user_profile(streamer, %{
+          "social_discord" => "        glimesh      "
+        })
+
+      {:ok, _, html} = live_isolated(conn, @component, session: %{"user_id" => streamer.id})
+
+      assert html =~ "https://discord.gg/glimesh"
     end
   end
 end

--- a/test/glimesh_web/live/user_live_components/social_buttons_test.exs
+++ b/test/glimesh_web/live/user_live_components/social_buttons_test.exs
@@ -75,5 +75,38 @@ defmodule GlimeshWeb.UserLive.Components.SocialButtonsTest do
 
       assert html =~ "https://discord.gg/glimesh"
     end
+
+    test "correctly trims guilded urls", %{conn: conn, streamer: streamer} do
+      {:ok, _} =
+        Accounts.update_user_profile(streamer, %{
+          "social_guilded" => "https://guilded.gg/glimesh"
+        })
+
+      {:ok, _, html} = live_isolated(conn, @component, session: %{"user_id" => streamer.id})
+
+      assert html =~ "https://guilded.gg/glimesh"
+    end
+
+    test "correctly shows guilded urls using username", %{conn: conn, streamer: streamer} do
+      {:ok, _} =
+        Accounts.update_user_profile(streamer, %{
+          "social_guilded" => "glimesh"
+        })
+
+      {:ok, _, html} = live_isolated(conn, @component, session: %{"user_id" => streamer.id})
+
+      assert html =~ "https://guilded.gg/glimesh"
+    end
+
+    test "correctly handles nil values", %{conn: conn, streamer: streamer} do
+      {:ok, _} =
+        Accounts.update_user_profile(streamer, %{
+          "social_guilded" => nil
+        })
+
+      {:ok, _, html} = live_isolated(conn, @component, session: %{"user_id" => streamer.id})
+
+      refute html =~ "guilded"
+    end
   end
 end


### PR DESCRIPTION
- adds sanitiziation to public facing social buttons
- attempts to sanitize when connecting manually input social

This covers the following cases
- "@username" -> "username"
- "@@@@@username" -> "username"
- "user@name@" -> "user@name@"
- "////username////" -> "username"
- "    username    " -> "username"

closes #48

Edit:
Adding guilded.gg sanitize under a :guilded function param for perf
See the following regex:
https://rubular.com/r/KwEKgHNxi3y3ej

What this does not fix:
- A frontend liveview form validation that lets the user know to only add the username part.
- The value in the form field when editing the guilded "url" - if they put `https://guilded.gg/TheKeep` then it will still show like that when editing preferences until saved again. 