### PR TITLE
Ensure we're not accidentally using Elixir 1.12

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Glimesh.MixProject do
     [
       app: :glimesh,
       version: "0.1.0",
-      elixir: "~> 1.7",
+      elixir: "~> 1.11.2",
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: [:phoenix, :gettext] ++ Mix.compilers(),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
By specifiying a revision version, we can allow `1.11.2  | 1.11.3 | 1.11.4` but not `1.12`