### PR TITLE
Maint/speed up GitHub actions

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -1,6 +1,6 @@
 name: Elixir CI
 
-env: 
+env:
   MIX_ENV: test
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -27,7 +27,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    
+
     - name: Set up Elixir
       uses: erlef/setup-elixir@v1
       with:
@@ -36,13 +36,29 @@ jobs:
 
     - name: Restore dependencies cache
       uses: actions/cache@v2
+      id: mix-cache
       with:
         path: deps
         key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
         restore-keys: ${{ runner.os }}-mix-
 
+    - name: Restore build cache
+      uses: actions/cache@v2
+      id: build-cache
+      with:
+        path: _build
+        key: ${{ runner.os }}-build-${{ hashFiles('**/mix.lock') }}
+        restore-keys: ${{ runner.os }}-build-
+
+    - name: Compile Dependencies
+      if: steps.build-cache.outputs.cache-hit != 'true'
+      run: MIX_ENV=test mix compile
+
     - name: Install dependencies
-      run: mix deps.get
+      run: |
+        mix local.rebar --force
+        mix local.hex --force
+        mix deps.get
 
     - name: Start stripe-mock
       run: docker run -d -p 12111-12112:12111-12112 stripemock/stripe-mock && sleep 5


### PR DESCRIPTION
Caching build dependencies makes new builds more efficient on test in actions as it only recompiles things it needs to.
This should improve times once a build is available by around ~2-3m.

I'd also recommend enabling workflow dispatch on your releases action (if you can gate it to only admins) as it allows you to roll back deploys to previous revisions quite easily. It's also very helpful for testing actions - but i'll leave it up to you.

https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/
