### PR TITLE
Add discord link on packet loss message

### DIFF
--- a/lib/glimesh_web/live/user_live/stream.ex
+++ b/lib/glimesh_web/live/user_live/stream.ex
@@ -111,15 +111,15 @@ defmodule GlimeshWeb.UserLive.Stream do
     message =
       if lost_packets > 6,
         do:
-          gettext(
-            "We're detecting some networking problems between you and the streamer. You may experience video drops, jitter, or other issues!"
-          ),
+        gettext(
+          "We're detecting some networking problems between you and the streamer. You may experience video drops, jitter, or other issues! If this continues, the streamer is recommended to submit a ticket in #streaming-help in our <a href=\"https://discord.gg/Glimesh\">Discord</a> server."
+        ),
         else: nil
 
     {:noreply,
      socket
      |> update(:lost_packets, &(&1 + lost_packets))
-     |> assign(:player_error, message)}
+     |> assign(:player_error, Phoenix.HTML.raw(message))}
   end
 
   def handle_event("lost_packets", _, socket) do

--- a/lib/glimesh_web/live/user_live/stream.ex
+++ b/lib/glimesh_web/live/user_live/stream.ex
@@ -112,9 +112,8 @@ defmodule GlimeshWeb.UserLive.Stream do
       if lost_packets > 6,
         do:
         gettext(
-          "We're detecting some networking problems between you and the streamer. You may experience video drops, jitter, or other issues! If this continues, the streamer is recommended to submit a ticket in #streaming-help in our"
-        ) <> " <a href=\"https://discord.gg/Glimesh\">Discord</a>."
-        |> Phoenix.HTML.raw(),
+          "We're detecting some networking problems between you and the streamer. You may experience video drops, jitter, or other issues! If this continues, the streamer is recommended to submit a ticket in #streaming-help in our Discord."
+        ),
         else: nil
 
     {:noreply,

--- a/lib/glimesh_web/live/user_live/stream.ex
+++ b/lib/glimesh_web/live/user_live/stream.ex
@@ -112,14 +112,15 @@ defmodule GlimeshWeb.UserLive.Stream do
       if lost_packets > 6,
         do:
         gettext(
-          "We're detecting some networking problems between you and the streamer. You may experience video drops, jitter, or other issues! If this continues, the streamer is recommended to submit a ticket in #streaming-help in our <a href=\"https://discord.gg/Glimesh\">Discord</a> server."
-        ),
+          "We're detecting some networking problems between you and the streamer. You may experience video drops, jitter, or other issues! If this continues, the streamer is recommended to submit a ticket in #streaming-help in our"
+        ) <> " <a href=\"https://discord.gg/Glimesh\">Discord</a>."
+        |> Phoenix.HTML.raw(),
         else: nil
 
     {:noreply,
      socket
      |> update(:lost_packets, &(&1 + lost_packets))
-     |> assign(:player_error, Phoenix.HTML.raw(message))}
+     |> assign(:player_error, message)}
   end
 
   def handle_event("lost_packets", _, socket) do

--- a/lib/glimesh_web/live/user_live/stream.html.leex
+++ b/lib/glimesh_web/live/user_live/stream.html.leex
@@ -104,6 +104,7 @@
                                     <%= if @player_error do %>
                                     <div class="alert alert-warning" role="alert">
                                         <%= @player_error %>
+                                        <a class="btn btn-primary mt-2" href="https://discord.gg/Glimesh">Join our Discord!</a>
                                     </div>
                                     <% end %>
                                     <pre class="px-2">


### PR DESCRIPTION
PR adds a link to the discord if there is packet loss.

I don't know if this is the best way to do it, but Phoenix.html.raw was the only way that I found to add an html tag. If there is a better way to do it let me know and I'll change it. 

Adds #720 