### PR TITLE
Add option for only showing recent chat messages in chat

### DIFF
--- a/lib/glimesh/api/schema/channel_types.ex
+++ b/lib/glimesh/api/schema/channel_types.ex
@@ -227,6 +227,8 @@ defmodule Glimesh.Api.ChannelTypes do
 
     field :show_on_homepage, :boolean, description: "Toggle for homepage visibility"
 
+    field :show_recent_chat_messages_only, :boolean
+
     field :disable_hyperlinks, :boolean,
       description: "Toggle for links automatically being clickable"
 

--- a/lib/glimesh/chat.ex
+++ b/lib/glimesh/chat.ex
@@ -187,6 +187,26 @@ defmodule Glimesh.Chat do
 
   """
   def list_chat_messages(channel, limit \\ 5) do
+    Repo.all(
+      from m in ChatMessage,
+        where: m.is_visible == true and m.channel_id == ^channel.id,
+        order_by: [desc: :inserted_at],
+        limit: ^limit
+    )
+    |> Repo.preload([:user, :channel])
+    |> Enum.reverse()
+  end
+
+  @doc """
+  Returns only recent chat messages.
+
+  ## Examples
+
+      iex> list_recent_chat_messages()
+      [%ChatMessage{}, ...]
+
+  """
+  def list_recent_chat_messages(channel, limit \\ 5) do
     timeframe = NaiveDateTime.add(NaiveDateTime.utc_now(), -(60 * 60), :second)
 
     Repo.all(

--- a/lib/glimesh/chat.ex
+++ b/lib/glimesh/chat.ex
@@ -187,9 +187,14 @@ defmodule Glimesh.Chat do
 
   """
   def list_chat_messages(channel, limit \\ 5) do
+    timeframe = NaiveDateTime.add(NaiveDateTime.utc_now(), -(60 * 60), :second)
+
     Repo.all(
       from m in ChatMessage,
-        where: m.is_visible == true and m.channel_id == ^channel.id,
+        where:
+          m.is_visible == true and
+            m.channel_id == ^channel.id and
+            m.inserted_at >= ^timeframe,
         order_by: [desc: :inserted_at],
         limit: ^limit
     )

--- a/lib/glimesh/community_team.ex
+++ b/lib/glimesh/community_team.ex
@@ -118,6 +118,8 @@ defmodule Glimesh.CommunityTeam do
     _fancy_string = """
     Title changed from #{channel.title} to #{channel_params["title"]}
     Category changed from #{channel.category_id} to #{channel_params["category_id"]}
+    Show recent chat messages only changed from #{channel.show_recent_chat_messages_only} to #{channel_params["show_recent_chat_messages_only"]}
+    Show on homepage changed from #{channel.show_on_homepage} to #{channel_params["show_on_homepage"]}
     Disable hyperlinks changed from #{channel.disable_hyperlinks} to #{channel_params["disable_hyperlinks"]}
     Block links changed from #{channel.block_links} to #{channel_params["block_links"]}
     """

--- a/lib/glimesh/graphql/schema/channel_types.ex
+++ b/lib/glimesh/graphql/schema/channel_types.ex
@@ -220,6 +220,7 @@ defmodule Glimesh.Schema.ChannelTypes do
     field :chat_rules_md, :string
     field :chat_rules_html, :string
 
+    field :show_recent_chat_messages_only, :boolean
     field :disable_hyperlinks, :boolean
     field :block_links, :boolean
     field :require_confirmed_email, :boolean

--- a/lib/glimesh/streams/channel.ex
+++ b/lib/glimesh/streams/channel.ex
@@ -27,6 +27,8 @@ defmodule Glimesh.Streams.Channel do
     field :require_confirmed_email, :boolean, default: false
     field :minimum_account_age, :integer, default: 0
 
+    field :show_recent_chat_messages_only, :boolean, default: false
+
     field :chat_rules_md, :string
     field :chat_rules_html, :string
 
@@ -85,6 +87,7 @@ defmodule Glimesh.Streams.Channel do
       :chat_rules_md,
       :inaccessible,
       :status,
+      :show_recent_chat_messages_only,
       :disable_hyperlinks,
       :block_links,
       :require_confirmed_email,

