### PR TITLE
safely recover from janusftl.js non-integer on lost packets

### DIFF
--- a/lib/glimesh_web/live/user_live/stream.ex
+++ b/lib/glimesh_web/live/user_live/stream.ex
@@ -107,9 +107,10 @@ defmodule GlimeshWeb.UserLive.Stream do
     end
   end
 
-  def handle_event("lost_packets", %{"uplink" => _uplink, "lostPackets" => lostPackets}, socket) do
+  def handle_event("lost_packets", %{"uplink" => _uplink, "lostPackets" => lost_packets}, socket)
+      when is_integer(lost_packets) do
     message =
-      if lostPackets > 6,
+      if lost_packets > 6,
         do:
           gettext(
             "We're detecting some networking problems between you and the streamer. You may experience video drops, jitter, or other issues!"
@@ -118,8 +119,12 @@ defmodule GlimeshWeb.UserLive.Stream do
 
     {:noreply,
      socket
-     |> update(:lost_packets, &(&1 + lostPackets))
+     |> update(:lost_packets, &(&1 + lost_packets))
      |> assign(:player_error, message)}
+  end
+
+  def handle_event("lost_packets", _, socket) do
+    {:noreply, socket}
   end
 
   defp get_stream_thumbnail(channel) do

--- a/test/glimesh_web/live/user_live/stream_test.exs
+++ b/test/glimesh_web/live/user_live/stream_test.exs
@@ -86,4 +86,60 @@ defmodule GlimeshWeb.UserLive.StreamTest do
       assert html =~ "https://some-de-server/janus"
     end
   end
+
+  describe "lost packets event" do
+    setup do
+      streamer = streamer_fixture()
+
+      %{
+        channel: streamer.channel,
+        streamer: streamer
+      }
+    end
+
+    test "lost_packets doesnt crash", %{conn: conn, streamer: streamer} do
+      {:ok, view, _} = live(conn, Routes.user_stream_path(conn, :index, streamer.username))
+
+      params = %{
+        "uplink" => "doesnt matter",
+        "lostPackets" => 1
+      }
+
+      render_click(view, "toggle_debug")
+      render_click(view, "lost_packets", params)
+
+      # event = GlimeshWeb.UserLive.Stream.handle_event("lost_packets", params, socket)
+      assert render(view) =~ "lost_packets"
+    end
+
+    test "lost_packets safely recovers from nil", %{conn: conn, streamer: streamer} do
+      {:ok, view, _} = live(conn, Routes.user_stream_path(conn, :index, streamer.username))
+
+      params = %{
+        "uplink" => "doesnt matter",
+        "lostPackets" => nil
+      }
+
+      render_click(view, "toggle_debug")
+      render_click(view, "lost_packets", params)
+
+      # event = GlimeshWeb.UserLive.Stream.handle_event("lost_packets", params, socket)
+      assert render(view) =~ "lost_packets"
+    end
+
+    test "lost_packets safely recovers from garbage", %{conn: conn, streamer: streamer} do
+      {:ok, view, _} = live(conn, Routes.user_stream_path(conn, :index, streamer.username))
+
+      params = %{
+        "uplink" => "doesnt matter",
+        "lostPackets" => <<123, 123, 123, 123, 123, 123>>
+      }
+
+      render_click(view, "toggle_debug")
+      render_click(view, "lost_packets", params)
+
+      # event = GlimeshWeb.UserLive.Stream.handle_event("lost_packets", params, socket)
+      assert render(view) =~ "lost_packets"
+    end
+  end
 end


### PR DESCRIPTION
Handles any case where lost packets might send some bad data and crash the liveview

Not entirely sure if this fixes the issue, but its something that might help :P