### PR TITLE
Fixing banned users from showing on the profile lists

### DIFF
--- a/lib/glimesh/account_follows.ex
+++ b/lib/glimesh/account_follows.ex
@@ -126,6 +126,7 @@ defmodule Glimesh.AccountFollows do
     Repo.all(
       from f in Follower,
         where: f.user_id == ^streamer.id,
+        where: u.is_banned == false,
         offset: ^((current_page - 1) * per_page),
         limit: ^per_page,
         preload: [:streamer]
@@ -136,6 +137,7 @@ defmodule Glimesh.AccountFollows do
     Repo.all(
       from f in Follower,
         where: f.streamer_id == ^streamer.id,
+        where: u.is_banned == false,
         offset: ^((current_page - 1) * per_page),
         limit: ^per_page,
         preload: [:user]


### PR DESCRIPTION
Currently banned users will show on the `profile/following` and `profile/follower` pages due to a forgotten `where` statement. This PR adds that statement. 