--- a/lib/glimesh_web/live/chat_live/index.ex
+++ b/lib/glimesh_web/live/chat_live/index.ex
@@ -9,6 +9,7 @@ defmodule GlimeshWeb.ChatLive.Index do
   alias Glimesh.Chat.ChatMessage
   alias Glimesh.Presence
   alias Glimesh.Streams
+  alias Glimesh.Streams.Channel
 
   @impl true
   def mount(_params, %{"channel_id" => channel_id} = session, socket) do
@@ -187,6 +188,10 @@ defmodule GlimeshWeb.ChatLive.Index do
   @impl true
   def handle_info({:message_deleted, message_id}, socket) do
     {:noreply, push_event(socket, "remove_deleted_message", %{message_id: message_id})}
+  end
+
+  defp list_chat_messages(%Channel{show_recent_chat_messages_only: true} = channel) do
+    Chat.list_recent_chat_messages(channel)
   end
 
   defp list_chat_messages(channel) do

--- a/lib/glimesh_web/live/user_settings/components/channel_settings_live.html.leex
+++ b/lib/glimesh_web/live/user_settings/components/channel_settings_live.html.leex
@@ -146,32 +146,38 @@
     <div class="col-sm-6">
         <div class="form-group">
             <%= label f, gettext("Chat Rules (Markdown Supported)") %>
-                <markdown-toolbar for="chatRules_edit" phx-update="ignore">
-                    <div class="d-inline-flex mb-2">
-                         <div class="pr-3">
-                            <md-bold class="fas fa-bold fa-2x" data-toggle="tooltip" data-placement="top" title=<%= gettext("Bold") %>></md-bold>
-                            <md-italic class="fas fa-italic fa-2x" data-toggle="tooltip" data-placement="top" title=<%= gettext("Italic") %>></md-italic>
-                            <md-header class="fas fa-heading fa-2x" data-toggle="tooltip" data-placement="top" title=<%= gettext("Heading") %>></md-header>
-                        </div>
-                        <div class="pr-3 pl-3">
-                            <md-quote class="fas fa-quote-right fa-2x" data-toggle="tooltip" data-placement="top" title=<%= gettext("Quote") %>></md-quote>
-                            <md-code class="fas fa-code fa-2x" data-toggle="tooltip" data-placement="top" title=<%= gettext("Code") %>></md-code>
-                            <md-link class="fas fa-link fa-2x" data-toggle="tooltip" data-placement="top" title=<%= gettext("Link") %>></md-link>
-                            <md-image class="fas fa-image fa-2x" data-toggle="tooltip" data-placement="top" title=<%= gettext("Image") %>></md-image>
-                        </div>
-                        <div class="pr-3 pl-3">
-                            <md-unordered-list class="fas fa-list-ul fa-2x" data-toggle="tooltip" data-placement="top" title=<%= gettext("Unordered List") %>>
-                                </md-unordered-list>
-                            <md-ordered-list class="fas fa-list-ol fa-2x" data-toggle="tooltip" data-placement="top" title=<%= gettext("Ordered List") %>>
-                                </md-ordered-list>
-                        </div>
+            <markdown-toolbar for="chatRules_edit" phx-update="ignore">
+                <div class="d-inline-flex mb-2">
+                    <div class="pr-3">
+                        <md-bold class="fas fa-bold fa-2x" data-toggle="tooltip" data-placement="top" title=<%= gettext("Bold") %>></md-bold>
+                        <md-italic class="fas fa-italic fa-2x" data-toggle="tooltip" data-placement="top" title=<%= gettext("Italic") %>></md-italic>
+                        <md-header class="fas fa-heading fa-2x" data-toggle="tooltip" data-placement="top" title=<%= gettext("Heading") %>></md-header>
                     </div>
