### PR TITLE
Small tweaks to the channel statistics page

### DIFF
--- a/lib/glimesh/streams.ex
+++ b/lib/glimesh/streams.ex
@@ -157,7 +157,12 @@ defmodule Glimesh.Streams do
   end
 
   def list_streams(channel) do
-    Repo.all(from s in Glimesh.Streams.Stream, where: s.channel_id == ^channel.id)
+    Repo.all(
+      from s in Glimesh.Streams.Stream,
+        where: s.channel_id == ^channel.id,
+        order_by: [desc: s.started_at]
+    )
+    |> Repo.preload(:category)
   end
 
   @doc """

--- a/lib/glimesh_web/controllers/user_settings_controller.ex
+++ b/lib/glimesh_web/controllers/user_settings_controller.ex
@@ -4,7 +4,6 @@ defmodule GlimeshWeb.UserSettingsController do
   alias Glimesh.Accounts
   alias Glimesh.ChannelCategories
   alias Glimesh.ChannelLookups
-  alias Glimesh.ChannelStatistics
   alias Glimesh.Streams
   alias GlimeshWeb.UserAuth
 

--- a/lib/glimesh_web/live/user_settings/components/channel_statistics_live.ex
+++ b/lib/glimesh_web/live/user_settings/components/channel_statistics_live.ex
@@ -11,6 +11,7 @@ defmodule GlimeshWeb.UserSettings.Components.ChannelStatisticsLive do
       %Glimesh.Streams.Channel{} = channel ->
         {:ok,
          socket
+         |> assign(:streams, Glimesh.Streams.list_streams(channel))
          |> assign(:channel, channel)}
 
       nil ->

--- a/lib/glimesh_web/live/user_settings/components/channel_statistics_live.html.leex
+++ b/lib/glimesh_web/live/user_settings/components/channel_statistics_live.html.leex
@@ -1,26 +1,26 @@
 <div class="card">
-	<div class="alert alert-info" role="alert">
-            <strong><%= gettext("Early Feature Alert!") %></strong> Hey there! Channel Statistics are a new feature still under heavy development. We're continually building this new feature, and we'd love your opinion on how we should do it. Thank you!
+    <div class="alert alert-info" role="alert">
+        <strong><%= gettext("Early Feature Alert!") %></strong> Hey there! Channel Statistics are a new feature still under heavy development. We're continually building this new feature, and we'd love your opinion on how we should do it. Thank you!
     </div>
-    
-	<table class="table">
-		<thead>
-			<tr>
-				<th><%= gettext("Stream title") %></th>
-				<th><%= gettext("Stream started") %></th>
-				<th><%= gettext("Stream ended") %></th>
-				<th><%= gettext("Category") %></th>
-				<th><%= gettext("Viewers") %></th>
-			</tr>
-		</thead>
-		<%= for stream <- Glimesh.Streams.list_streams(@channel) do %>
-			<tr>
-				<td><%= stream.title %></td>
-				<td><%= stream.started_at %></td>
-				<td><%= stream.ended_at %></td>
-				<td>ID: <%= stream.category_id %></td>
-				<td><%= stream.count_viewers %></td>
-			</tr>
-		<% end %>
-	</table>
+
+    <table class="table">
+        <thead>
+            <tr>
+                <th><%= gettext("Stream title") %></th>
+                <th><%= gettext("Stream started") %></th>
+                <th><%= gettext("Stream ended") %></th>
+                <th><%= gettext("Category") %></th>
+                <th><%= gettext("Peak Viewers") %></th>
+            </tr>
+        </thead>
+        <%= for stream <- @streams do %>
+        <tr>
+            <td><%= stream.title %></td>
+            <td><%= stream.started_at %></td>
+            <td><%= stream.ended_at %></td>
+            <td><%= stream.category.name %></td>
+            <td><%= stream.peak_viewers %></td>
+        </tr>
+        <% end %>
+    </table>
 </div>


### PR DESCRIPTION
1. Sorting the table by the newest streams first
2. Adding the category name to the display
3. Reformatting the HTML template
4. Removing the Elixir function call from the HTML template