### PR TITLE
GCT global chat message perms

### DIFF
--- a/lib/glimesh/chat/policy.ex
+++ b/lib/glimesh/chat/policy.ex
@@ -81,7 +81,7 @@ defmodule Glimesh.Chat.Policy do
   def authorize(:unban, %User{is_gct: true}, _channel), do: true
   def authorize(:short_timeout, %User{is_gct: true}, _channel), do: true
   def authorize(:long_timeout, %User{is_gct: true}, _channel), do: true
-  def authorize(:delete, %User{is_fct: true}, _channel), do: true
+  def authorize(:delete, %User{is_gct: true}, _channel), do: true
 
   # Channel Owners
   def authorize(:ban, %User{id: user_id}, %Channel{user_id: channel_user_id})

--- a/lib/glimesh/chat/policy.ex
+++ b/lib/glimesh/chat/policy.ex
@@ -75,6 +75,13 @@ defmodule Glimesh.Chat.Policy do
   def authorize(:short_timeout, %User{is_admin: true}, _channel), do: true
   def authorize(:long_timeout, %User{is_admin: true}, _channel), do: true
   def authorize(:delete, %User{is_admin: true}, _channel), do: true
+  
+  # GCT
+  def authorize(:ban, %User{is_gct: true}, _channel), do: true
+  def authorize(:unban, %User{is_gct: true}, _channel), do: true
+  def authorize(:short_timeout, %User{is_gct: true}, _channel), do: true
+  def authorize(:long_timeout, %User{is_gct: true}, _channel), do: true
+  def authorize(:delete, %User{is_fct: true}, _channel), do: true
 
   # Channel Owners
   def authorize(:ban, %User{id: user_id}, %Channel{user_id: channel_user_id})


### PR DESCRIPTION
Apparently, the GCT was previously unable to delete/time-out/ban in other people's chats without being appointed as a moderator. This fixes tha.t 