-                </markdown-toolbar>
+                    <div class="pr-3 pl-3">
+                        <md-quote class="fas fa-quote-right fa-2x" data-toggle="tooltip" data-placement="top" title=<%= gettext("Quote") %>></md-quote>
+                        <md-code class="fas fa-code fa-2x" data-toggle="tooltip" data-placement="top" title=<%= gettext("Code") %>></md-code>
+                        <md-link class="fas fa-link fa-2x" data-toggle="tooltip" data-placement="top" title=<%= gettext("Link") %>></md-link>
+                        <md-image class="fas fa-image fa-2x" data-toggle="tooltip" data-placement="top" title=<%= gettext("Image") %>></md-image>
+                    </div>
+                    <div class="pr-3 pl-3">
+                        <md-unordered-list class="fas fa-list-ul fa-2x" data-toggle="tooltip" data-placement="top" title=<%= gettext("Unordered List") %>>
+                        </md-unordered-list>
+                        <md-ordered-list class="fas fa-list-ol fa-2x" data-toggle="tooltip" data-placement="top" title=<%= gettext("Ordered List") %>>
+                        </md-ordered-list>
+                    </div>
+                </div>
+            </markdown-toolbar>
             <%= textarea f, :chat_rules_md, [class: "form-control mb-4", rows: 20, id: "chatRules_edit"] %>
             <%= error_tag f, :chat_rules_md %>
         </div>
     </div>
     <div class="col-sm-6">
+        <div class="form-group">
+            <%= label f, :show_recent_chat_messages_only, gettext("Show recent chat messages only?") %>
+            <%= select f, :show_recent_chat_messages_only, [Yes: true, No: false], [class: "form-control"] %>
+            <small class="form-text text-muted"><%= gettext("If yes, chat will only show 5 messages posted in the last 60 minutes when a new viewer joins.") %></small>
+            <%= error_tag f, :show_recent_chat_messages_only %>
+        </div>
         <div class="form-group">
             <%= label f, :disable_hyperlinks, gettext("Should links automatically be clickable?") %>
             <%= select f, :disable_hyperlinks, [Yes: false, No: true], [class: "form-control", disabled: @channel.block_links] %>

--- a/lib/glimesh_web/templates/gct/lookup_channel.html.eex
+++ b/lib/glimesh_web/templates/gct/lookup_channel.html.eex
@@ -25,6 +25,7 @@
                         <p><%= gettext("Backend: %{value}", value: @channel.backend ) %></p>
                         <p><%= gettext("Disabled hyperlinks: %{value}", value: @channel.disable_hyperlinks ) %></p>
                         <p><%= gettext("Blocked links: %{value}", value: @channel.block_links ) %></p>
+                        <p><%= gettext("Show on homepage: %{value}", value: @channel.show_on_homepage ) %></p>
                     </div>
                 </div>
                 <div class="col-md-8">

--- a/priv/repo/migrations/20210705023653_add_show_recent_historical_chat_messages_to_channel.exs
+++ b/priv/repo/migrations/20210705023653_add_show_recent_historical_chat_messages_to_channel.exs
@@ -1,0 +1,9 @@
+defmodule Glimesh.Repo.Migrations.AddShowRecentHistoricalChatMessagesToChannel do
+  use Ecto.Migration
+
+  def change do
+    alter table(:channels) do
+      add :show_recent_chat_messages_only, :boolean, default: false
+    end
+  end
+end

--- a/test/glimesh/chat_test.exs
+++ b/test/glimesh/chat_test.exs
@@ -59,6 +59,11 @@ defmodule Glimesh.ChatTest do
       assert length(Chat.list_chat_messages(chat_message.channel)) == 1
     end
 
+    test "list_recent_chat_messages/0 returns all recent chat_messages" do
+      chat_message = chat_message_fixture()
+      assert length(Chat.list_recent_chat_messages(chat_message.channel)) == 1
+    end
+
     test "list_chat_messages/2 returns all chat_messages within the specified limit" do
       chat_message = multiple_chat_message_fixture()
       assert length(Chat.list_chat_messages(chat_message.channel, 8)) == 8


### PR DESCRIPTION
Following off of https://github.com/Glimesh/glimesh.tv/pull/578

This PR adds a flag on the channel settings page that allows the user to either:
a) Show the 5 most recent chat messages (Default)
b) Show the 5 most recent chat messages in the last 60 minutes

The idea being that users can select what they are comfortable with, instead of us forcing a new normal.

![image](https://user-images.githubusercontent.com/226638/124411929-78794100-dd1b-11eb-83b3-8b219d7deff9.png)
