### PR TITLE
Add Guilded to socials + Accessibility improvements

### DIFF
--- a/assets/css/glimesh/components/footer.scss
+++ b/assets/css/glimesh/components/footer.scss
@@ -12,11 +12,11 @@
 }
 
 .footer-social .btn-default .fab {
-    font-size: 2rem;
+    font-size: 1.75rem;
 }
 
 .footer-social .btn-default:hover {
-    color: var(--secondary-color);
+    color: #0056b3;
 }
 
 .footer-main {

--- a/lib/glimesh_web/templates/layout/root.html.leex
+++ b/lib/glimesh_web/templates/layout/root.html.leex
@@ -111,15 +111,16 @@
             </div>
         </section>
 
-        <section class="footer-social pt-2 pb-2">
+        <section class="footer-social pt-2 pb-1">
             <div class="container">
                 <div class="btn-group btn-block" role="group" aria-label="Glimesh Socials">
-                    <a href="https://twitter.com/Glimesh" class="btn btn-default"><i class="fab fa-twitter-square"></i></a>
-                    <a href="https://discord.gg/Glimesh" class="btn btn-default"><i class="fab fa-discord"></i></a>
-                    <a href="https://facebook.com/Glimesh" class="btn btn-default"><i class="fab fa-facebook-square"></i></a>
-                    <a href="https://instagram.com/Glimesh" class="btn btn-default"><i class="fab fa-instagram-square"></i></a>
-                    <a href="https://reddit.com/r/Glimesh" class="btn btn-default"><i class="fab fa-reddit-square"></i></a>
-                    <a href="https://github.com/Glimesh" class="btn btn-default"><i class="fab fa-github-square"></i></a>
+                    <a href="https://twitter.com/Glimesh" class="btn btn-default" target="_blank" title="Twitter"><i class="fab fa-twitter-square"></i></a>
+                    <a href="https://discord.gg/Glimesh" class="btn btn-default" target="_blank" title="Discord"><i class="fab fa-discord"></i></a>
+                    <a href="https://www.guilded.gg/Glimesh" class="btn btn-default" target="_blank" title="Guilded"><i class="fab fa-guilded"></i></a>
+                    <a href="https://facebook.com/Glimesh" class="btn btn-default" target="_blank" title="Facebook"><i class="fab fa-facebook-square"></i></a>
+                    <a href="https://instagram.com/Glimesh" class="btn btn-default" target="_blank" title="Instagram"><i class="fab fa-instagram"></i></a>
+                    <a href="https://reddit.com/r/Glimesh" class="btn btn-default" target="_blank" title="Reddit"><i class="fab fa-reddit"></i></a>
+                    <a href="https://github.com/Glimesh" class="btn btn-default" target="_blank" title="GitHub"><i class="fab fa-github"></i></a>
                 </div>
             </div>
         </section>


### PR DESCRIPTION
Nekron recently suggested that we add the Glimesh Guilded server link to social footer. Kinda been overlooked (sorry to folks who use and enjoy Guilded). In addition to Guilded link, titles and targets were missing in original footer rework.

![image](https://user-images.githubusercontent.com/1784580/125017994-0cebe800-e029-11eb-9a0c-c268f99498c0.png)
"Desktop" view

![image](https://user-images.githubusercontent.com/1784580/125018153-60f6cc80-e029-11eb-84fa-8d47633b1a69.png)
"Mobile" view