### PR TITLE
Refactor/streams to video live

### DIFF
--- a/lib/glimesh/streams.ex
+++ b/lib/glimesh/streams.ex
@@ -270,6 +270,10 @@ defmodule Glimesh.Streams do
     )
   end
 
+  def get_last_stream_metadata(_fallback) do
+    %Glimesh.Streams.StreamMetadata{}
+  end
+
   def log_stream_metadata(%Glimesh.Streams.Stream{} = stream, attrs \\ %{}) do
     %StreamMetadata{
       stream: stream

--- a/lib/glimesh_web/live/chat_live/index.ex
+++ b/lib/glimesh_web/live/chat_live/index.ex
@@ -16,12 +16,13 @@ defmodule GlimeshWeb.ChatLive.Index do
       if session["locale"], do: Gettext.put_locale(session["locale"])
       if connected?(socket), do: Streams.subscribe_to(:chat, channel_id)
 
+      user = Accounts.get_user_by_session_token(session["user_token"])
       channel = ChannelLookups.get_channel!(channel_id)
 
       # Sets a default user_preferences map for the chat if the user is logged out
       user_preferences =
-        if session["user"] do
-          Accounts.get_user_preference!(session["user"])
+        if user do
+          Accounts.get_user_preference!(user)
         else
           %{
             show_timestamps: false,
@@ -29,9 +30,7 @@ defmodule GlimeshWeb.ChatLive.Index do
           }
         end
 
-      if session["user"] do
-        user = session["user"]
-
+      if user do
         Presence.track_presence(
           self(),
           Streams.get_subscribe_topic(:chatters, channel.id),
@@ -51,7 +50,7 @@ defmodule GlimeshWeb.ChatLive.Index do
         |> assign(:channel_chat_parser_config, Chat.get_chat_parser_config(channel))
         |> assign(:update_action, "replace")
         |> assign(:channel, channel)
-        |> assign(:user, session["user"])
+        |> assign(:user, user)
         |> assign(:theme, Map.get(session, "site_theme", "dark"))
         |> assign(:permissions, Chat.get_moderator_permissions(channel, session["user"]))
         |> assign(:chat_messages, list_chat_messages(channel))

--- a/lib/glimesh_web/live/streams_live/video.ex
+++ b/lib/glimesh_web/live/streams_live/video.ex
@@ -1,0 +1,130 @@
+defmodule GlimeshWeb.StreamLive.Video do
+  use GlimeshWeb, :live_view
+  alias Glimesh.Accounts
+  alias Glimesh.Accounts.Profile
+  alias Glimesh.Avatar
+  alias Glimesh.ChannelLookups
+  alias Glimesh.Presence
+  alias Glimesh.Streams
+
+  def mount(_params, session, socket) do
+    user = Accounts.get_user_by_session_token(session["user_token"])
+    channel = ChannelLookups.get_channel!(session["channel_id"])
+    streamer = Map.get(channel, :user, nil)
+    stream = Map.get(channel, :stream, nil)
+
+    if connected?(socket) do
+      # Wait until the socket connection is ready to load the stream
+      Process.send(self(), :load_stream, [])
+    end
+
+    avatar_url = Avatar.url({streamer.avatar, streamer}, :original)
+
+    {:ok,
+     socket
+     |> assign(:user, user)
+     |> assign(:channel, channel)
+     |> assign(:streamer, streamer)
+     |> assign(:stream, stream)
+     |> assign(:country, Map.get(session, "country"))
+     |> assign(:channel_poster, get_stream_thumbnail(channel))
+     |> assign(:janus_url, "Pending...")
+     |> assign(:janus_hostname, "Pending...")
+     |> assign(:lost_packets, 0)
+     |> assign(:player_error, nil)
+     |> assign(:show_debug, false)
+     |> assign(:unique_user, Map.get(session, "unique_user"))
+     |> assign(:custom_meta, Profile.meta_tags(streamer, avatar_url))
+     |> assign(:stream_metadata, get_last_stream_metadata(stream))
+     |> assign(:prompt_mature, Streams.prompt_mature_content(channel, user))
+     |> assign(:can_receive_payments, Accounts.can_receive_payments?(channel.user))}
+  end
+
+  def handle_info(:load_stream, socket) do
+    case Glimesh.Janus.get_closest_edge_location(socket.assigns.country) do
+      %Glimesh.Janus.EdgeRoute{id: janus_edge_id, url: janus_url, hostname: janus_hostname} ->
+        Presence.track_presence(
+          self(),
+          Streams.get_subscribe_topic(:viewers, socket.assigns.channel.id),
+          socket.assigns.unique_user,
+          %{
+            janus_edge_id: janus_edge_id
+          }
+        )
+
+        Process.send(self(), :remove_packet_warning, [])
+
+        {:noreply,
+         socket
+         |> push_event("load_video", %{
+           janus_url: janus_url,
+           channel_id: socket.assigns.channel.id
+         })
+         |> assign(:janus_url, janus_url)
+         |> assign(:janus_hostname, janus_hostname)}
+
+      _ ->
+        # In the event we can't find an edge, something is real wrong
+        {:noreply,
+         socket
+         |> assign(:player_error, "Unable to find edge video location, we'll be back soon!")}
+    end
+  end
+
+  def handle_info(:remove_packet_warning, socket) do
+    Process.send_after(self(), :remove_packet_warning, 15_000)
+
+    {:noreply, socket |> assign(:player_error, nil)}
+  end
+
+  def handle_info({:channel, channel}, socket) do
+    {:noreply, socket |> assign(:stream, channel.stream)}
+  end
+
+  def handle_event("show_mature", _value, socket) do
+    Process.send(self(), :load_stream, [])
+
+    {:noreply, assign(socket, :prompt_mature, false)}
+  end
+
+  def handle_event("lost_packets", %{"uplink" => _uplink, "lostPackets" => lostPackets}, socket) do
+    message =
+      if lostPackets > 6,
+        do:
+          gettext(
+            "We're detecting some networking problems between you and the streamer. You may experience video drops, jitter, or other issues!"
+          ),
+        else: nil
+
+    {:noreply,
+     socket
+     |> update(:lost_packets, &(&1 + lostPackets))
+     |> assign(:player_error, message)}
+  end
+
+  def handle_event("toggle_debug", _value, socket) do
+    if socket.assigns.show_debug === false do
+      # Opening the window
+      {:noreply,
+       socket
+       |> assign(:stream_metadata, get_last_stream_metadata(socket.assigns.stream))
+       |> assign(:show_debug, true)}
+    else
+      {:noreply, assign(socket, :show_debug, false)}
+    end
+  end
+
+  defp get_stream_thumbnail(channel) do
+    case channel.stream do
+      %Glimesh.Streams.Stream{} = stream ->
+        Glimesh.StreamThumbnail.url({stream.thumbnail, stream}, :original)
+
+      _ ->
+        Glimesh.ChannelPoster.url({channel.poster, channel}, :original)
+    end
+  end
+
+  defp get_last_stream_metadata(stream) do
+    Glimesh.Streams.get_last_stream_metadata(stream)
+  end
+end

--- a/lib/glimesh_web/live/streams_live/video.html.leex
+++ b/lib/glimesh_web/live/streams_live/video.html.leex
@@ -1,0 +1,149 @@
+<div class="card">
+  <div class="card-header p-1">
+    <div class="row">
+      <div class="col align-self-center d-block text-truncate">
+        <%= live_render(@socket, GlimeshWeb.UserLive.Components.ChannelTitle, id: "channel-title", session: %{"user" => @user, "channel_id" => @channel.id}) %>
+      </div>
+      <div class="col-auto">
+        <div class="float-right">
+          <div class="stream-info btn-toolbar">
+            <div class="btn-group mr-1" role="group" aria-label="First group">
+              <%= if @can_receive_payments do %>
+                <%= live_render(@socket, GlimeshWeb.UserLive.Components.SubscribeButton, id: "subscribe-button", session: %{"user" => @user, "streamer" => @streamer}) %>
+              <% end %>
+            </div>
+            <div class="btn-group mr-1" role="group" aria-label="Second group">
+              <%= live_render(@socket, GlimeshWeb.UserLive.Components.FollowButton, id: "follow-button", session: %{"user" => @user, "streamer" => @streamer}) %>
+            </div>
+            <div class="btn-group" role="group" aria-label="Third group">
+              <%= live_render(@socket, GlimeshWeb.UserLive.Components.ViewerCount, id: "viewer-count", session: %{"channel_id" => @channel.id}) %>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="card-body p-0 p-md-1">
+    <%= if @prompt_mature do %>
+      <div class="jumbotron jumbotron-fluid jumbotron-mature-content mb-0">
+        <div class="container p-5">
+          <div class="row justify-content-center">
+            <div class="col-sm-6">
+              <h3 class="display-5 text-center"><%= gettext("Mature Content Warning") %></h3>
+              <p class="lead text-center">
+              <%= gettext("The streamer has flagged this channel as only appropriate for Mature Audiences.") %><br>
+              <%= gettext("Do you wish to continue?") %>
+              </p>
+            </div>
+            <div class="w-100"></div>
+            <div class="col-8 col-lg-3">
+              <button type="button" phx-click="show_mature" class="btn btn-primary btn-block"><%= gettext("Agree & View Channel") %></button>
+            </div>
+          </div>
+
+        </div>
+      </div>
+
+    <% else %>
+      <div id="video-container" class="embed-responsive embed-responsive-16by9">
+        <video id="video-player" class="embed-responsive-item" phx-hook="FtlVideo" controls playsinline poster="<%= @channel_poster %>"></video>
+        <div id="video-loading-container" class="">
+          <div class="lds-ring">
+            <div></div>
+            <div></div>
+            <div></div>
+            <div></div>
+          </div>
+        </div>
+      </div>
+    <% end %>
+  </div>
+  <div class="card-footer p-1 d-none d-sm-block">
+    <div class="row">
+      <div class="col-8 d-inline-flex align-items-center">
+        <div id="streamer-avatar">
+          <a href="<%= Routes.user_profile_path(@socket, :index, @channel.user.username) %>">
+            <img src="<%= Glimesh.Avatar.url({@channel.user.avatar, @channel.user}, :original)%>" alt="<%= @channel.user.displayname %>" width="48" height="48" class="img-avatar mr-2 float-left <%= if Glimesh.Accounts.can_receive_payments?(@channel.user), do: "img-verified-streamer", else: "" %>">
+          </a>
+        </div>
+        <a title="<%= gettext("View Profile") %>" class="<%= Glimesh.Chat.Effects.get_username_color(@channel.user) %>" href="<%= Routes.user_profile_path(@socket, :index, @channel.user.username) %>">
+          <h3 class="mb-0"><%= @channel.user.displayname %></h3>
+        </a>
+
+        <span class="badge badge-pill badge-info ml-2"><%= Glimesh.Streams.get_channel_language(@channel) %></span>
+        <%= if @channel.mature_content do %>
+          <span class="badge badge-pill badge-warning ml-2"><%= gettext("Mature") %></span>
+        <% end %>
+
+        <%= live_render(@socket, GlimeshWeb.UserLive.Components.SocialButtons, id: "social-buttons", container: {:ul, class: "list-inline ml-2 mb-0"}, session: %{"user_id" => @streamer.id}) %>
+      </div>
+      <div class="col-4 align-self-center">
+        <div class="float-right mr-sm-2">
+          <div class="d-inline-block mr-sm-2">
+            <a href="#" phx-click="toggle_debug" class="text-color-link <%= if @player_error, do: "text-warning", else: "" %>">
+              <i class="fas fa-signal"></i>
+              <span class="sr-only">Debug</span>
+            </a>
+          </div>
+          <div class="d-inline-block">
+            <%= live_render(@socket, GlimeshWeb.UserLive.Components.ReportButton, id: "report-button", session: %{"user" => @user, "streamer" => @streamer}) %>
+          </div>
+        </div>
+      </div>
+    </div>
+    <%= if @show_debug do %>
+      <div id="debugModal" class="live-modal" phx-capture-click="toggle_debug" phx-window-keydown="toggle_debug" phx-key="escape" phx-target="#debugModal" phx-page-loading>
+        <div class="modal-dialog" role="document">
+          <div class="modal-content">
+            <div class="modal-header">
+              <h5 class="modal-title"><%= gettext("Debug Information") %></h5>
+              <button type="button" class="close" phx-click="toggle_debug" aria-label="Close">
+                <span aria-hidden="true">&times;</span>
+              </button>
+            </div>
+
+            <div class="modal-body">
+              <%= if @player_error do %>
+                <div class="alert alert-warning" role="alert">
+                  <%= @player_error %>
+                </div>
+              <% end %>
+              <pre class="px-2">
+== Janus Edge Information ==
+Edge Hostname: <%= @janus_hostname %>
+Edge URL: <%= @janus_url %>
+Reported Lost Packets: <%= @lost_packets %>
+<br>
+== Stream Metadata ==
+# Stream Metadata no longer auto reloads,
+# close & reopen modal to see newest data.
+ingest_server: <%= @stream_metadata.ingest_server %>
+ingest_viewers: <%= @stream_metadata.ingest_viewers %> // unused
+stream_time_seconds: <%= @stream_metadata.stream_time_seconds %>
+
+source_bitrate: <%= @stream_metadata.source_bitrate %>
+source_ping: <%= @stream_metadata.source_ping %> // unused
+
+recv_packets: <%= @stream_metadata.recv_packets %>
+lost_packets: <%= @stream_metadata.lost_packets %> // unused
+nack_packets: <%= @stream_metadata.nack_packets %> // unused
+
+vendor_name: <%= @stream_metadata.vendor_name %>
+vendor_version: <%= @stream_metadata.vendor_version %>
+
+audio_codec: <%= @stream_metadata.audio_codec %>
+video_codec: <%= @stream_metadata.video_codec %>
+video_height: <%= @stream_metadata.video_height %> // unused
+video_width: <%= @stream_metadata.video_width %> // unused
+
+inserted_at: <%= @stream_metadata.inserted_at %>
+updated_at: <%= @stream_metadata.updated_at %>
+              </pre>
+            </div>
+
+          </div>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/lib/glimesh_web/live/user_live/stream.ex
+++ b/lib/glimesh_web/live/user_live/stream.ex
@@ -2,9 +2,7 @@ defmodule GlimeshWeb.UserLive.Stream do
   use GlimeshWeb, :live_view
 
   alias Glimesh.Accounts
-  alias Glimesh.Accounts.Profile
   alias Glimesh.ChannelLookups
-  alias Glimesh.Presence
   alias Glimesh.Streams
 
   def mount(%{"username" => streamer_username}, session, socket) do
@@ -18,128 +16,21 @@ defmodule GlimeshWeb.UserLive.Stream do
           Streams.subscribe_to(:channel, channel.id)
         end
 
-        maybe_user = Accounts.get_user_by_session_token(session["user_token"])
         streamer = Accounts.get_user!(channel.streamer_id)
-
-        avatar_url = Glimesh.Avatar.url({streamer.avatar, streamer}, :original)
 
         {:ok,
          socket
          |> put_page_title(channel.title)
-         |> assign(:show_debug, false)
-         |> assign(:unique_user, Map.get(session, "unique_user"))
-         |> assign(:country, Map.get(session, "country"))
-         |> assign(:prompt_mature, Streams.prompt_mature_content(channel, maybe_user))
-         |> assign(:custom_meta, Profile.meta_tags(streamer, avatar_url))
          |> assign(:streamer, channel.user)
-         |> assign(:can_receive_payments, Accounts.can_receive_payments?(channel.user))
          |> assign(:channel, channel)
-         |> assign(:stream, channel.stream)
-         |> assign(:channel_poster, get_stream_thumbnail(channel))
-         |> assign(:janus_url, "Pending...")
-         |> assign(:janus_hostname, "Pending...")
-         |> assign(:lost_packets, 0)
-         |> assign(:stream_metadata, get_last_stream_metadata(channel.stream))
-         |> assign(:player_error, nil)
-         |> assign(:user, maybe_user)}
+         |> assign(:stream, channel.stream)}
 
       nil ->
         {:ok, redirect(socket, to: "/#{streamer_username}/profile")}
     end
   end
 
-  def handle_info(:load_stream, socket) do
-    case Glimesh.Janus.get_closest_edge_location(socket.assigns.country) do
-      %Glimesh.Janus.EdgeRoute{id: janus_edge_id, url: janus_url, hostname: janus_hostname} ->
-        Presence.track_presence(
-          self(),
-          Streams.get_subscribe_topic(:viewers, socket.assigns.channel.id),
-          socket.assigns.unique_user,
-          %{
-            janus_edge_id: janus_edge_id
-          }
-        )
-
-        Process.send(self(), :remove_packet_warning, [])
-
-        {:noreply,
-         socket
-         |> push_event("load_video", %{
-           janus_url: janus_url,
-           channel_id: socket.assigns.channel.id
-         })
-         |> assign(:janus_url, janus_url)
-         |> assign(:janus_hostname, janus_hostname)}
-
-      _ ->
-        # In the event we can't find an edge, something is real wrong
-        {:noreply,
-         socket
-         |> assign(:player_error, "Unable to find edge video location, we'll be back soon!")}
-    end
-  end
-
-  def handle_info(:remove_packet_warning, socket) do
-    Process.send_after(self(), :remove_packet_warning, 15_000)
-
-    {:noreply, socket |> assign(:player_error, nil)}
-  end
-
-  def handle_info({:channel, channel}, socket) do
-    {:noreply, socket |> assign(:stream, channel.stream)}
-  end
-
-  def handle_event("show_mature", _value, socket) do
-    Process.send(self(), :load_stream, [])
-
-    {:noreply, assign(socket, :prompt_mature, false)}
-  end
-
-  def handle_event("toggle_debug", _value, socket) do
-    if socket.assigns.show_debug === false do
-      # Opening the window
-      {:noreply,
-       socket
-       |> assign(:stream_metadata, get_last_stream_metadata(socket.assigns.stream))
-       |> assign(:show_debug, true)}
-    else
-      {:noreply, assign(socket, :show_debug, false)}
-    end
-  end
-
-  def handle_event("lost_packets", %{"uplink" => _uplink, "lostPackets" => lostPackets}, socket) do
-    message =
-      if lostPackets > 6,
-        do:
-          gettext(
-            "We're detecting some networking problems between you and the streamer. You may experience video drops, jitter, or other issues!"
-          ),
-        else: nil
-
-    {:noreply,
-     socket
-     |> update(:lost_packets, &(&1 + lostPackets))
-     |> assign(:player_error, message)}
-  end
-
-  defp get_stream_thumbnail(channel) do
-    case channel.stream do
-      %Glimesh.Streams.Stream{} = stream ->
-        Glimesh.StreamThumbnail.url({stream.thumbnail, stream}, :original)
-
-      _ ->
-        Glimesh.ChannelPoster.url({channel.poster, channel}, :original)
-    end
-  end
-
-  defp get_last_stream_metadata(%Glimesh.Streams.Stream{} = stream) do
-    case Glimesh.Streams.get_last_stream_metadata(stream) do
-      %Glimesh.Streams.StreamMetadata{} = metadata -> metadata
-      _ -> %Glimesh.Streams.StreamMetadata{stream: stream}
-    end
-  end
-
-  defp get_last_stream_metadata(_) do
-    %Glimesh.Streams.StreamMetadata{}
+  def handle_info(_message, socket) do
+    {:noreply, socket}
   end
 end

--- a/lib/glimesh_web/live/user_live/stream.html.leex
+++ b/lib/glimesh_web/live/user_live/stream.html.leex
@@ -1,166 +1,15 @@
 <div class="container-fluid container-stream">
     <div class="row mt-lg-3">
-
         <div id="video-column" class="col-lg-9 layout-spacing">
-            <div class="card">
-                <div class="card-header p-1">
-                    <div class="row">
-                        <div class="col align-self-center d-block text-truncate">
-                            <%= live_render(@socket, GlimeshWeb.UserLive.Components.ChannelTitle, id: "channel-title", session: %{"user" => @user, "channel_id" => @channel.id}) %>
-                        </div>
-                        <div class="col-auto">
-                            <div class="float-right">
-                                <div class="stream-info btn-toolbar">
-                                    <div class="btn-group mr-1" role="group" aria-label="First group">
-                                        <%= if @can_receive_payments do %>
-                                        <%= live_render(@socket, GlimeshWeb.UserLive.Components.SubscribeButton, id: "subscribe-button", session: %{"user" => @user, "streamer" => @streamer}) %>
-                                        <% end %>
-                                    </div>
-                                    <div class="btn-group mr-1" role="group" aria-label="Second group">
-                                        <%= live_render(@socket, GlimeshWeb.UserLive.Components.FollowButton, id: "follow-button", session: %{"user" => @user, "streamer" => @streamer}) %>
-                                    </div>
-                                    <div class="btn-group" role="group" aria-label="Third group">
-                                        <%= live_render(@socket, GlimeshWeb.UserLive.Components.ViewerCount, id: "viewer-count", session: %{"channel_id" => @channel.id}) %>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <div class="card-body p-0 p-md-1">
-                    <%= if @prompt_mature do %>
-                    <div class="jumbotron jumbotron-fluid jumbotron-mature-content mb-0">
-                        <div class="container p-5">
-                            <div class="row justify-content-center">
-                                <div class="col-sm-6">
-                                    <h3 class="display-5 text-center"><%= gettext("Mature Content Warning") %></h3>
-                                    <p class="lead text-center">
-                                        <%= gettext("The streamer has flagged this channel as only appropriate for Mature Audiences.") %><br>
-                                        <%= gettext("Do you wish to continue?") %>
-                                    </p>
-                                </div>
-                                <div class="w-100"></div>
-                                <div class="col-8 col-lg-3">
-                                    <button type="button" phx-click="show_mature" class="btn btn-primary btn-block"><%= gettext("Agree & View Channel") %></button>
-                                </div>
-                            </div>
-
-                        </div>
-                    </div>
-
-                    <% else %>
-                    <div id="video-container" class="embed-responsive embed-responsive-16by9">
-                        <video id="video-player" class="embed-responsive-item" phx-hook="FtlVideo" controls playsinline poster="<%= @channel_poster %>"></video>
-                        <div id="video-loading-container" class="">
-                            <div class="lds-ring">
-                                <div></div>
-                                <div></div>
-                                <div></div>
-                                <div></div>
-                            </div>
-                        </div>
-                    </div>
-                    <% end %>
-                </div>
-                <div class="card-footer p-1 d-none d-sm-block">
-                    <div class="row">
-                        <div class="col-8 d-inline-flex align-items-center">
-                            <div id="streamer-avatar">
-                                <a href="<%= Routes.user_profile_path(@socket, :index, @channel.user.username) %>">
-                                    <img src="<%= Glimesh.Avatar.url({@channel.user.avatar, @channel.user}, :original)%>" alt="<%= @channel.user.displayname %>" width="48" height="48" class="img-avatar mr-2 float-left <%= if Glimesh.Accounts.can_receive_payments?(@channel.user), do: "img-verified-streamer", else: "" %>">
-                                </a>
-                            </div>
-                            <a title="<%= gettext("View Profile") %>" class="<%= Glimesh.Chat.Effects.get_username_color(@channel.user) %>" href="<%= Routes.user_profile_path(@socket, :index, @channel.user.username) %>">
-                                <h3 class="mb-0"><%= @channel.user.displayname %></h3>
-                            </a>
-
-                            <span class="badge badge-pill badge-info ml-2"><%= Glimesh.Streams.get_channel_language(@channel) %></span>
-                            <%= if @channel.mature_content do %>
-                                <span class="badge badge-pill badge-warning ml-2"><%= gettext("Mature") %></span>
-                            <% end %>
-
-                            <%= live_render(@socket, GlimeshWeb.UserLive.Components.SocialButtons, id: "social-buttons", container: {:ul, class: "list-inline ml-2 mb-0"}, session: %{"user_id" => @streamer.id}) %>
-                        </div>
-                        <div class="col-4 align-self-center">
-                            <div class="float-right mr-sm-2">
-                                <div class="d-inline-block mr-sm-2">
-                                    <a href="#" phx-click="toggle_debug" class="text-color-link <%= if @player_error, do: "text-warning", else: "" %>">
-                                        <i class="fas fa-signal"></i>
-                                        <span class="sr-only">Debug</span>
-                                    </a>
-                                </div>
-                                <div class="d-inline-block">
-                                    <%= live_render(@socket, GlimeshWeb.UserLive.Components.ReportButton, id: "report-button", session: %{"user" => @user, "streamer" => @streamer}) %>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                    <%= if @show_debug do %>
-                    <div id="debugModal" class="live-modal" phx-capture-click="toggle_debug" phx-window-keydown="toggle_debug" phx-key="escape" phx-target="#debugModal" phx-page-loading>
-                        <div class="modal-dialog" role="document">
-                            <div class="modal-content">
-                                <div class="modal-header">
-                                    <h5 class="modal-title"><%= gettext("Debug Information") %></h5>
-                                    <button type="button" class="close" phx-click="toggle_debug" aria-label="Close">
-                                        <span aria-hidden="true">&times;</span>
-                                    </button>
-                                </div>
-
-                                <div class="modal-body">
-                                    <%= if @player_error do %>
-                                    <div class="alert alert-warning" role="alert">
-                                        <%= @player_error %>
-                                    </div>
-                                    <% end %>
-                                    <pre class="px-2">
-== Janus Edge Information ==
-Edge Hostname: <%= @janus_hostname %>
-Edge URL: <%= @janus_url %>
-Reported Lost Packets: <%= @lost_packets %>
-<br>
-== Stream Metadata ==
-# Stream Metadata no longer auto reloads,
-# close & reopen modal to see newest data.
-ingest_server: <%= @stream_metadata.ingest_server %>
-ingest_viewers: <%= @stream_metadata.ingest_viewers %> // unused
-stream_time_seconds: <%= @stream_metadata.stream_time_seconds %>
-
-source_bitrate: <%= @stream_metadata.source_bitrate %>
-source_ping: <%= @stream_metadata.source_ping %> // unused
-
-recv_packets: <%= @stream_metadata.recv_packets %>
-lost_packets: <%= @stream_metadata.lost_packets %> // unused
-nack_packets: <%= @stream_metadata.nack_packets %> // unused
-
-vendor_name: <%= @stream_metadata.vendor_name %>
-vendor_version: <%= @stream_metadata.vendor_version %>
-
-audio_codec: <%= @stream_metadata.audio_codec %>
-video_codec: <%= @stream_metadata.video_codec %>
-video_height: <%= @stream_metadata.video_height %> // unused
-video_width: <%= @stream_metadata.video_width %> // unused
-
-inserted_at: <%= @stream_metadata.inserted_at %>
-updated_at: <%= @stream_metadata.updated_at %>
-</pre>
-                                </div>
-
-                            </div>
-                        </div>
-                    </div>
-                    <% end %>
-                </div>
-            </div>
+            <%= live_render @socket, GlimeshWeb.StreamLive.Video, id: "stream", session: %{"channel_id" => @channel.id, "popped_out" => false} %>
         </div>
-
         <div id="chat-column" class="col-lg-3 d-flex flex-column position-relative layout-spacing">
             <div class="chat-flex">
                 <div class="chat-absolute">
-                    <%= live_render @socket, GlimeshWeb.ChatLive.Index, id: "chat", session: %{"user" => @user, "channel_id" => @channel.id, "popped_out" => false} %>
+                    <%= live_render @socket, GlimeshWeb.ChatLive.Index, id: "chat", session: %{"channel_id" => @channel.id, "popped_out" => false} %>
                 </div>
             </div>
         </div>
-
     </div>
 
     <div class="row">
@@ -190,7 +39,7 @@ updated_at: <%= @stream_metadata.updated_at %>
                     <p>1. <strong>Hate Speech</strong> - Hate Speech is not tolerated by Glimesh under any circumstances. Any
                         message that promotes, encourages, or facilitates discrimination, denigration, objectification, harassment,
                         or violence based on race, age, sexuality, physical characteristics, gender identity, disability, military
-                        service, religion and/or nationality will be considered hate speech is prohibited. We don't allow the use of 
+                        service, religion and/or nationality will be considered hate speech is prohibited. We don't allow the use of
                         hateful slurs of any kind. If you have to question whether your message violates this rule, don't send it.</p>
                     <p>2. <strong>Harassment</strong> - We want you, as a member of our community, to feel safe and respected so
                         you can engage and connect with others. Harassment or bullying of other community members or the streamer

--- a/priv/repo/mocks/streams.exs
+++ b/priv/repo/mocks/streams.exs
@@ -4,8 +4,6 @@ possible_categories = Enum.map(Glimesh.ChannelCategories.list_categories(), fn x
 
 for n <- 1..num_streams do
   category_id = Enum.random(possible_categories)
-  possible_tags = Glimesh.ChannelCategories.list_tags(category_id)
-  tags = Enum.take_random(possible_tags, :rand.uniform(length(possible_tags)))
 
   {:ok, user} =
     Glimesh.Accounts.register_user(%{
@@ -22,8 +20,6 @@ for n <- 1..num_streams do
 
   {:ok, channel} =
     channel
-    |> Glimesh.Repo.preload(:tags)
     |> Ecto.Changeset.change()
-    |> Ecto.Changeset.put_assoc(:tags, tags)
     |> Glimesh.Repo.update()
 end


### PR DESCRIPTION
This PR refactors the stream part of the channel page into its own liveview so it can crash in isolation. This removes alot of the work of `streams.ex` and ensures only catastrophic failures will prevent a liveview from rendering.

This has been tested by killing the process that holds the new streams liveview and the chat liveview doesn't reset state

This will need detailed review and testing
- [ ] Ensure tags still work (cant gen them locally on my end without a bunch of work)
- [ ] Ensure janus debug still works
- [ ] Ensure all stream metadata still works
- [ ] Ensure follows still works
- [ ] Ensure views still works
- [ ] Ensure report still works

This also pulls user lookups from streams.ex into chat and video separately. This causes an additional lookup but since each liveview manages their own state there isn't a good way to do this cleanly besides smashing user into live session.

Other notes:
1. Raiding will likely need additional refactoring similar to this, as almost all liveviews will need to know how to change the channel - when implementing raiding it might be a good idea to think about how data travels between liveviews, or even think of a better way of providing data from a simple context to a less complex set of `live_components` and hydrate these views with only they data they need. (also see note below about refactoring lookup functions)
2. Sessions are packed in some locations, This generally causes sessions in the data-phx-session tag which is consider bad design
![image](https://user-images.githubusercontent.com/5025835/116839688-1fa8f300-ab88-11eb-8c6e-9e3dfeba89fb.png)
It might be worth thinking about how much data other liveviews need, how to refactor functions to use id's instead of entire structs, among other things.
