### PR TITLE
Develop a hosting feature so streamers can recommend other channels to their community when they are offline. 

### DIFF
--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -58,8 +58,10 @@ $fa-font-path: "/fa-fonts";
 @import "glimesh/components/follow-button";
 @import "glimesh/components/apex-charts";
 @import "glimesh/components/video";
+@import "glimesh/components/channel-lookup-typeahead";
 
 @import "glimesh/pages/dmca";
+@import "glimesh/pages/hosting.scss";
 
 @include media-breakpoint-up(lg) {
     .layout-spacing {

--- a/assets/css/glimesh/components/channel-lookup-typeahead.scss
+++ b/assets/css/glimesh/components/channel-lookup-typeahead.scss
@@ -1,0 +1,40 @@
+@mixin show-dropdown {
+  z-index: 9999;
+  display: block;
+  max-height: 250px;
+  overflow: auto;
+}
+
+.channel-typeahead {
+    position: relative;
+    &-dropdown {
+      display: none;
+      position: absolute;
+      top: 100%;
+      left: 0;
+      width: 100%;
+      margin-top: -2px;
+      > .list-group-item {
+        display: flex;
+        align-items: center;
+        padding: 12px 15px;
+        margin: 0;
+        opacity: 100;
+        &:hover {
+            background: blue;
+            cursor: pointer;
+        }
+      }
+      &:hover {
+        @include show-dropdown;
+      }
+  }
+    &-input {
+      position: relative;
+      &:focus {
+        + .channel-typeahead-dropdown {
+          @include show-dropdown;
+        }
+      }
+    }
+}

--- a/assets/css/glimesh/pages/hosting.scss
+++ b/assets/css/glimesh/pages/hosting.scss
@@ -1,0 +1,14 @@
+.fixed-header-table {
+    table {
+        text-align: left;
+        position: relative;
+        border-collapse: collapse; 
+    }
+    th, td {
+        padding: 0.25rem;
+    }
+    th {
+        position: sticky;
+        top: 0; /* Don't forget this, required for the stickiness */
+    }
+}

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -15,6 +15,7 @@ import InfiniteScroll from "./hooks/InfiniteScroll";
 import TagSearch from "./hooks/TagSearch";
 import LaunchCountdown from "./hooks/LaunchCountdown";
 import Tagify from "./hooks/Tagify";
+import ChannelLookupTypeahead from "./hooks/ChannelLookupTypeahead";
 
 // https://github.com/github/markdown-toolbar-element
 import "@github/markdown-toolbar-element";
@@ -33,6 +34,7 @@ Hooks.InfiniteScroll = InfiniteScroll;
 Hooks.TagSearch = TagSearch;
 Hooks.LaunchCountdown = LaunchCountdown;
 Hooks.Tagify = Tagify;
+Hooks.ChannelLookupTypeahead = ChannelLookupTypeahead;
 
 let csrfToken = document.querySelector("meta[name='csrf-token']").getAttribute("content");
 let liveSocket = new LiveSocket("/live", Socket, {

--- a/assets/js/hooks/ChannelLookupTypeahead.js
+++ b/assets/js/hooks/ChannelLookupTypeahead.js
@@ -1,0 +1,11 @@
+export default {
+    mounted() {
+        this.el.addEventListener("click", e => {
+            let userId = this.el.getAttribute('data-id');
+            let userName = this.el.getAttribute('data-name');
+            let fieldName = this.el.getAttribute('data-fieldname');
+            let channelId = this.el.getAttribute('data-channel-id');
+            this.pushEvent(fieldName + "_selection_made", {"user_id": userId, "username": userName, "channel_id": channelId});
+        });
+    }
+}

--- a/lib/glimesh/accounts.ex
+++ b/lib/glimesh/accounts.ex
@@ -656,4 +656,8 @@ defmodule Glimesh.Accounts do
        valid?: false
      }}
   end
+
+  def get_account_age_in_days(%User{} = user) do
+    NaiveDateTime.diff(NaiveDateTime.utc_now(), user.inserted_at, :second) / 86_400
+  end
 end

--- a/lib/glimesh/channel_hosts_lookups.ex
+++ b/lib/glimesh/channel_hosts_lookups.ex
@@ -46,8 +46,9 @@ defmodule Glimesh.ChannelHostsLookups do
       set status = 'ready'\
       where id in\
       (select ch.id from channel_hosts as ch\
-       inner join channels as c on ch.target_channel_id = c.id\
-       where c.status != 'live'\
+       inner join channels as tc on ch.target_channel_id = tc.id\
+       inner join channels as hc on ch.hosting_channel_id = hc.id\
+       where (tc.status != 'live' or hc.status = 'live')\
        and ch.status = 'hosting')\
       returning id\
     """

--- a/lib/glimesh/channel_hosts_lookups.ex
+++ b/lib/glimesh/channel_hosts_lookups.ex
@@ -1,0 +1,138 @@
+defmodule Glimesh.ChannelHostsLookups do
+  @moduledoc """
+  Channel Hosting lookups
+  """
+
+  import Ecto.Query, warn: false
+
+  alias Glimesh.ChannelLookups
+  alias Glimesh.Repo
+  alias Glimesh.Streams.ChannelHosts
+
+  def get_channel_hosting_list(channel_id) do
+    ChannelHosts
+    |> where([ch], ch.hosting_channel_id == ^channel_id)
+    |> preload(host: [:user], target: [:user])
+    |> Repo.all()
+  end
+
+  def get_current_hosting_target(channel) do
+    ChannelHosts
+    |> where([ch], ch.hosting_channel_id == ^channel.id and ch.status == "hosting")
+    |> limit(1)
+    |> preload(host: [:user], target: [:user])
+    |> Repo.one()
+  end
+
+  def get_targets_host_info(host_username, target_channel) do
+    host = ChannelLookups.get_channel_for_username(host_username)
+
+    ChannelHosts
+    |> where(
+      [ch],
+      ch.hosting_channel_id == ^host.id and ch.status == "hosting" and
+        ch.target_channel_id == ^target_channel.id
+    )
+    |> preload(host: [:user], target: [:user])
+    |> Repo.one()
+  end
+
+  @doc """
+   Used by Auto Host Job -- find channels that are being hosted but are no longer live and reset them to "ready" state
+  """
+  def unhost_channels_not_live do
+    sql = """
+      update channel_hosts\
+      set status = 'ready'\
+      where id in\
+      (select ch.id from channel_hosts as ch\
+       inner join channels as c on ch.target_channel_id = c.id\
+       where c.status != 'live'\
+       and ch.status = 'hosting')\
+      returning id\
+    """
+
+    Repo.query(sql)
+  end
+
+  @doc """
+   Used by Auto Host Job -- find channels that are no longer eligible for hosting by the current host and set them to "error" state
+  """
+  def invalidate_hosting_channels_where_necessary do
+    sql = """
+      update channel_hosts\
+      set status = 'error'\
+      where id in\
+      (select ch.id from channel_hosts as ch\
+       inner join channels as tc on ch.target_channel_id = tc.id\
+       inner join users as tu on tc.user_id = tu.id\
+       inner join channels as hc on ch.hosting_channel_id = hc.id\
+       inner join users as hu on hc.user_id = hu.id\
+       where ch.status != 'error'\
+       and (tc.allow_hosting = 'false'\
+       or tc.inaccessible = 'true'\
+       or tu.is_banned = 'true'\
+       or tu.can_stream = 'false'\
+       or exists(select user_id from channel_bans where user_id = hc.user_id and channel_id = tc.id and expires_at is null)\
+       or hu.is_banned = 'true'\
+       or hu.can_stream = 'false'\
+       or hc.inaccessible = 'true'))\
+      returning id\
+    """
+
+    Repo.query(sql)
+  end
+
+  @doc """
+   Used by Auto Host Job -- find channels that are live with hosted channels that aren't live and host them!
+   This will only affect channel_hosts table records in "ready" state -- it is assumed that invalidate_hosting_channels_where_necessary()
+   and unhost_channels_not_live() have updated the channel_hosts table record states appropriately.
+  """
+  def host_some_channels do
+    now = NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
+
+    sql = """
+      update channel_hosts\
+      set status = 'hosting', last_hosted_date = $1\
+      where id in\
+        (select distinct on(ch_sub.hosting_channel_id) ch_sub.id\
+        from channel_hosts as ch_sub\
+        inner join channels as tc on ch_sub.target_channel_id = tc.id\
+        inner join channels as hc on ch_sub.hosting_channel_id = hc.id\
+        where ch_sub.status = 'ready'\
+        and hc.status = 'offline'\
+        and tc.status = 'live'\
+        and not exists(select true from channel_hosts where status = 'hosting' and hosting_channel_id = ch_sub.hosting_channel_id)\
+        group by ch_sub.id\
+        order by ch_sub.hosting_channel_id asc, min(coalesce(ch_sub.last_hosted_date, to_timestamp(0))) asc)\
+      returning id\
+    """
+
+    Repo.query(sql, [now])
+  end
+
+  def recheck_error_status_channels do
+    sql = """
+      update channel_hosts\
+      set status = 'ready'\
+      where id in\
+      (select ch.id from channel_hosts as ch\
+       inner join channels as tc on ch.target_channel_id = tc.id\
+       inner join users as tu on tc.user_id = tu.id\
+       inner join channels as hc on ch.hosting_channel_id = hc.id\
+       inner join users as hu on hc.user_id = hu.id\
+       where ch.status = 'error'\
+       and tc.allow_hosting = 'true'\
+       and tc.inaccessible = 'false'\
+       and tu.is_banned = 'false'\
+       and tu.can_stream = 'true'\
+       and not exists(select user_id from channel_bans where user_id = hc.user_id and channel_id = tc.id and expires_at is null)\
+       and hu.is_banned = 'false'\
+       and hu.can_stream = 'true'\
+       and hc.inaccessible = 'false')\
+      returning id\
+    """
+
+    Repo.query(sql)
+  end
+end

--- a/lib/glimesh/jobs/auto_host_cron.ex
+++ b/lib/glimesh/jobs/auto_host_cron.ex
@@ -1,0 +1,63 @@
+defmodule Glimesh.Jobs.AutoHostCron do
+  @moduledoc false
+  @behaviour Rihanna.Job
+
+  require Logger
+
+  alias Glimesh.ChannelHostsLookups
+
+  # 10 Minutes
+  @interval 600_000
+
+  def perform(_) do
+    Logger.info("Starting Auto-Host runner")
+    start = NaiveDateTime.utc_now()
+
+    case ChannelHostsLookups.recheck_error_status_channels() do
+      {:ok, %{rows: _, num_rows: num}} ->
+        Logger.info(
+          "Auto-Host runner - Changed #{num} of entries from errored back to ready for hosting targets."
+        )
+
+      {:error, _} ->
+        Logger.error("Auto-Host runner - failed to recheck hosting targets that are in error.")
+    end
+
+    case ChannelHostsLookups.unhost_channels_not_live() do
+      {:ok, %{rows: _, num_rows: num}} ->
+        Logger.info("Auto-Host runner - Un-hosted #{num} of entries for channels no longer live.")
+
+      {:error, _} ->
+        Logger.error("Auto-Host runner - failed to un-host channels no longer live.")
+    end
+
+    case ChannelHostsLookups.invalidate_hosting_channels_where_necessary() do
+      {:ok, %{rows: _, num_rows: num}} ->
+        Logger.info(
+          "Auto-Host runner - invalidated #{num} of entries for host/target pairs that are no longer valid."
+        )
+
+      {:error, _} ->
+        Logger.error("Auto-Host runner - failed to invalidate host/target pairs no longer valid.")
+    end
+
+    case ChannelHostsLookups.host_some_channels() do
+      {:ok, %{rows: _, num_rows: num}} ->
+        Logger.info("Auto-Host runner - updated #{num} entries to hosting status.")
+
+      {:error, _} ->
+        Logger.error("Auto-Host runner - failed to host any channels")
+    end
+
+    complete = NaiveDateTime.utc_now()
+    time = NaiveDateTime.diff(start, complete, :millisecond)
+    Logger.info("Auto-Host runner finished in #{time} ms")
+
+    Rihanna.schedule(Glimesh.Jobs.AutoHostCron, [], in: @interval)
+
+    :ok
+  rescue
+    e ->
+      {:error, e}
+  end
+end

--- a/lib/glimesh/jobs/auto_host_cron.ex
+++ b/lib/glimesh/jobs/auto_host_cron.ex
@@ -50,7 +50,7 @@ defmodule Glimesh.Jobs.AutoHostCron do
     end
 
     complete = NaiveDateTime.utc_now()
-    time = NaiveDateTime.diff(start, complete, :millisecond)
+    time = NaiveDateTime.diff(complete, start, :millisecond)
     Logger.info("Auto-Host runner finished in #{time} ms")
 
     Rihanna.schedule(Glimesh.Jobs.AutoHostCron, [], in: @interval)

--- a/lib/glimesh/streams/channel.ex
+++ b/lib/glimesh/streams/channel.ex
@@ -34,6 +34,8 @@ defmodule Glimesh.Streams.Channel do
 
     field :emote_prefix, :string
 
+    field :allow_hosting, :boolean, default: false
+
     # This is here temporarily as we add additional schema to handle it.
     field :streamloots_url, :string, default: nil
 
@@ -43,6 +45,9 @@ defmodule Glimesh.Streams.Channel do
 
     field :poster, Glimesh.ChannelPoster.Type
     field :chat_bg, Glimesh.ChatBackground.Type
+
+    # This is used when searching for live channels that are live or hosted
+    field :match_type, :string, virtual: true
 
     many_to_many :tags, Glimesh.Streams.Tag, join_through: "channel_tags", on_replace: :delete
 
@@ -98,7 +103,8 @@ defmodule Glimesh.Streams.Channel do
       :disable_hyperlinks,
       :block_links,
       :require_confirmed_email,
-      :minimum_account_age
+      :minimum_account_age,
+      :allow_hosting
     ])
     |> validate_length(:chat_rules_md, max: 8192)
     |> validate_length(:title, max: 250)
@@ -247,5 +253,16 @@ defmodule Glimesh.Streams.Channel do
 
   defp generate_hmac_key do
     :crypto.strong_rand_bytes(64) |> Base.encode64() |> binary_part(0, 64)
+  end
+
+  def change_allow_hosting(%Glimesh.Streams.Channel{} = channel, attrs \\ %{}) do
+    channel
+    |> cast(attrs, [:allow_hosting])
+    |> validate_required(:allow_hosting)
+  end
+
+  def update_allow_hosting(%Glimesh.Streams.Channel{} = channel, attrs \\ %{}) do
+    change_allow_hosting(channel, attrs)
+    |> Glimesh.Repo.update()
   end
 end

--- a/lib/glimesh/streams/channel_hosts.ex
+++ b/lib/glimesh/streams/channel_hosts.ex
@@ -1,0 +1,127 @@
+defmodule Glimesh.Streams.ChannelHosts do
+  @moduledoc false
+  use Ecto.Schema
+  use Waffle.Ecto.Schema
+
+  alias Glimesh.Accounts.User
+  alias Glimesh.Repo
+  alias Glimesh.Streams.Channel
+  alias Glimesh.Streams.ChannelHosts
+
+  import Ecto.{Changeset, Query}
+  import GlimeshWeb.Gettext
+
+  schema "channel_hosts" do
+    belongs_to :host, Glimesh.Streams.Channel, source: :hosting_channel_id
+    belongs_to :target, Glimesh.Streams.Channel, source: :target_channel_id
+
+    field :hosting_channel_id, :integer
+    field :target_channel_id, :integer
+    field :status, :string, default: "ready"
+    field :last_hosted_date, :naive_datetime
+
+    timestamps()
+  end
+
+  def changeset(channel_hosts, attrs \\ %{}) do
+    channel_hosts
+    |> cast(attrs, [:hosting_channel_id, :target_channel_id, :status, :last_hosted_date])
+    |> unique_constraint([:hosting_channel_id, :target_channel_id])
+    |> validate_required([:hosting_channel_id, :target_channel_id, :status])
+    |> validate_hosting_qualifications()
+    |> validate_target_qualifications()
+  end
+
+  defp validate_hosting_qualifications(changeset) do
+    host_channel_id = get_field(changeset, :hosting_channel_id)
+    target_channel_id = get_field(changeset, :target_channel_id)
+    host_channel = Glimesh.ChannelLookups.get_channel(host_channel_id)
+    host_channel_hours = Glimesh.Streams.get_channel_hours(host_channel)
+
+    validate_host_query =
+      from(user in User,
+        join: ch in Channel,
+        on: user.id == ch.user_id,
+        where: ch.id == ^host_channel_id,
+        where: ch.inaccessible == false,
+        where: not is_nil(user.confirmed_at),
+        where: user.is_banned == false,
+        where: user.can_stream == true,
+        where:
+          fragment(
+            "((extract(epoch from now()) - extract(epoch from ?)) / 86400) >= 5",
+            user.inserted_at
+          ),
+        where:
+          fragment(
+            "not exists(select user_id from channel_bans where user_id = ? and channel_id = ? and expires_at is null)",
+            user.id,
+            ^target_channel_id
+          )
+      )
+
+    if Repo.exists?(validate_host_query) and host_channel_hours >= 10 do
+      changeset
+    else
+      add_error(
+        changeset,
+        :hosting_channel_id,
+        gettext("Host channel does not meet hosting requirements")
+      )
+    end
+  end
+
+  def validate_target_qualifications(changeset) do
+    target_channel_id = get_field(changeset, :target_channel_id)
+
+    if target_channel_id do
+      validate_target_query =
+        from(user in User,
+          join: channel in Channel,
+          on: user.id == channel.user_id,
+          where: channel.id == ^target_channel_id,
+          where: user.can_stream == true,
+          where: user.is_banned == false,
+          where: not is_nil(user.confirmed_at),
+          where: channel.inaccessible == false,
+          where: channel.allow_hosting == true
+        )
+
+      if Repo.exists?(validate_target_query) do
+        changeset
+      else
+        add_error(
+          changeset,
+          :target_channel_id,
+          gettext("Target channel does not qualify for hosting")
+        )
+      end
+    else
+      add_error(changeset, :target_channel_id, gettext("Target channel id is required"))
+    end
+  end
+
+  def add_new_host(
+        %User{} = user,
+        %Channel{} = channel,
+        %ChannelHosts{} = channel_hosts,
+        attrs \\ %{}
+      ) do
+    with :ok <- Bodyguard.permit(Glimesh.Streams.Policy, :add_hosting_target, user, channel) do
+      channel_hosts
+      |> changeset(attrs)
+      |> Repo.insert()
+    end
+  end
+
+  def delete_hosting_target(%User{} = user, %Channel{} = channel, %ChannelHosts{} = channel_hosts) do
+    with :ok <- Bodyguard.permit(Glimesh.Streams.Policy, :delete_hosting_target, user, channel) do
+      channel_hosts
+      |> Repo.delete()
+    end
+  end
+
+  def get_by_id(id) do
+    Repo.get_by(ChannelHosts, id: id)
+  end
+end

--- a/lib/glimesh/streams/policy.ex
+++ b/lib/glimesh/streams/policy.ex
@@ -27,6 +27,8 @@ defmodule Glimesh.Streams.Policy do
   def authorize(:update_channel_moderator, %User{is_admin: true}, _channel), do: true
   def authorize(:delete_channel_moderator, %User{is_admin: true}, _channel), do: true
 
+  def authorize(:delete_hosting_target, %User{is_admin: true}, _channel), do: true
+
   # GCT
   def authorize(:update_channel, %User{is_gct: true}, _channel), do: true
   def authorize(:delete_channel, %User{is_gct: true}, _channel), do: true
@@ -58,6 +60,14 @@ defmodule Glimesh.Streams.Policy do
       do: true
 
   def authorize(:delete_channel_moderator, %User{id: user_id}, %Channel{user_id: channel_user_id})
+      when user_id == channel_user_id,
+      do: true
+
+  def authorize(:delete_hosting_target, %User{id: user_id}, %Channel{user_id: channel_user_id})
+      when user_id == channel_user_id,
+      do: true
+
+  def authorize(:add_hosting_target, %User{id: user_id}, %Channel{user_id: channel_user_id})
       when user_id == channel_user_id,
       do: true
 

--- a/lib/glimesh_web/controllers/user_settings_controller.ex
+++ b/lib/glimesh_web/controllers/user_settings_controller.ex
@@ -38,6 +38,11 @@ defmodule GlimeshWeb.UserSettingsController do
     |> Controller.live_render(ChannelSettingsLive.UploadEmotes)
   end
 
+  def hosting(conn, _params) do
+    conn
+    |> Controller.live_render(ChannelSettingsLive.Hosting)
+  end
+
   def preference(conn, _params) do
     render(conn, "preference.html", page_title: format_page_title(gettext("Preferences")))
   end

--- a/lib/glimesh_web/live/channel_settings_live/hosting.ex
+++ b/lib/glimesh_web/live/channel_settings_live/hosting.ex
@@ -1,0 +1,137 @@
+defmodule GlimeshWeb.ChannelSettingsLive.Hosting do
+  use GlimeshWeb, :live_view
+
+  alias Glimesh.ChannelHostsLookups
+  alias Glimesh.ChannelLookups
+  alias Glimesh.Streams.Channel
+  alias Glimesh.Streams.ChannelHosts
+
+  @impl true
+  def mount(_, session, socket) do
+    if session["locale"], do: Gettext.put_locale(session["locale"])
+
+    user = Glimesh.Accounts.get_user_by_session_token(session["user_token"])
+    channel = ChannelLookups.get_channel_for_user(user)
+    allow_hosting_changeset = Channel.change_allow_hosting(channel)
+    hosted_channels = ChannelHostsLookups.get_channel_hosting_list(channel.id)
+
+    {:ok,
+     socket
+     |> put_page_title(gettext("Hosting Settings"))
+     |> assign(:user, user)
+     |> assign(:channel, channel)
+     |> assign(:hosting_qualified, hosting_qualified?(user, channel))
+     |> assign(:allow_changeset, allow_hosting_changeset)
+     |> assign(:matches, [])
+     |> assign(:add_channel, "")
+     |> assign(:add_channel_selected_value, "")
+     |> assign(:hosted_channels, hosted_channels)}
+  end
+
+  defp hosting_qualified?(user, channel) do
+    account_age = Glimesh.Accounts.get_account_age_in_days(user)
+    total_streamed_hours = Glimesh.Streams.get_channel_hours(channel)
+
+    user.confirmed_at != nil and account_age >= 5 and total_streamed_hours >= 10
+  end
+
+  defp search_for_channels(user, term) do
+    ChannelLookups.search_hostable_channels_by_name(user, term)
+  end
+
+  @impl true
+  def handle_event("toggle_allow_hosting", %{"channel" => channel_params}, socket) do
+    case Channel.update_allow_hosting(socket.assigns.channel, channel_params) do
+      {:ok, channel} ->
+        {:noreply,
+         socket
+         |> assign(:channel, channel)
+         |> assign(:allow_changeset, Channel.change_allow_hosting(channel))
+         |> put_flash(:hosting_info, gettext("Saved Hosting Preference."))}
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        {:noreply, assign(socket, :allow_changeset, changeset)}
+    end
+  end
+
+  @impl true
+  def handle_event("suggest", %{"add_channel" => add_channel}, socket) do
+    matches = search_for_channels(socket.assigns.user, add_channel)
+
+    {:noreply,
+     assign(socket, matches: matches, add_channel: add_channel, add_channel_selected_value: "")}
+  end
+
+  @impl true
+  def handle_event(
+        "add_hosting_channel",
+        %{"name" => channel_name, "selected" => selected},
+        socket
+      ) do
+    # if the user copy/pastes or completely enters a channel name without using the picker, try to handle that scenario
+    selected_value =
+      if selected == "" and channel_name != "" do
+        matches = search_for_channels(socket.assigns.user, channel_name)
+        if length(matches) == 1, do: Enum.at(matches, 0).id, else: ""
+      else
+        selected
+      end
+
+    case ChannelHosts.add_new_host(
+           socket.assigns.user,
+           socket.assigns.channel,
+           %ChannelHosts{hosting_channel_id: socket.assigns.channel.id},
+           %{target_channel_id: selected_value}
+         ) do
+      {:ok, _} ->
+        {:noreply,
+         socket
+         |> assign(:matches, [])
+         |> assign(:add_channel, "")
+         |> assign(:add_channel_selected_value, "")
+         |> put_flash(:hosting_info, gettext("Channel added"))
+         |> redirect(to: Routes.user_settings_path(socket, :hosting))}
+
+      {:error, _channel_hosts} ->
+        {:noreply,
+         socket
+         |> assign(matches: [])
+         |> assign(add_channel_selected_value: "")
+         |> put_flash(:error, gettext("Unable to add channel to hosting list"))}
+    end
+  end
+
+  @impl true
+  def handle_event(
+        "add_channel_selection_made",
+        %{"user_id" => _user_id, "username" => username, "channel_id" => channel_id},
+        socket
+      ) do
+    {:noreply,
+     socket
+     |> assign(add_channel_selected_value: channel_id)
+     |> assign(add_channel: username)}
+  end
+
+  @impl true
+  def handle_event("remove_host", %{"id" => target_id}, socket) do
+    channel_host = ChannelHosts.get_by_id(target_id)
+
+    case ChannelHosts.delete_hosting_target(
+           socket.assigns.user,
+           socket.assigns.channel,
+           channel_host
+         ) do
+      {:ok, _channel_host} ->
+        {:noreply,
+         socket
+         |> put_flash(:hosting_info, gettext("Hosting target removed"))
+         |> redirect(to: Routes.user_settings_path(socket, :hosting))}
+
+      {:error, _} ->
+        {:noreply,
+         socket
+         |> put_flash(:error, gettext("Unable to remove hosting target"))}
+    end
+  end
+end

--- a/lib/glimesh_web/live/channel_settings_live/hosting.html.leex
+++ b/lib/glimesh_web/live/channel_settings_live/hosting.html.leex
@@ -1,0 +1,105 @@
+<%= if live_flash(@flash, :hosting_info) do %>
+<p class="alert alert-success" role="alert" phx-click="lv:clear-flash" phx-value-key="hosting_info"><%= live_flash(@flash, :hosting_info) %></p>
+<% end %>
+<div class="card">
+    <div class="card-header">
+        <div class="row">
+            <div class="col-10">
+                <h4><%= gettext("Manage Hosting") %></h4>
+            </div>
+        </div>
+    </div>
+    <div class="card-body">
+        <%= f = form_for @allow_changeset, "#", [class: "form_allow_hosting", phx_change: :toggle_allow_hosting] %>
+        <h5><%= gettext("Being Hosted") %></h5>
+        <div class="row">
+            <div class="col-6">
+                <div class="form-group">
+                    <div class="custom-control custom-switch">
+                        <%= checkbox f, :allow_hosting, class: "custom-control-input" %>
+                        <%= label f, :allow_hosting, gettext("Other streamers may host my channel"), class: "custom-control-label" %>
+                        <%= error_tag f, :allow_hosting %>
+                    </div>
+                </div>
+            </div>
+        </div>
+        </form>
+        <p><%= gettext("Hosting channels must still meet the following qualifications in order to host your channel:") %>
+        <ul>
+        <li><%= gettext("They must have a verified email address.") %></li>
+        <li><%= gettext("Their account must be more than 5 days old.") %></li>
+        <li><%= gettext("They must NOT be banned from your channel.") %></li>
+        <li><%= gettext("They must have streamed for at least 10 hours total on Glimesh.") %></li>
+        </ul>
+
+        <h5><%= gettext("Hosting Others") %></h5>
+        <p><%= gettext("Host other Glimesh channels when you are not live.") %></p>
+        <%= if not @hosting_qualified do %>
+        <div class="row">
+            <div id="not-qualified" class="col-12 card card-body text-center">
+                <%= gettext("You have not met the minimum qualifications to host others, see list above for details") %>
+            </div>
+        </div>
+        <% else %>
+        <%= form_tag "", [class: "form_add_channel", phx_change: :suggest] %>
+        <div class="row">
+            <div class="col-12 col-lg-6">
+                <div class="input-group">
+                    <%= live_component(@socket, GlimeshWeb.Components.ChannelLookupTypeahead, [id: "channel_lookup", user: @user, field: "add_channel", value: @add_channel, class: "form-control pl-0 channel-typeahead-input", matches: @matches, timeout: 700, extra_params: "maxlength=24"]) %>
+                    <div class="input-group-append">
+                        <button id="add-channel-button" type="button" class="btn btn-primary btn-block" aria-label="Add Channel" phx-click="add_hosting_channel" phx-value-name="<%= @add_channel %>" phx-value-selected="<%= @add_channel_selected_value %>">
+                            <span aria-hidden="true"><%= gettext("Add Channel") %></span>
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
+        </form>
+        <div class="row">
+            <div class="col-12 pt-3">
+                <table class="table">
+                    <thead style="background-color: var(--input-bg-color);">
+                        <tr>
+                            <th><%= gettext("Channel") %></th>
+                            <th class="text-center"><%= gettext("Status") %></th>
+                            <th><%= gettext("Last Hosted") %></th>
+                            <th>&nbsp;</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <%= for host <- @hosted_channels do %>
+                            <tr id="hosted-row-<%= host.target_channel_id %>">
+                                <td>
+                                    <img class="img-avatar" src="<%= Glimesh.Avatar.url({host.target.user.avatar, host.target.user}, :original) %>" width=50 height=50>&nbsp;<%= host.target.user.displayname %>
+                                </td>
+                                <td id="hosted-row-<%= host.target_channel_id %>-status" class="text-center">
+                                    <%= case host.status do %>
+                                        <% "ready" -> %>
+                                            <i class="fas fa-check text-success" title="<%= gettext("Ready to host") %>"></i>
+                                        <% "error" -> %>
+                                            <i class="fas fa-circle-xmark text-error" title="<%= gettext("Unable to host") %>"></i>
+                                        <% "hosting" -> %>
+                                            <i class="fas fa-tv text-info" title="<%= gettext("Currently hosting") %>"></i>
+                                        <% _ -> %>
+                                            gettext(host.status)
+                                    <% end %>
+                                </td>
+                                <td>
+                                    <%= if host.last_hosted_date do %>
+                                    <local-time phx-update="ignore" datetime="<%= "#{host.last_hosted_date}" <> "Z" %>"><%= host.last_hosted_date %></local-time>
+                                    <% else %>
+                                    -
+                                    <% end %>
+                                </td>
+                                <td>
+                                    <button type="button" id="remove-channel-button-<%= host.target_channel_id %>" class="close close-delete" phx-click="remove_host" phx-value-id="<%= host.id %>">&times;</button>
+                                </td>
+                            </tr>
+                        <% end %>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+        <% end %>
+    </div>
+</div>

--- a/lib/glimesh_web/live/channel_settings_live/hosting.html.leex
+++ b/lib/glimesh_web/live/channel_settings_live/hosting.html.leex
@@ -77,7 +77,7 @@
                                         <% "ready" -> %>
                                             <i class="fas fa-check text-success" title="<%= gettext("Ready to host") %>"></i>
                                         <% "error" -> %>
-                                            <i class="fas fa-circle-xmark text-error" title="<%= gettext("Unable to host") %>"></i>
+                                            <i class="fas fa-times-circle text-danger" title="<%= gettext("Unable to host") %>"></i>
                                         <% "hosting" -> %>
                                             <i class="fas fa-tv text-info" title="<%= gettext("Currently hosting") %>"></i>
                                         <% _ -> %>

--- a/lib/glimesh_web/live/components/channel_lookup_typeahead.ex
+++ b/lib/glimesh_web/live/components/channel_lookup_typeahead.ex
@@ -1,0 +1,26 @@
+defmodule GlimeshWeb.Components.ChannelLookupTypeahead do
+  use GlimeshWeb, :live_component
+
+  @impl true
+  def render(assigns) do
+    ~L"""
+        <input type="text" name="<%= @field %>" value="<%= @value %>" class="<%= @field %>-input <%= @class %>" phx-debounce="<%= @timeout %>" autocomplete="off" <%= if assigns[:extra_params], do: @extra_params, else: "" %>>
+        <%= if @matches != [] do %>
+        <div class="channel-typeahead-dropdown list-group">
+          <%= for match <- @matches do %>
+              <div id="channel-lookup-<%= match.user.id %>" class="list-group-item bg-primary-hover" phx-hook="ChannelLookupTypeahead" data-fieldname="<%= @field %>" data-id="<%= match.user.id %>" data-name="<%= match.user.displayname %>" data-channel-id="<%= match.id %>">
+                <img class="img-avatar" src="<%= Glimesh.Avatar.url({match.user.avatar, match.user}, :original) %>" width=50 height=50>&nbsp;<%= match.user.displayname %>
+              </div>
+          <% end %>
+        </div>
+        <% end %>
+    """
+  end
+
+  @impl true
+  def mount(socket) do
+    {:ok,
+     socket
+     |> assign(value: "")}
+  end
+end

--- a/lib/glimesh_web/live/streams_live/following.ex
+++ b/lib/glimesh_web/live/streams_live/following.ex
@@ -10,7 +10,7 @@ defmodule GlimeshWeb.StreamsLive.Following do
       %Glimesh.Accounts.User{} = user ->
         if session["locale"], do: Gettext.put_locale(session["locale"])
 
-        live_streams = Glimesh.ChannelLookups.list_live_followed_channels(user)
+        live_streams = Glimesh.ChannelLookups.list_live_followed_channels_and_hosts(user)
 
         {:ok,
          socket

--- a/lib/glimesh_web/live/streams_live/following.html.leex
+++ b/lib/glimesh_web/live/streams_live/following.html.leex
@@ -2,14 +2,14 @@
     <div class="position-relative overflow-hidden p-3 p-md-5 m-md-3 text-center">
         <div class="col-md-12 mx-auto ">
             <h1 class="display-4 font-weight-normal">
-                <%= gettext("Live Followed Streams") %>
+                <%= gettext("Live Streams") %>
             </h1>
             <%= if length(@channels) == 0 do %>
             <p><%= gettext("None of the streams you follow are live.") %></p>
             <% end %>
         </div>
     </div>
-    <div class="row">
+    <div class="row d-flex justify-content-center">
         <%= for channel <- @channels do %>
         <div class="col-sm-12 col-md-6 col-xl-4 mt-4">
             <%= link to: Routes.user_stream_path(@socket, :index, channel.user.username), class: "text-color-link" do %>
@@ -18,8 +18,12 @@
                 <div class="card-img-overlay h-100 d-flex flex-column justify-content-between">
 
                     <div>
+                        <div class="card-stream-category">
+                            <%= if channel.match_type == "hosting" do %>
+                            <span class="badge badge-warning"><%= gettext("Hosted") %></span>
+                            <% end %>
+                        </div>
                         <div class="card-stream-tags">
-
                             <%= if channel.subcategory do %>
                             <span class="badge badge-info"><%= channel.subcategory.name %></span>
                             <% end %>

--- a/lib/glimesh_web/live/user_live/stream.html.leex
+++ b/lib/glimesh_web/live/user_live/stream.html.leex
@@ -1,3 +1,25 @@
+<%= if @hosting_channel != nil and @hosting_channel.target.id == @channel.id do %>
+<div id="hosted-banner" class="container bg-secondary collapse show">
+    <div class="float-right"><button class="btn btn-close" data-toggle="collapse" data-target="#hosted-banner">&times;</button></div>
+    <div class="row pt-2">
+        <div class="col-9 text-center">
+            <h2><img class="img-avatar" src="<%= Glimesh.Avatar.url({@hosting_channel.host.user.avatar, @hosting_channel.host.user}, :original) %>" width=50 height=50>&nbsp;<%= gettext("%{hostname} is hosting %{targetname}", hostname: @hosting_channel.host.user.displayname, targetname: @hosting_channel.target.user.displayname) %>&nbsp;<img class="img-avatar" src="<%= Glimesh.Avatar.url({@hosting_channel.target.user.avatar, @hosting_channel.target.user}, :original) %>" width=50 height=50></h2>
+        </div>
+        <div class="col-3 text-center pt-2"><a class="btn btn-primary" href="<%= "/#{@hosting_channel.host.user.username}/?follow_host=false" %>"><%= gettext("Return to host") %></a></div>
+    </div>
+</div>
+<% end %>
+<%= if @hosting_channel != nil and @hosting_channel.host.id == @channel.id do %>
+<div id="hosting-banner" class="container bg-secondary collapse show">
+    <div class="float-right"><button class="btn btn-close" data-toggle="collapse" data-target="#hosting-banner">&times;</button></div>
+    <div class="row pt-2">
+        <div class="col-9 text-center">
+            <h2><img class="img-avatar" src="<%= Glimesh.Avatar.url({@hosting_channel.host.user.avatar, @hosting_channel.host.user}, :original) %>" width=50 height=50>&nbsp;<%= gettext("%{hostname} is hosting %{targetname}", hostname: @hosting_channel.host.user.displayname, targetname: @hosting_channel.target.user.displayname) %>&nbsp;<img class="img-avatar" src="<%= Glimesh.Avatar.url({@hosting_channel.target.user.avatar, @hosting_channel.target.user}, :original) %>" width=50 height=50></h2>
+        </div>
+        <div class="col-3 text-center pt-2"><a class="btn btn-primary" href="<%= "/#{@hosting_channel.target.user.username}/?host=#{@hosting_channel.host.user.username}" %>"><%= gettext("Go there") %></a></div>
+    </div>
+</div>
+<% end %>
 <div class="container-fluid container-stream">
     <div class="row mt-lg-3">
 

--- a/lib/glimesh_web/router.ex
+++ b/lib/glimesh_web/router.ex
@@ -126,6 +126,7 @@ defmodule GlimeshWeb.Router do
     get "/users/settings/addons", UserSettingsController, :addons
     get "/users/settings/emotes", UserSettingsController, :emotes
     get "/users/settings/upload_emotes", UserSettingsController, :upload_emotes
+    get "/users/settings/hosting", UserSettingsController, :hosting
 
     put "/users/settings/create_channel", UserSettingsController, :create_channel
     put "/users/settings/delete_channel", UserSettingsController, :delete_channel

--- a/lib/glimesh_web/templates/layout/_navbar.html.leex
+++ b/lib/glimesh_web/templates/layout/_navbar.html.leex
@@ -12,7 +12,14 @@
             <%= if assigns[:current_user] do %>
             <li class="nav-item d-inline mr-3">
                 <%= live_redirect to: Routes.streams_list_path(@conn, :index, "following") do %>
-                <i class="fas fa-heart fa-fw"></i> <%= if count_live = count_live_following_channels(@conn) do %><span class="badge badge-danger"><%= count_live %></span><% end %>
+                <i class="fas fa-heart fa-fw"></i>
+                    <%= cond do %>
+                    <% count_live = count_live_following_channels(@conn) -> %>
+                    <span class="badge badge-danger"><%= count_live %></span>
+                    <% count_hosted = count_live_hosted_channels(@conn) -> %>
+                    <span class="badge badge-primary"><%= count_hosted %></span>
+                    <% true -> %>
+                    <% end %>
                 <% end %>
             </li>
             <% end %>
@@ -74,7 +81,14 @@
             <%= if assigns[:current_user] do %>
             <li class="nav-item">
                 <%= live_redirect class: "nav-link", to: Routes.streams_list_path(@conn, :index, "following") do %>
-                <%= gettext("Following") %> <%= if count_live = count_live_following_channels(@conn) do %><span class="badge badge-danger"><%= count_live %></span><% end %>
+                <%= gettext("Following") %>
+                    <%= cond do %>
+                    <% count_live = count_live_following_channels(@conn) -> %>
+                    <span class="badge badge-danger align-top"><%= count_live %></span>
+                    <% count_hosted = count_live_hosted_channels(@conn) -> %>
+                    <span class="badge badge-primary align-top"><%= count_hosted %></span>
+                    <% true -> %>
+                    <% end %>
                 <% end %>
             </li>
             <% end %>

--- a/lib/glimesh_web/templates/layout/app.html.eex
+++ b/lib/glimesh_web/templates/layout/app.html.eex
@@ -1,8 +1,9 @@
+<!-- app.html.eex -->
 <%= if get_flash(@conn, :info) do %>
 <p class="alert alert-info" role="alert"><%= get_flash(@conn, :info) %></p>
 <% end %>
 <%= if get_flash(@conn, :error) do %>
 <p class="alert alert-danger" role="alert"><%= get_flash(@conn, :error) %></p>
 <% end %>
-
+<!-- end app.html.eex -->
 <%= @inner_content %>

--- a/lib/glimesh_web/templates/layout/live.html.leex
+++ b/lib/glimesh_web/templates/layout/live.html.leex
@@ -1,6 +1,6 @@
 
 
-
+<!-- live.html.leex -->
 <%= if live_flash(@flash, :info) do %>
 <p class="alert alert-info" role="alert"
     phx-click="lv:clear-flash"
@@ -11,5 +11,5 @@
     phx-click="lv:clear-flash"
     phx-value-key="error"><%= live_flash(@flash, :error) %></p>
 <% end %>
-
+<!-- live.html.leex -->
 <%= @inner_content %>

--- a/lib/glimesh_web/templates/layout/user-sidebar.html.eex
+++ b/lib/glimesh_web/templates/layout/user-sidebar.html.eex
@@ -41,6 +41,9 @@
                 <%= link class: "list-group-item list-group-item-action " <> active_user_emotes_path(@conn), to: Routes.user_settings_path(@conn, :emotes) do %>
                 <i class="fas fa-smile fa-fw"></i> <%= gettext("Emotes") %>
                 <% end %>
+                <%= link class: "list-group-item list-group-item-action " <> active_user_hosting_path(@conn), to: Routes.user_settings_path(@conn, :hosting) do %>
+                <i class="fas fa-tv fa-fw"></i> <%= gettext("Hosting") %>
+                <% end %>
                 <% else %>
                 <%= link class: "list-group-item list-group-item-action " <> active_user_stream_path(@conn), to: Routes.user_settings_path(@conn, :stream) do %>
                 <i class="fas fa-video fa-fw"></i> <%= gettext("Create Channel") %>
@@ -58,6 +61,8 @@
         </div>
         <div class="col-lg-10">
 
+            <!-- user-sidebar.html.eex -->
+            <%# BUG this section needs to be removed, it conflicts with app.html.eex and the few settings pages that rely on this need to be fixed %>
             <%= if get_flash(@conn, :info) do %>
             <p class="alert alert-info mt-4" role="alert"><%= get_flash(@conn, :info) %></p>
             <% end %>
@@ -65,6 +70,7 @@
             <p class="alert alert-danger mt-4" role="alert"><%= get_flash(@conn, :error) %></p>
             <% end %>
 
+            <!-- user-sidebar.html.eex -->
             <%= @inner_content %>
 
         </div>

--- a/lib/glimesh_web/views/layout_view.ex
+++ b/lib/glimesh_web/views/layout_view.ex
@@ -71,6 +71,10 @@ defmodule GlimeshWeb.LayoutView do
     )
   end
 
+  def active_user_hosting_path(conn) do
+    truthy_active(controller_action(conn) == [GlimeshWeb.UserSettingsController, :hosting])
+  end
+
   def active_channel_addons_path(conn) do
     truthy_active(controller_action(conn) == [GlimeshWeb.UserSettingsController, :addons])
   end
@@ -151,6 +155,20 @@ defmodule GlimeshWeb.LayoutView do
   end
 
   def count_live_following_channels(_) do
+    nil
+  end
+
+  def count_live_hosted_channels(%{assigns: %{current_user: user}}) do
+    count = Glimesh.ChannelLookups.count_live_followed_channels_that_are_hosting(user)
+
+    if count > 0 do
+      count
+    else
+      nil
+    end
+  end
+
+  def count_live_hosted_channels(_) do
     nil
   end
 end

--- a/priv/repo/migrations/20211126035720_add_hosting_feature.exs
+++ b/priv/repo/migrations/20211126035720_add_hosting_feature.exs
@@ -1,0 +1,20 @@
+defmodule Glimesh.Repo.Migrations.AddHostingFeature do
+  use Ecto.Migration
+
+  def change do
+    alter table("channels") do
+      add :allow_hosting, :boolean, default: false
+    end
+
+    create table(:channel_hosts) do
+      add :hosting_channel_id, references(:channels, column: :id), null: false
+      add :target_channel_id, references(:channels, column: :id), null: false
+      add :status, :string, null: false, default: "ready"
+      add :last_hosted_date, :naive_datetime, null: true
+
+      timestamps()
+    end
+
+    create unique_index(:channel_hosts, [:hosting_channel_id, :target_channel_id])
+  end
+end

--- a/test/glimesh/channel_hosts_lookups_test.exs
+++ b/test/glimesh/channel_hosts_lookups_test.exs
@@ -1,0 +1,573 @@
+defmodule Glimesh.ChannelHostsLookupsTest do
+  use Glimesh.DataCase
+  use Bamboo.Test
+
+  import Glimesh.AccountsFixtures
+  import Glimesh.StreamsFixtures
+  alias Glimesh.Streams
+  alias Glimesh.Streams.ChannelHosts
+  alias Glimesh.ChannelHostsLookups
+
+  defp create_auto_hosting_data(_) do
+    hosting_channel =
+      streamer_fixture(%{}, %{})
+      |> change_inserted_at_for_user(
+        NaiveDateTime.add(NaiveDateTime.utc_now(), 86_400 * -6)
+        |> NaiveDateTime.truncate(:second)
+      )
+
+    Streams.create_stream(hosting_channel.channel, %{
+      started_at:
+        NaiveDateTime.add(NaiveDateTime.utc_now(), 60 * 60 * -10)
+        |> NaiveDateTime.truncate(:second),
+      ended_at: NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
+    })
+
+    # -------------------------------------------------------------
+
+    good_target = streamer_fixture(%{}, %{allow_hosting: true})
+
+    {:ok, good_target_channel_hosts} =
+      ChannelHosts.add_new_host(hosting_channel, hosting_channel.channel, %ChannelHosts{
+        hosting_channel_id: hosting_channel.channel.id,
+        target_channel_id: good_target.channel.id
+      })
+
+    # -------------------------------------------------------------
+
+    bad_target_not_allow_hosting = streamer_fixture(%{}, %{allow_hosting: true})
+
+    {:ok, bad_target_not_allow_hosting_channel_hosts} =
+      ChannelHosts.add_new_host(hosting_channel, hosting_channel.channel, %ChannelHosts{
+        hosting_channel_id: hosting_channel.channel.id,
+        target_channel_id: bad_target_not_allow_hosting.channel.id
+      })
+
+    Ecto.Changeset.change(bad_target_not_allow_hosting.channel)
+    |> Ecto.Changeset.force_change(:allow_hosting, false)
+    |> Repo.update()
+
+    # -------------------------------------------------------------
+
+    bad_target_banned_host = streamer_fixture(%{}, %{allow_hosting: true})
+
+    {:ok, bad_target_banned_host_channel_hosts} =
+      ChannelHosts.add_new_host(hosting_channel, hosting_channel.channel, %ChannelHosts{
+        hosting_channel_id: hosting_channel.channel.id,
+        target_channel_id: bad_target_banned_host.channel.id
+      })
+
+    channel_banned_user_fixture(bad_target_banned_host.channel, hosting_channel)
+    # -------------------------------------------------------------
+
+    bad_target_inaccessible = streamer_fixture(%{}, %{allow_hosting: true})
+
+    {:ok, bad_target_inaccessible_channel_hosts} =
+      ChannelHosts.add_new_host(hosting_channel, hosting_channel.channel, %ChannelHosts{
+        hosting_channel_id: hosting_channel.channel.id,
+        target_channel_id: bad_target_inaccessible.channel.id
+      })
+
+    Ecto.Changeset.change(bad_target_inaccessible.channel)
+    |> Ecto.Changeset.force_change(:inaccessible, true)
+    |> Repo.update()
+
+    # -------------------------------------------------------------
+
+    bad_target_user_banned = streamer_fixture(%{}, %{allow_hosting: true})
+
+    {:ok, bad_target_user_banned_channel_hosts} =
+      ChannelHosts.add_new_host(hosting_channel, hosting_channel.channel, %ChannelHosts{
+        hosting_channel_id: hosting_channel.channel.id,
+        target_channel_id: bad_target_user_banned.channel.id
+      })
+
+    bad_target_user_banned = change_user_banned_status(bad_target_user_banned, true)
+    # -------------------------------------------------------------
+
+    hosting_target_still_live = streamer_fixture(%{}, %{allow_hosting: true})
+    change_channel_status(hosting_target_still_live.channel, "live")
+
+    {:ok, hosting_target_still_live_channel_hosts} =
+      ChannelHosts.add_new_host(hosting_channel, hosting_channel.channel, %ChannelHosts{
+        hosting_channel_id: hosting_channel.channel.id,
+        target_channel_id: hosting_target_still_live.channel.id,
+        status: "hosting"
+      })
+
+    # -------------------------------------------------------------
+
+    hosting_target_no_longer_live = streamer_fixture(%{}, %{allow_hosting: true})
+
+    {:ok, hosting_target_no_longer_live_channel_hosts} =
+      ChannelHosts.add_new_host(hosting_channel, hosting_channel.channel, %ChannelHosts{
+        hosting_channel_id: hosting_channel.channel.id,
+        target_channel_id: hosting_target_no_longer_live.channel.id,
+        status: "hosting"
+      })
+
+    # -------------------------------------------------------------
+
+    bad_hosting_channel_banned_by_target = streamer_fixture(%{}, %{})
+
+    {:ok, bad_target_host_banned_in_target_chat_channel_hosts} =
+      Ecto.Changeset.change(%ChannelHosts{
+        hosting_channel_id: bad_hosting_channel_banned_by_target.channel.id,
+        target_channel_id: good_target.channel.id
+      })
+      |> Repo.insert()
+
+    Ecto.Changeset.change(%Glimesh.Streams.ChannelBan{
+      user: bad_hosting_channel_banned_by_target,
+      channel: good_target.channel,
+      expires_at: nil
+    })
+    |> Repo.insert()
+
+    # -------------------------------------------------------------
+
+    bad_hosting_channel_platform_banned = streamer_fixture(%{is_banned: true}, %{})
+
+    {:ok, bad_hosting_channel_platform_banned_channel_hosts} =
+      Ecto.Changeset.change(%ChannelHosts{
+        hosting_channel_id: bad_hosting_channel_platform_banned.channel.id,
+        target_channel_id: good_target.channel.id
+      })
+      |> Repo.insert()
+
+    # -------------------------------------------------------------
+
+    bad_hosting_channel_inaccessible = streamer_fixture(%{}, %{inaccessible: true})
+
+    {:ok, bad_hosting_channel_inaccessible_channel_hosts} =
+      Ecto.Changeset.change(%ChannelHosts{
+        hosting_channel_id: bad_hosting_channel_inaccessible.channel.id,
+        target_channel_id: good_target.channel.id
+      })
+      |> Repo.insert()
+
+    # -------------------------------------------------------------
+
+    bad_hosting_channel_cant_stream = streamer_fixture(%{}, %{})
+
+    Ecto.Changeset.change(bad_hosting_channel_cant_stream)
+    |> Ecto.Changeset.force_change(:can_stream, false)
+    |> Repo.update()
+
+    {:ok, bad_hosting_channel_cant_stream_channel_hosts} =
+      Ecto.Changeset.change(%ChannelHosts{
+        hosting_channel_id: bad_hosting_channel_cant_stream.channel.id,
+        target_channel_id: good_target.channel.id
+      })
+      |> Repo.insert()
+
+    # -------------------------------------------------------------
+
+    %{
+      host: hosting_channel,
+      good_target: good_target,
+      good_target_channel_hosts: good_target_channel_hosts,
+      bad_target_not_allow_hosting: bad_target_not_allow_hosting,
+      bad_target_not_allow_hosting_channel_hosts: bad_target_not_allow_hosting_channel_hosts,
+      bad_target_banned_host: bad_target_banned_host,
+      bad_target_banned_host_channel_hosts: bad_target_banned_host_channel_hosts,
+      bad_target_inaccessible: bad_target_inaccessible,
+      bad_target_inaccessible_channel_hosts: bad_target_inaccessible_channel_hosts,
+      bad_target_user_banned: bad_target_user_banned,
+      bad_target_user_banned_channel_hosts: bad_target_user_banned_channel_hosts,
+      hosting_target_still_live: hosting_target_still_live,
+      hosting_target_still_live_channel_hosts: hosting_target_still_live_channel_hosts,
+      hosting_target_no_longer_live: hosting_target_no_longer_live,
+      hosting_target_no_longer_live_channel_hosts: hosting_target_no_longer_live_channel_hosts,
+      bad_hosting_channel_banned_by_target: bad_hosting_channel_banned_by_target,
+      bad_target_host_banned_in_target_chat_channel_hosts:
+        bad_target_host_banned_in_target_chat_channel_hosts,
+      bad_hosting_channel_platform_banned: bad_hosting_channel_platform_banned,
+      bad_hosting_channel_platform_banned_channel_hosts:
+        bad_hosting_channel_platform_banned_channel_hosts,
+      bad_hosting_channel_inaccessible: bad_hosting_channel_inaccessible,
+      bad_hosting_channel_inaccessible_channel_hosts:
+        bad_hosting_channel_inaccessible_channel_hosts,
+      bad_hosting_channel_cant_stream: bad_hosting_channel_cant_stream,
+      bad_hosting_channel_cant_stream_channel_hosts: bad_hosting_channel_cant_stream_channel_hosts
+    }
+  end
+
+  describe "Auto Host Job Cleanup Tasks" do
+    setup :create_auto_hosting_data
+
+    test "Unhost no longer live channels",
+         %{
+           hosting_target_no_longer_live_channel_hosts:
+             hosting_target_no_longer_live_channel_hosts,
+           hosting_target_still_live_channel_hosts: hosting_target_still_live_channel_hosts
+         } do
+      assert Repo.get_by(ChannelHosts, %{
+               id: hosting_target_no_longer_live_channel_hosts.id,
+               status: "hosting"
+             })
+
+      assert Repo.get_by(ChannelHosts, %{
+               id: hosting_target_still_live_channel_hosts.id,
+               status: "hosting"
+             })
+
+      {:ok, %{:num_rows => num_rows}} = ChannelHostsLookups.unhost_channels_not_live()
+      assert num_rows == 1
+
+      refute Repo.get_by(ChannelHosts, %{
+               id: hosting_target_no_longer_live_channel_hosts.id,
+               status: "hosting"
+             })
+
+      assert Repo.get_by(ChannelHosts, %{
+               id: hosting_target_no_longer_live_channel_hosts.id,
+               status: "ready"
+             })
+
+      assert Repo.get_by(ChannelHosts, %{
+               id: hosting_target_still_live_channel_hosts.id,
+               status: "hosting"
+             })
+    end
+
+    test "Invalidate a previously valid host target if it no longer allows hosting",
+         %{
+           bad_target_not_allow_hosting_channel_hosts: bad_channel_hosts,
+           good_target_channel_hosts: good_channel_hosts
+         } do
+      assert Repo.get_by(ChannelHosts, %{id: bad_channel_hosts.id, status: "ready"})
+
+      {:ok, %{:num_rows => num_rows}} =
+        ChannelHostsLookups.invalidate_hosting_channels_where_necessary()
+
+      assert num_rows >= 1
+      refute Repo.get_by(ChannelHosts, %{id: bad_channel_hosts.id, status: "ready"})
+      assert Repo.get_by(ChannelHosts, %{id: bad_channel_hosts.id, status: "error"})
+      assert Repo.get_by(ChannelHosts, %{id: good_channel_hosts.id, status: "ready"})
+    end
+
+    test "re-validate a previously invalid host target if it now allows hosting",
+         %{
+           bad_target_not_allow_hosting_channel_hosts: bad_channel_hosts,
+           bad_target_not_allow_hosting: bad_channel,
+           good_target_channel_hosts: good_channel_hosts
+         } do
+      Ecto.Changeset.change(bad_channel_hosts)
+      |> Ecto.Changeset.force_change(:status, "error")
+      |> Repo.update()
+
+      Ecto.Changeset.change(bad_channel.channel)
+      |> Ecto.Changeset.force_change(:allow_hosting, true)
+      |> Repo.update()
+
+      {:ok, %{:num_rows => num_rows}} = ChannelHostsLookups.recheck_error_status_channels()
+      assert num_rows == 1
+      refute Repo.get_by(ChannelHosts, %{id: bad_channel_hosts.id, status: "error"})
+      assert Repo.get_by(ChannelHosts, %{id: bad_channel_hosts.id, status: "ready"})
+      assert Repo.get_by(ChannelHosts, %{id: good_channel_hosts.id, status: "ready"})
+    end
+
+    test "Invalidate a previously valid host target if the host is banned in the target chat",
+         %{
+           bad_target_host_banned_in_target_chat_channel_hosts: bad_channel_hosts,
+           good_target_channel_hosts: good_channel_hosts
+         } do
+      assert Repo.get_by(ChannelHosts, %{id: bad_channel_hosts.id, status: "ready"})
+
+      {:ok, %{:num_rows => num_rows}} =
+        ChannelHostsLookups.invalidate_hosting_channels_where_necessary()
+
+      assert num_rows >= 1
+      refute Repo.get_by(ChannelHosts, %{id: bad_channel_hosts.id, status: "ready"})
+      assert Repo.get_by(ChannelHosts, %{id: bad_channel_hosts.id, status: "error"})
+      assert Repo.get_by(ChannelHosts, %{id: good_channel_hosts.id, status: "ready"})
+    end
+
+    test "re-validate a previously invalid host target if the host is no longer banned in the target chat",
+         %{
+           bad_target_host_banned_in_target_chat_channel_hosts: bad_channel_hosts,
+           bad_hosting_channel_banned_by_target: bad_channel,
+           good_target_channel_hosts: good_channel_hosts
+         } do
+      Ecto.Changeset.change(bad_channel_hosts)
+      |> Ecto.Changeset.force_change(:status, "error")
+      |> Repo.update()
+
+      Repo.get_by(Glimesh.Streams.ChannelBan, %{
+        user_id: bad_channel.id,
+        channel_id: bad_channel_hosts.target_channel_id
+      })
+      |> Repo.delete()
+
+      {:ok, %{:num_rows => num_rows}} = ChannelHostsLookups.recheck_error_status_channels()
+      assert num_rows == 1
+      refute Repo.get_by(ChannelHosts, %{id: bad_channel_hosts.id, status: "error"})
+      assert Repo.get_by(ChannelHosts, %{id: bad_channel_hosts.id, status: "ready"})
+      assert Repo.get_by(ChannelHosts, %{id: good_channel_hosts.id, status: "ready"})
+    end
+
+    test "Invalidate a previously valid host target if the target is now inaccessible",
+         %{
+           bad_target_inaccessible_channel_hosts: bad_channel_hosts,
+           good_target_channel_hosts: good_channel_hosts
+         } do
+      assert Repo.get_by(ChannelHosts, %{id: bad_channel_hosts.id, status: "ready"})
+
+      {:ok, %{:num_rows => num_rows}} =
+        ChannelHostsLookups.invalidate_hosting_channels_where_necessary()
+
+      assert num_rows >= 1
+      refute Repo.get_by(ChannelHosts, %{id: bad_channel_hosts.id, status: "ready"})
+      assert Repo.get_by(ChannelHosts, %{id: bad_channel_hosts.id, status: "error"})
+      assert Repo.get_by(ChannelHosts, %{id: good_channel_hosts.id, status: "ready"})
+    end
+
+    test "re-validate a previously invalid host target if the target is now accessible",
+         %{
+           bad_target_inaccessible_channel_hosts: bad_channel_hosts,
+           bad_target_inaccessible: bad_channel,
+           good_target_channel_hosts: good_channel_hosts
+         } do
+      Ecto.Changeset.change(bad_channel.channel)
+      |> Ecto.Changeset.force_change(:inaccessible, false)
+      |> Repo.update()
+
+      Ecto.Changeset.change(bad_channel_hosts)
+      |> Ecto.Changeset.force_change(:status, "error")
+      |> Repo.update()
+
+      {:ok, %{:num_rows => num_rows}} = ChannelHostsLookups.recheck_error_status_channels()
+
+      assert num_rows == 1
+      refute Repo.get_by(ChannelHosts, %{id: bad_channel_hosts.id, status: "error"})
+      assert Repo.get_by(ChannelHosts, %{id: bad_channel_hosts.id, status: "ready"})
+      assert Repo.get_by(ChannelHosts, %{id: good_channel_hosts.id, status: "ready"})
+    end
+
+    test "Invalidate a previously valid host target if the target is banned",
+         %{
+           bad_target_user_banned_channel_hosts: bad_channel_hosts,
+           good_target_channel_hosts: good_channel_hosts
+         } do
+      assert Repo.get_by(ChannelHosts, %{id: bad_channel_hosts.id, status: "ready"})
+
+      {:ok, %{:num_rows => num_rows}} =
+        ChannelHostsLookups.invalidate_hosting_channels_where_necessary()
+
+      assert num_rows >= 1
+      refute Repo.get_by(ChannelHosts, %{id: bad_channel_hosts.id, status: "ready"})
+      assert Repo.get_by(ChannelHosts, %{id: bad_channel_hosts.id, status: "error"})
+      assert Repo.get_by(ChannelHosts, %{id: good_channel_hosts.id, status: "ready"})
+    end
+
+    test "re-validate a previously invalid host target if the target is no longer banned",
+         %{
+           bad_target_user_banned_channel_hosts: bad_channel_hosts,
+           bad_target_user_banned: bad_channel,
+           good_target_channel_hosts: good_channel_hosts
+         } do
+      Ecto.Changeset.change(bad_channel)
+      |> Ecto.Changeset.force_change(:is_banned, false)
+      |> Repo.update()
+
+      Ecto.Changeset.change(bad_channel_hosts)
+      |> Ecto.Changeset.force_change(:status, "error")
+      |> Repo.update()
+
+      {:ok, %{:num_rows => num_rows}} = ChannelHostsLookups.recheck_error_status_channels()
+
+      assert num_rows == 1
+      refute Repo.get_by(ChannelHosts, %{id: bad_channel_hosts.id, status: "error"})
+      assert Repo.get_by(ChannelHosts, %{id: bad_channel_hosts.id, status: "ready"})
+      assert Repo.get_by(ChannelHosts, %{id: good_channel_hosts.id, status: "ready"})
+    end
+
+    test "Invalidate a host if the host is platform banned",
+         %{
+           bad_hosting_channel_platform_banned_channel_hosts: bad_channel_hosts,
+           good_target_channel_hosts: good_channel_hosts
+         } do
+      assert Repo.get_by(ChannelHosts, %{id: bad_channel_hosts.id, status: "ready"})
+
+      {:ok, %{:num_rows => num_rows}} =
+        ChannelHostsLookups.invalidate_hosting_channels_where_necessary()
+
+      assert num_rows >= 1
+      refute Repo.get_by(ChannelHosts, %{id: bad_channel_hosts.id, status: "ready"})
+      assert Repo.get_by(ChannelHosts, %{id: bad_channel_hosts.id, status: "error"})
+      assert Repo.get_by(ChannelHosts, %{id: good_channel_hosts.id, status: "ready"})
+    end
+
+    test "re-validate a host if the host is no longer platform banned",
+         %{
+           bad_hosting_channel_platform_banned_channel_hosts: bad_channel_hosts,
+           bad_hosting_channel_platform_banned: bad_channel,
+           good_target_channel_hosts: good_channel_hosts
+         } do
+      Ecto.Changeset.change(bad_channel)
+      |> Ecto.Changeset.force_change(:is_banned, false)
+      |> Repo.update()
+
+      Ecto.Changeset.change(bad_channel_hosts)
+      |> Ecto.Changeset.force_change(:status, "error")
+      |> Repo.update()
+
+      {:ok, %{:num_rows => num_rows}} = ChannelHostsLookups.recheck_error_status_channels()
+
+      assert num_rows == 1
+      refute Repo.get_by(ChannelHosts, %{id: bad_channel_hosts.id, status: "error"})
+      assert Repo.get_by(ChannelHosts, %{id: bad_channel_hosts.id, status: "ready"})
+      assert Repo.get_by(ChannelHosts, %{id: good_channel_hosts.id, status: "ready"})
+    end
+
+    test "Invalidate a host if the host channel is inaccessible",
+         %{
+           bad_hosting_channel_inaccessible_channel_hosts: bad_channel_hosts,
+           good_target_channel_hosts: good_channel_hosts
+         } do
+      assert Repo.get_by(ChannelHosts, %{id: bad_channel_hosts.id, status: "ready"})
+
+      {:ok, %{:num_rows => num_rows}} =
+        ChannelHostsLookups.invalidate_hosting_channels_where_necessary()
+
+      assert num_rows >= 1
+      refute Repo.get_by(ChannelHosts, %{id: bad_channel_hosts.id, status: "ready"})
+      assert Repo.get_by(ChannelHosts, %{id: bad_channel_hosts.id, status: "error"})
+      assert Repo.get_by(ChannelHosts, %{id: good_channel_hosts.id, status: "ready"})
+    end
+
+    test "re-validate a host if the host channel is accessible again",
+         %{
+           bad_hosting_channel_inaccessible_channel_hosts: bad_channel_hosts,
+           bad_hosting_channel_inaccessible: bad_channel,
+           good_target_channel_hosts: good_channel_hosts
+         } do
+      Ecto.Changeset.change(bad_channel.channel)
+      |> Ecto.Changeset.force_change(:inaccessible, false)
+      |> Repo.update()
+
+      Ecto.Changeset.change(bad_channel_hosts)
+      |> Ecto.Changeset.force_change(:status, "error")
+      |> Repo.update()
+
+      {:ok, %{:num_rows => num_rows}} = ChannelHostsLookups.recheck_error_status_channels()
+
+      assert num_rows == 1
+      refute Repo.get_by(ChannelHosts, %{id: bad_channel_hosts.id, status: "error"})
+      assert Repo.get_by(ChannelHosts, %{id: bad_channel_hosts.id, status: "ready"})
+      assert Repo.get_by(ChannelHosts, %{id: good_channel_hosts.id, status: "ready"})
+    end
+
+    test "Invalidate a host if the host channel can't stream",
+         %{
+           bad_hosting_channel_cant_stream_channel_hosts: bad_channel_hosts,
+           good_target_channel_hosts: good_channel_hosts
+         } do
+      assert Repo.get_by(ChannelHosts, %{id: bad_channel_hosts.id, status: "ready"})
+
+      {:ok, %{:num_rows => num_rows}} =
+        ChannelHostsLookups.invalidate_hosting_channels_where_necessary()
+
+      assert num_rows >= 1
+      refute Repo.get_by(ChannelHosts, %{id: bad_channel_hosts.id, status: "ready"})
+      assert Repo.get_by(ChannelHosts, %{id: bad_channel_hosts.id, status: "error"})
+      assert Repo.get_by(ChannelHosts, %{id: good_channel_hosts.id, status: "ready"})
+    end
+
+    test "re-validate a host if the host channel can stream again",
+         %{
+           bad_hosting_channel_cant_stream_channel_hosts: bad_channel_hosts,
+           bad_hosting_channel_cant_stream: bad_channel,
+           good_target_channel_hosts: good_channel_hosts
+         } do
+      Ecto.Changeset.change(bad_channel)
+      |> Ecto.Changeset.force_change(:can_stream, true)
+      |> Repo.update()
+
+      Ecto.Changeset.change(bad_channel_hosts)
+      |> Ecto.Changeset.force_change(:status, "error")
+      |> Repo.update()
+
+      {:ok, %{:num_rows => num_rows}} = ChannelHostsLookups.recheck_error_status_channels()
+
+      assert num_rows == 1
+      refute Repo.get_by(ChannelHosts, %{id: bad_channel_hosts.id, status: "error"})
+      assert Repo.get_by(ChannelHosts, %{id: bad_channel_hosts.id, status: "ready"})
+      assert Repo.get_by(ChannelHosts, %{id: good_channel_hosts.id, status: "ready"})
+    end
+
+    test "Test cleanup functions in aggregate", %{
+      good_target_channel_hosts: good,
+      bad_hosting_channel_banned_by_target: bad_host,
+      bad_hosting_channel_platform_banned: bad_host_platform_banned,
+      bad_hosting_channel_inaccessible: bad_host_inaccessible,
+      bad_hosting_channel_cant_stream: bad_host_cant_stream,
+      hosting_target_still_live_channel_hosts: live
+    } do
+      {:ok, %{:num_rows => num_rows}} = ChannelHostsLookups.recheck_error_status_channels()
+      assert num_rows == 0
+
+      {:ok, %{:num_rows => num_rows}} = ChannelHostsLookups.unhost_channels_not_live()
+      assert num_rows == 1
+
+      {:ok, %{:num_rows => num_rows}} =
+        ChannelHostsLookups.invalidate_hosting_channels_where_necessary()
+
+      assert num_rows == 8
+
+      assert Repo.get_by(ChannelHosts, %{id: good.id, status: "ready"})
+      assert Repo.get_by(ChannelHosts, %{id: live.id, status: "hosting"})
+
+      assert length(
+               Repo.all(
+                 from ch in ChannelHosts,
+                   where:
+                     ch.hosting_channel_id == ^good.hosting_channel_id and ch.status == "error"
+               )
+             ) == 4
+
+      assert length(
+               Repo.all(
+                 from ch in ChannelHosts,
+                   where: ch.hosting_channel_id == ^bad_host.channel.id and ch.status == "error"
+               )
+             ) == 1
+
+      assert length(
+               Repo.all(
+                 from ch in ChannelHosts,
+                   where:
+                     ch.hosting_channel_id == ^bad_host_platform_banned.channel.id and
+                       ch.status == "error"
+               )
+             ) == 1
+
+      assert length(
+               Repo.all(
+                 from ch in ChannelHosts,
+                   where:
+                     ch.hosting_channel_id == ^bad_host_inaccessible.channel.id and
+                       ch.status == "error"
+               )
+             ) == 1
+
+      assert length(
+               Repo.all(
+                 from ch in ChannelHosts,
+                   where:
+                     ch.hosting_channel_id == ^bad_host_cant_stream.channel.id and
+                       ch.status == "error"
+               )
+             ) == 1
+
+      assert length(
+               Repo.all(
+                 from ch in ChannelHosts,
+                   where:
+                     ch.hosting_channel_id == ^good.hosting_channel_id and ch.status == "ready"
+               )
+             ) == 2
+    end
+  end
+end

--- a/test/glimesh/channel_lookups_test.exs
+++ b/test/glimesh/channel_lookups_test.exs
@@ -3,8 +3,11 @@ defmodule Glimesh.ChannelLookupsTest do
   use Bamboo.Test
 
   import Glimesh.AccountsFixtures
+  import Glimesh.StreamsFixtures
   alias Glimesh.ChannelLookups
   alias Glimesh.ChannelCategories
+  alias Glimesh.Streams
+  alias Glimesh.Streams.ChannelHosts
 
   defp create_channel(_) do
     gaming_id = ChannelCategories.get_category("gaming").id
@@ -151,6 +154,366 @@ defmodule Glimesh.ChannelLookupsTest do
 
       {:ok, _} = Glimesh.Streams.end_stream(channel)
       assert length(ChannelLookups.list_live_followed_channels(user)) == 0
+    end
+  end
+
+  defp account_ages(_) do
+    %{
+      five_days_ago:
+        NaiveDateTime.add(NaiveDateTime.utc_now(), 86_400 * -5) |> NaiveDateTime.truncate(:second),
+      ten_days_from_now:
+        NaiveDateTime.add(NaiveDateTime.utc_now(), 86_400 * 10) |> NaiveDateTime.truncate(:second)
+    }
+  end
+
+  defp create_hosting_data(_) do
+    hosting_channel =
+      streamer_fixture(%{}, %{})
+      |> change_inserted_at_for_user(
+        NaiveDateTime.add(NaiveDateTime.utc_now(), 86_400 * -6)
+        |> NaiveDateTime.truncate(:second)
+      )
+
+    Streams.create_stream(hosting_channel.channel, %{
+      started_at:
+        NaiveDateTime.add(NaiveDateTime.utc_now(), 60 * 60 * -10)
+        |> NaiveDateTime.truncate(:second),
+      ended_at: NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
+    })
+
+    %{
+      target_allowed_hosting: streamer_fixture(%{}, %{allow_hosting: true}),
+      hosting_channel_five_days_old: hosting_channel
+    }
+  end
+
+  describe "Hosting Channels" do
+    setup [:account_ages, :create_hosting_data]
+
+    test "Banned user cannot be hosted", %{hosting_channel_five_days_old: hosting_channel} do
+      banned_user = streamer_fixture(%{is_banned: true}, %{allow_hosting: true})
+
+      assert length(
+               ChannelLookups.search_hostable_channels_by_name(
+                 hosting_channel,
+                 banned_user.displayname
+               )
+             ) == 0
+    end
+
+    test "Users without channels cannot be hosted", %{
+      hosting_channel_five_days_old: hosting_channel
+    } do
+      ordinary_user = user_fixture(%{})
+
+      assert length(
+               ChannelLookups.search_hostable_channels_by_name(
+                 hosting_channel,
+                 ordinary_user.displayname
+               )
+             ) == 0
+    end
+
+    test "Streamers banned from a channel cannot host channel", %{
+      target_allowed_hosting: target_channel,
+      hosting_channel_five_days_old: hosting_channel
+    } do
+      channel_banned_user_fixture(target_channel.channel, hosting_channel)
+
+      assert length(
+               ChannelLookups.search_hostable_channels_by_name(
+                 hosting_channel,
+                 target_channel.displayname
+               )
+             ) == 0
+    end
+
+    test "Streamers cannot host channels that don't allow hosting", %{
+      hosting_channel_five_days_old: hosting_channel
+    } do
+      target_channel = streamer_fixture(%{}, %{allow_hosting: false})
+
+      assert length(
+               ChannelLookups.search_hostable_channels_by_name(
+                 hosting_channel,
+                 target_channel.displayname
+               )
+             ) == 0
+    end
+
+    test "Streamers cannot host their own channel", %{
+      hosting_channel_five_days_old: hosting_channel
+    } do
+      assert length(
+               ChannelLookups.search_hostable_channels_by_name(
+                 hosting_channel,
+                 hosting_channel.displayname
+               )
+             ) == 0
+    end
+
+    test "Streamers CAN host a channel", %{
+      target_allowed_hosting: target_channel,
+      hosting_channel_five_days_old: hosting_channel
+    } do
+      assert length(
+               ChannelLookups.search_hostable_channels_by_name(
+                 hosting_channel,
+                 target_channel.displayname
+               )
+             ) == 1
+    end
+
+    test "Streamers timed out from a channel CAN host channel",
+         %{
+           target_allowed_hosting: target_channel,
+           hosting_channel_five_days_old: hosting_channel,
+           ten_days_from_now: ten_days_from_now
+         } do
+      channel_timed_out_user_fixture(target_channel.channel, hosting_channel, ten_days_from_now)
+
+      assert length(
+               ChannelLookups.search_hostable_channels_by_name(
+                 hosting_channel,
+                 target_channel.displayname
+               )
+             ) == 1
+    end
+
+    test "Streamers CAN find more than one channel to host",
+         %{
+           target_allowed_hosting: _target_channel,
+           hosting_channel_five_days_old: hosting_channel,
+           ten_days_from_now: ten_days_from_now
+         } do
+      _target_channel_one = streamer_fixture(%{}, %{allow_hosting: true})
+      _target_channel_two = streamer_fixture(%{}, %{allow_hosting: true})
+      target_channel_three = streamer_fixture(%{}, %{allow_hosting: true})
+
+      channel_timed_out_user_fixture(
+        target_channel_three.channel,
+        hosting_channel,
+        ten_days_from_now
+      )
+
+      # banned
+      _bad_target_one = streamer_fixture(%{is_banned: true}, %{allow_hosting: true})
+      # doesn't allow hosting
+      _bad_target_two = streamer_fixture(%{}, %{allow_hosting: false})
+      # ordinary user, no channel
+      _bad_target_three = user_fixture(%{})
+      bad_target_four = streamer_fixture(%{}, %{allow_hosting: true})
+      # hosting channel banned from target
+      channel_banned_user_fixture(bad_target_four.channel, hosting_channel)
+
+      # includes target_channel
+      assert length(ChannelLookups.search_hostable_channels_by_name(hosting_channel, "user")) == 4
+    end
+
+    test "Already hosted channels should be filtered out of search", %{
+      target_allowed_hosting: target_channel,
+      hosting_channel_five_days_old: hosting_channel
+    } do
+      case ChannelHosts.add_new_host(hosting_channel, hosting_channel.channel, %ChannelHosts{
+             hosting_channel_id: hosting_channel.channel.id,
+             target_channel_id: target_channel.channel.id
+           }) do
+        {:ok, _channel_hosts} ->
+          assert length(
+                   ChannelLookups.search_hostable_channels_by_name(
+                     hosting_channel,
+                     target_channel.displayname
+                   )
+                 ) == 0
+
+        {:error, _channel_hosts} ->
+          flunk("Unable to setup channel host")
+      end
+    end
+
+    test "Search terms should be sanitized", %{hosting_channel_five_days_old: hosting_channel} do
+      assert length(ChannelLookups.search_hostable_channels_by_name(hosting_channel, "user_")) ==
+               0
+
+      assert length(ChannelLookups.search_hostable_channels_by_name(hosting_channel, "%user")) ==
+               0
+
+      assert length(ChannelLookups.search_hostable_channels_by_name(hosting_channel, "user%")) ==
+               0
+
+      assert length(ChannelLookups.search_hostable_channels_by_name(hosting_channel, "%user_%")) ==
+               0
+    end
+
+    test "Search terms must be less than username max size", %{
+      hosting_channel_five_days_old: hosting_channel
+    } do
+      bad_search = "0123456789012345678901234"
+
+      assert length(ChannelLookups.search_hostable_channels_by_name(hosting_channel, bad_search)) ==
+               0
+
+      bad_search = nil
+
+      assert length(ChannelLookups.search_hostable_channels_by_name(hosting_channel, bad_search)) ==
+               0
+    end
+  end
+
+  defp create_followed_hosting_data(_) do
+    user = user_fixture()
+    non_followed_live_channel = streamer_fixture()
+
+    Ecto.Changeset.change(non_followed_live_channel.channel)
+    |> Ecto.Changeset.force_change(:status, "live")
+    |> Repo.update()
+
+    live_channel_hosted = streamer_fixture(%{}, %{status: "live"})
+
+    Ecto.Changeset.change(live_channel_hosted.channel)
+    |> Ecto.Changeset.force_change(:status, "live")
+    |> Repo.update()
+
+    host = streamer_fixture()
+
+    Ecto.Changeset.change(%Glimesh.Streams.ChannelHosts{
+      hosting_channel_id: host.channel.id,
+      target_channel_id: live_channel_hosted.channel.id,
+      status: "hosting"
+    })
+    |> Repo.insert()
+
+    Glimesh.AccountFollows.follow(host, user)
+
+    live_channel_hosted_but_not_followed = streamer_fixture()
+
+    Ecto.Changeset.change(live_channel_hosted_but_not_followed.channel)
+    |> Ecto.Changeset.force_change(:status, "live")
+    |> Repo.update()
+
+    host_not_followed = streamer_fixture()
+
+    Ecto.Changeset.change(%Glimesh.Streams.ChannelHosts{
+      hosting_channel_id: host_not_followed.channel.id,
+      target_channel_id: live_channel_hosted_but_not_followed.channel.id,
+      status: "hosting"
+    })
+    |> Repo.insert()
+
+    live_channel_followed_but_not_hosted = streamer_fixture()
+
+    Ecto.Changeset.change(live_channel_followed_but_not_hosted.channel)
+    |> Ecto.Changeset.force_change(:status, "live")
+    |> Repo.update()
+
+    Glimesh.AccountFollows.follow(live_channel_followed_but_not_hosted, user)
+
+    %{
+      user: user,
+      host: host,
+      live_channel_hosted: live_channel_hosted,
+      non_followed_live_channel: non_followed_live_channel,
+      live_channel_hosted_but_not_followed: live_channel_hosted_but_not_followed,
+      host_not_followed: host_not_followed,
+      live_channel_followed_but_not_hosted: live_channel_followed_but_not_hosted
+    }
+  end
+
+  describe "Followed hosting channels" do
+    setup [:create_followed_hosting_data]
+
+    test "should show up in the search when the followed channel is not live", %{
+      user: user,
+      live_channel_hosted: live_hosted,
+      live_channel_followed_but_not_hosted: live_followed
+    } do
+      results = ChannelLookups.list_live_followed_channels_and_hosts(user)
+      assert length(results) == 2
+      assert Enum.at(results, 0).id == live_followed.channel.id
+      assert Enum.at(results, 0).match_type == "live"
+      assert Enum.at(results, 1).id == live_hosted.channel.id
+      assert Enum.at(results, 1).match_type == "hosting"
+    end
+
+    test "should NOT show duplicates when followed channels host the same live channel", %{
+      user: user,
+      live_channel_hosted: live_hosted,
+      live_channel_followed_but_not_hosted: live_followed
+    } do
+      followed_channel_same_host_target = streamer_fixture()
+      Glimesh.AccountFollows.follow(followed_channel_same_host_target, user)
+
+      Ecto.Changeset.change(%Glimesh.Streams.ChannelHosts{
+        hosting_channel_id: followed_channel_same_host_target.channel.id,
+        target_channel_id: live_hosted.channel.id,
+        status: "hosting"
+      })
+      |> Repo.insert()
+
+      results = ChannelLookups.list_live_followed_channels_and_hosts(user)
+      assert length(results) == 2
+      assert Enum.at(results, 0).id == live_followed.channel.id
+      assert Enum.at(results, 0).match_type == "live"
+      assert Enum.at(results, 1).id == live_hosted.channel.id
+      assert Enum.at(results, 1).match_type == "hosting"
+    end
+
+    test "should show followed live channel without duplicating it when it is hosted by an offline channel that is followed",
+         %{
+           user: user,
+           live_channel_hosted: live_hosted,
+           live_channel_followed_but_not_hosted: live_followed
+         } do
+      followed_offline_channel_same_host_target = streamer_fixture()
+      Glimesh.AccountFollows.follow(followed_offline_channel_same_host_target, user)
+
+      Ecto.Changeset.change(%Glimesh.Streams.ChannelHosts{
+        hosting_channel_id: followed_offline_channel_same_host_target.channel.id,
+        target_channel_id: live_followed.channel.id,
+        status: "hosting"
+      })
+      |> Repo.insert()
+
+      results = ChannelLookups.list_live_followed_channels_and_hosts(user)
+      assert length(results) == 2
+      assert Enum.at(results, 0).id == live_followed.channel.id
+      assert Enum.at(results, 0).match_type == "live"
+      assert Enum.at(results, 1).id == live_hosted.channel.id
+      assert Enum.at(results, 1).match_type == "hosting"
+    end
+
+    test "should prefer live channels over hosted when duplicates occur", %{
+      user: user,
+      live_channel_hosted: live_hosted,
+      live_channel_followed_but_not_hosted: live_followed
+    } do
+      # sanity check
+      results = ChannelLookups.list_live_followed_channels_and_hosts(user)
+      assert length(results) == 2
+      assert Enum.at(results, 0).id == live_followed.channel.id
+      assert Enum.at(results, 0).match_type == "live"
+      assert Enum.at(results, 1).id == live_hosted.channel.id
+      assert Enum.at(results, 1).match_type == "hosting"
+
+      # if the user follows the channel being hosted, it should show up in the live section and not as a "hosted" stream.
+      Glimesh.AccountFollows.follow(live_hosted, user)
+      results = ChannelLookups.list_live_followed_channels_and_hosts(user)
+      assert length(results) == 2
+      # I don't do an ID check here as the results are not sorted and could be random
+      assert Enum.at(results, 0).match_type == "live"
+      assert Enum.at(results, 1).match_type == "live"
+    end
+
+    test "followed channels and followed hosted channels counts should be accurate", %{
+      user: user,
+      live_channel_hosted: live_hosted
+    } do
+      assert ChannelLookups.count_live_followed_channels_that_are_hosting(user) == 1
+      assert length(ChannelLookups.list_live_followed_channels(user)) == 1
+
+      Glimesh.AccountFollows.follow(live_hosted, user)
+      assert ChannelLookups.count_live_followed_channels_that_are_hosting(user) == 0
+      assert length(ChannelLookups.list_live_followed_channels(user)) == 2
     end
   end
 end

--- a/test/glimesh_web/live/channel_settings_live/hosting_test.exs
+++ b/test/glimesh_web/live/channel_settings_live/hosting_test.exs
@@ -1,0 +1,261 @@
+defmodule GlimeshWeb.ChannelSettingsLive.HostingTest do
+  use GlimeshWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+
+  describe "Allow Hosting Settings" do
+    setup [:register_and_log_in_streamer_that_can_host]
+
+    test "can set allow hosting", %{conn: conn, user: user, channel: channel} do
+      {:ok, view, _html} =
+        live_isolated(conn, GlimeshWeb.ChannelSettingsLive.Hosting, session: %{"user" => user})
+
+      form = view |> element(".form_allow_hosting")
+
+      assert render_change(form, %{
+               "channel" => %{"allow_hosting" => "true"}
+             }) =~
+               "Saved Hosting Preference."
+
+      assert Glimesh.ChannelLookups.get_channel!(channel.id).allow_hosting == true
+    end
+
+    test "can set disallow hosting", %{conn: conn, user: user, channel: channel} do
+      {:ok, view, _html} =
+        live_isolated(conn, GlimeshWeb.ChannelSettingsLive.Hosting, session: %{"user" => user})
+
+      form = view |> element(".form_allow_hosting")
+
+      assert render_change(form, %{
+               "channel" => %{"allow_hosting" => "false"}
+             }) =~
+               "Saved Hosting Preference."
+
+      assert Glimesh.ChannelLookups.get_channel!(channel.id).allow_hosting == false
+    end
+  end
+
+  defp create_hosting_target_data(_) do
+    %{
+      target_allowed_hosting:
+        Glimesh.AccountsFixtures.streamer_fixture(%{}, %{allow_hosting: true})
+    }
+  end
+
+  describe "New Add Host Settings" do
+    setup [:register_and_log_in_streamer_that_can_host, :create_hosting_target_data]
+
+    test "can find a channel to host", %{
+      conn: conn,
+      user: user,
+      target_allowed_hosting: target_channel
+    } do
+      {:ok, view, _html} =
+        live_isolated(conn, GlimeshWeb.ChannelSettingsLive.Hosting, session: %{"user" => user})
+
+      view
+      |> element(".form_add_channel")
+      |> render_change(%{"suggest" => %{"add_channel" => "user"}})
+
+      assert has_element?(view, "#channel-lookup-#{target_channel.id}")
+    end
+
+    test "can host a channel", %{conn: conn, target_allowed_hosting: target_channel} do
+      {:ok, view, _html} = live(conn, Routes.user_settings_path(conn, :hosting))
+
+      render_hook(view, :add_channel_selection_made, %{
+        user_id: target_channel.id,
+        username: target_channel.displayname,
+        channel_id: target_channel.channel.id
+      })
+
+      assert {:ok, conn} =
+               view
+               |> element("#add-channel-button")
+               |> render_click()
+               |> follow_redirect(conn, Routes.user_settings_path(conn, :hosting))
+
+      assert html_response(conn, 200) =~ "Channel added"
+
+      {:ok, redirected_view, _html} = live(conn)
+      assert has_element?(redirected_view, "#hosted-row-#{target_channel.channel.id}")
+    end
+
+    test "can host a channel without using the picker", %{
+      conn: conn,
+      target_allowed_hosting: target_channel
+    } do
+      {:ok, view, _html} = live(conn, Routes.user_settings_path(conn, :hosting))
+
+      assert {:ok, conn} =
+               view
+               |> element("#add-channel-button")
+               |> render_click(%{"name" => target_channel.displayname, "selected" => ""})
+               |> follow_redirect(conn, Routes.user_settings_path(conn, :hosting))
+
+      assert html_response(conn, 200) =~ "Channel added"
+
+      {:ok, redirected_view, _html} = live(conn)
+      assert has_element?(redirected_view, "#hosted-row-#{target_channel.channel.id}")
+    end
+  end
+
+  defp associate_already_hosted_data(%{conn: conn}) do
+    hosting_target_ready = Glimesh.AccountsFixtures.streamer_fixture(%{}, %{allow_hosting: true})
+    hosting_target_error = Glimesh.AccountsFixtures.streamer_fixture(%{}, %{allow_hosting: true})
+    hosting_target_active = Glimesh.AccountsFixtures.streamer_fixture(%{}, %{allow_hosting: true})
+
+    %{conn: conn, user: user, channel: channel} =
+      register_and_log_in_streamer_that_can_host(%{conn: conn})
+
+    channel_host =
+      Glimesh.Streams.ChannelHosts.add_new_host(
+        user,
+        channel,
+        %Glimesh.Streams.ChannelHosts{
+          hosting_channel_id: channel.id,
+          target_channel_id: hosting_target_ready.channel.id,
+          status: "ready"
+        },
+        %{}
+      )
+
+    Glimesh.Streams.ChannelHosts.add_new_host(
+      user,
+      channel,
+      %Glimesh.Streams.ChannelHosts{
+        hosting_channel_id: channel.id,
+        target_channel_id: hosting_target_error.channel.id,
+        status: "error"
+      },
+      %{}
+    )
+
+    Glimesh.Streams.ChannelHosts.add_new_host(
+      user,
+      channel,
+      %Glimesh.Streams.ChannelHosts{
+        hosting_channel_id: channel.id,
+        target_channel_id: hosting_target_active.channel.id,
+        status: "hosting"
+      },
+      %{}
+    )
+
+    %{
+      conn: conn,
+      user: user,
+      channel: channel,
+      hosting_target_ready: hosting_target_ready,
+      hosting_target_error: hosting_target_error,
+      hosting_target_active: hosting_target_active,
+      channel_host_ready: channel_host
+    }
+  end
+
+  describe "Existing add hosts settings" do
+    setup [:associate_already_hosted_data]
+
+    test "Hosted channels appear on the setup page with proper status",
+         %{
+           conn: conn,
+           user: user,
+           hosting_target_ready: ready_target,
+           hosting_target_error: error_target,
+           hosting_target_active: active_target
+         } do
+      {:ok, view, _html} =
+        live_isolated(conn, GlimeshWeb.ChannelSettingsLive.Hosting, session: %{"user" => user})
+
+      assert has_element?(view, "#hosted-row-#{ready_target.channel.id}")
+      assert has_element?(view, "#hosted-row-#{error_target.channel.id}")
+      assert has_element?(view, "#hosted-row-#{active_target.channel.id}")
+      assert has_element?(view, "#hosted-row-#{ready_target.channel.id}-status > .fa-check")
+
+      assert has_element?(
+               view,
+               "#hosted-row-#{error_target.channel.id}-status > .fa-circle-xmark"
+             )
+
+      assert has_element?(view, "#hosted-row-#{active_target.channel.id}-status > .fa-tv")
+    end
+
+    test "Can remove hosted channels", %{conn: conn, hosting_target_ready: target} do
+      {:ok, view, _html} = live(conn, Routes.user_settings_path(conn, :hosting))
+
+      assert {:ok, conn} =
+               view
+               |> element("#remove-channel-button-#{target.channel.id}")
+               |> render_click()
+               |> follow_redirect(conn, Routes.user_settings_path(conn, :hosting))
+
+      assert html_response(conn, 200) =~ "Hosting target removed"
+
+      {:ok, redirected_view, _html} = live(conn)
+      refute has_element?(redirected_view, "#hosted-row-#{target.channel.id}")
+    end
+  end
+
+  describe "Can't host others" do
+    test "when you haven't streamed enough", %{conn: conn} do
+      user =
+        Glimesh.AccountsFixtures.streamer_fixture()
+        |> Glimesh.AccountsFixtures.change_inserted_at_for_user(
+          NaiveDateTime.add(NaiveDateTime.utc_now(), 86_400 * -6)
+          |> NaiveDateTime.truncate(:second)
+        )
+
+      conn = log_in_user(conn, user)
+
+      {:ok, view, _html} = live(conn, Routes.user_settings_path(conn, :hosting))
+
+      refute has_element?(view, "#add-channel-button")
+      assert has_element?(view, "#not-qualified")
+    end
+
+    test "when your account isn't old enough", %{conn: conn} do
+      user = Glimesh.AccountsFixtures.streamer_fixture()
+
+      Glimesh.Streams.create_stream(user.channel, %{
+        started_at:
+          NaiveDateTime.add(NaiveDateTime.utc_now(), 60 * 60 * -10)
+          |> NaiveDateTime.truncate(:second),
+        ended_at: NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
+      })
+
+      conn = log_in_user(conn, user)
+
+      {:ok, view, _html} = live(conn, Routes.user_settings_path(conn, :hosting))
+
+      refute has_element?(view, "#add-channel-button")
+      assert has_element?(view, "#not-qualified")
+    end
+
+    test "when your account isn't email verified", %{conn: conn} do
+      user =
+        Glimesh.AccountsFixtures.streamer_fixture()
+        |> Glimesh.AccountsFixtures.change_inserted_at_for_user(
+          NaiveDateTime.add(NaiveDateTime.utc_now(), 86_400 * -6)
+          |> NaiveDateTime.truncate(:second)
+        )
+
+      user
+      |> Ecto.Changeset.change(%{confirmed_at: nil})
+      |> Glimesh.Repo.update()
+
+      Glimesh.Streams.create_stream(user.channel, %{
+        started_at:
+          NaiveDateTime.add(NaiveDateTime.utc_now(), 60 * 60 * -10)
+          |> NaiveDateTime.truncate(:second),
+        ended_at: NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
+      })
+
+      conn = log_in_user(conn, user)
+
+      {:ok, view, _html} = live(conn, Routes.user_settings_path(conn, :hosting))
+
+      refute has_element?(view, "#add-channel-button")
+      assert has_element?(view, "#not-qualified")
+    end
+  end
+end

--- a/test/glimesh_web/live/channel_settings_live/hosting_test.exs
+++ b/test/glimesh_web/live/channel_settings_live/hosting_test.exs
@@ -174,7 +174,7 @@ defmodule GlimeshWeb.ChannelSettingsLive.HostingTest do
 
       assert has_element?(
                view,
-               "#hosted-row-#{error_target.channel.id}-status > .fa-circle-xmark"
+               "#hosted-row-#{error_target.channel.id}-status > .fa-times-circle"
              )
 
       assert has_element?(view, "#hosted-row-#{active_target.channel.id}-status > .fa-tv")

--- a/test/glimesh_web/views/layout_view_test.exs
+++ b/test/glimesh_web/views/layout_view_test.exs
@@ -1,8 +1,63 @@
 defmodule GlimeshWeb.LayoutViewTest do
   use GlimeshWeb.ConnCase, async: true
 
-  # When testing helpers, you may want to import Phoenix.HTML and
-  # use functions such as safe_to_string() to convert the helper
-  # result into an HTML string.
-  # import Phoenix.HTML
+  import Glimesh.AccountsFixtures
+
+  defp create_live_stream(_) do
+    streamer = streamer_fixture(%{}, %{})
+    Glimesh.Streams.start_stream(streamer.channel)
+
+    %{
+      channel: streamer.channel,
+      streamer: streamer
+    }
+  end
+
+  describe "Following/Hosted count for logged in user" do
+    setup [:register_and_log_in_user, :create_live_stream]
+
+    test "No following or hosted count if not following anyone", %{user: user} do
+      refute GlimeshWeb.LayoutView.count_live_following_channels(%{assigns: %{current_user: user}})
+    end
+
+    test "Following count when following people", %{streamer: streamer, user: user} do
+      Glimesh.AccountFollows.follow(streamer, user)
+
+      assert GlimeshWeb.LayoutView.count_live_following_channels(%{assigns: %{current_user: user}}) ==
+               1
+    end
+
+    test "Hosting count when following people who are hosting others", %{
+      channel: channel,
+      user: user
+    } do
+      followed_hosting_others = streamer_fixture(%{}, %{})
+
+      %Glimesh.Streams.ChannelHosts{
+        hosting_channel_id: followed_hosting_others.channel.id,
+        target_channel_id: channel.id,
+        status: "hosting"
+      }
+      |> Glimesh.Repo.insert()
+
+      Glimesh.AccountFollows.follow(followed_hosting_others, user)
+
+      refute GlimeshWeb.LayoutView.count_live_following_channels(%{assigns: %{current_user: user}})
+
+      assert GlimeshWeb.LayoutView.count_live_hosted_channels(%{assigns: %{current_user: user}}) ==
+               1
+    end
+  end
+
+  describe "No following/hosted counts for non-logged in users" do
+    setup [:create_live_stream]
+
+    test "No following count" do
+      refute GlimeshWeb.LayoutView.count_live_following_channels(%{})
+    end
+
+    test "No hosted count" do
+      refute GlimeshWeb.LayoutView.count_live_hosted_channels(%{})
+    end
+  end
 end

--- a/test/jobs/auto_host_cron_test.exs
+++ b/test/jobs/auto_host_cron_test.exs
@@ -1,0 +1,137 @@
+defmodule Glimesh.Jobs.AutoHostCronTest do
+  use Glimesh.DataCase
+  use Bamboo.Test
+
+  import Glimesh.AccountsFixtures
+
+  alias Glimesh.Streams
+  alias Glimesh.Streams.{Channel, ChannelHosts}
+  alias Glimesh.Jobs.AutoHostCron
+
+  defp create_host_task_data(_) do
+    hosting_channel =
+      streamer_fixture(%{}, %{})
+      |> change_inserted_at_for_user(
+        NaiveDateTime.add(NaiveDateTime.utc_now(), 86_400 * -6)
+        |> NaiveDateTime.truncate(:second)
+      )
+
+    Streams.create_stream(hosting_channel.channel, %{
+      started_at:
+        NaiveDateTime.add(NaiveDateTime.utc_now(), 60 * 60 * -10)
+        |> NaiveDateTime.truncate(:second),
+      ended_at: NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
+    })
+
+    good_target = streamer_fixture(%{}, %{allow_hosting: true})
+
+    Channel.changeset(good_target.channel, %{status: "live"})
+    |> Repo.update()
+
+    {:ok, good_target_channel_hosts} =
+      ChannelHosts.add_new_host(hosting_channel, hosting_channel.channel, %ChannelHosts{
+        hosting_channel_id: hosting_channel.channel.id,
+        target_channel_id: good_target.channel.id
+      })
+
+    bad_target_not_allow_hosting = streamer_fixture(%{}, %{allow_hosting: true})
+
+    {:ok, bad_target_not_allow_hosting_channel_hosts} =
+      ChannelHosts.add_new_host(hosting_channel, hosting_channel.channel, %ChannelHosts{
+        hosting_channel_id: hosting_channel.channel.id,
+        target_channel_id: bad_target_not_allow_hosting.channel.id
+      })
+
+    Ecto.Changeset.change(bad_target_not_allow_hosting.channel)
+    |> Ecto.Changeset.force_change(:allow_hosting, false)
+    |> Repo.update()
+
+    hosting_target_no_longer_live = streamer_fixture(%{}, %{allow_hosting: true})
+
+    {:ok, hosting_target_no_longer_live_channel_hosts} =
+      ChannelHosts.add_new_host(hosting_channel, hosting_channel.channel, %ChannelHosts{
+        hosting_channel_id: hosting_channel.channel.id,
+        target_channel_id: hosting_target_no_longer_live.channel.id,
+        status: "hosting",
+        last_hosted_date: NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
+      })
+
+    %{
+      host: hosting_channel,
+      good_target: good_target,
+      good_target_channel_hosts: good_target_channel_hosts,
+      bad_target_not_allow_hosting: bad_target_not_allow_hosting,
+      bad_target_not_allow_hosting_channel_hosts: bad_target_not_allow_hosting_channel_hosts,
+      hosting_target_no_longer_live: hosting_target_no_longer_live,
+      hosting_target_no_longer_live_channel_hosts: hosting_target_no_longer_live_channel_hosts
+    }
+  end
+
+  describe "Auto Host Job start hosting tasks" do
+    setup :create_host_task_data
+
+    test "Can Host a Channel", %{
+      good_target_channel_hosts: good_target,
+      host: host,
+      hosting_target_no_longer_live_channel_hosts: bad_target
+    } do
+      assert :ok = AutoHostCron.perform([])
+
+      assert Repo.get_by(ChannelHosts, %{id: good_target.id, status: "hosting"})
+      assert Repo.get_by(ChannelHosts, %{id: bad_target.id, status: "ready"})
+
+      assert length(
+               Repo.all(
+                 from ch in ChannelHosts,
+                   where: ch.hosting_channel_id == ^host.channel.id and ch.status == "hosting"
+               )
+             ) == 1
+    end
+
+    test "Will not host more than one target per host channel", %{
+      good_target_channel_hosts: good_target,
+      good_target: good_target_channel,
+      host: host
+    } do
+      ChannelHosts.changeset(good_target, %{status: "hosting"})
+      |> Repo.update()
+
+      Channel.changeset(good_target_channel.channel, %{status: "live"})
+      |> Repo.update()
+
+      assert :ok = AutoHostCron.perform([])
+
+      assert length(
+               Repo.all(
+                 from ch in ChannelHosts,
+                   where: ch.hosting_channel_id == ^host.channel.id and ch.status == "hosting"
+               )
+             ) == 1
+    end
+
+    test "Will re-check errored targets", %{
+      bad_target_not_allow_hosting: bad_target_channel,
+      bad_target_not_allow_hosting_channel_hosts: bad_target
+    } do
+      assert :ok = AutoHostCron.perform([])
+
+      assert length(
+               Repo.all(
+                 from ch in ChannelHosts, where: ch.id == ^bad_target.id and ch.status == "error"
+               )
+             ) == 1
+
+      Ecto.Changeset.change(bad_target_channel.channel)
+      |> Ecto.Changeset.force_change(:allow_hosting, true)
+      |> Repo.update()
+
+      assert :ok = AutoHostCron.perform([])
+
+      assert length(
+               Repo.all(
+                 from ch in ChannelHosts, where: ch.id == ^bad_target.id and ch.status == "ready"
+               )
+             ) == 1
+    end
+  end
+end

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -67,6 +67,32 @@ defmodule GlimeshWeb.ConnCase do
   end
 
   @doc """
+  Setup helper that registers and logs in a streamer that is eligible to host other streams
+
+      setup :register_and_log_in_streamer_that_can_host
+
+  """
+  def register_and_log_in_streamer_that_can_host(%{conn: conn}) do
+    user =
+      Glimesh.AccountsFixtures.streamer_fixture()
+      |> Glimesh.AccountsFixtures.change_inserted_at_for_user(
+        NaiveDateTime.add(NaiveDateTime.utc_now(), 86_400 * -6)
+        |> NaiveDateTime.truncate(:second)
+      )
+
+    channel = Glimesh.ChannelLookups.get_channel_for_user(user)
+
+    Glimesh.Streams.create_stream(channel, %{
+      started_at:
+        NaiveDateTime.add(NaiveDateTime.utc_now(), 60 * 60 * -10)
+        |> NaiveDateTime.truncate(:second),
+      ended_at: NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
+    })
+
+    %{conn: log_in_user(conn, user), user: user, channel: channel}
+  end
+
+  @doc """
   Setup helper that registers and logs in admin user.
 
       setup :register_and_log_in_admin_user

--- a/test/support/fixtures/accounts_fixtures.ex
+++ b/test/support/fixtures/accounts_fixtures.ex
@@ -78,6 +78,26 @@ defmodule Glimesh.AccountsFixtures do
     user
   end
 
+  def change_inserted_at_for_user(%Glimesh.Accounts.User{} = user, new_inserted_at) do
+    user
+    |> Ecto.Changeset.change()
+    |> Ecto.Changeset.force_change(:inserted_at, new_inserted_at)
+    |> Glimesh.Repo.update!()
+
+    Glimesh.Accounts.get_user!(user.id)
+    |> Glimesh.Repo.preload(channel: [:category, :subcategory, :tags])
+  end
+
+  def change_user_banned_status(%Glimesh.Accounts.User{} = user, new_status) do
+    user
+    |> Ecto.Changeset.change()
+    |> Ecto.Changeset.force_change(:is_banned, new_status)
+    |> Glimesh.Repo.update()
+
+    Glimesh.Accounts.get_user!(user.id)
+    |> Glimesh.Repo.preload(channel: [:category, :subcategory, :tags])
+  end
+
   def admin_fixture(_attrs \\ %{}) do
     user_fixture(%{is_admin: true})
   end

--- a/test/support/fixtures/streams_fixtures.ex
+++ b/test/support/fixtures/streams_fixtures.ex
@@ -1,0 +1,35 @@
+defmodule Glimesh.StreamsFixtures do
+  @moduledoc """
+    Test helpers for the Glimesh.Streams functions
+  """
+
+  def channel_banned_user_fixture(
+        %Glimesh.Streams.Channel{} = channel,
+        %Glimesh.Accounts.User{} = banned_user
+      ) do
+    {:ok, channel_ban} =
+      %Glimesh.Streams.ChannelBan{channel: channel, user: banned_user}
+      |> Glimesh.Streams.ChannelBan.changeset(%{expires_at: nil})
+      |> Glimesh.Repo.insert()
+
+    channel_ban
+  end
+
+  def channel_timed_out_user_fixture(
+        %Glimesh.Streams.Channel{} = channel,
+        %Glimesh.Accounts.User{} = banned_user,
+        until
+      ) do
+    {:ok, channel_ban} =
+      %Glimesh.Streams.ChannelBan{channel: channel, user: banned_user}
+      |> Glimesh.Streams.ChannelBan.changeset(%{expires_at: until})
+      |> Glimesh.Repo.insert()
+
+    channel_ban
+  end
+
+  def change_channel_status(%Glimesh.Streams.Channel{} = channel, status) do
+    Glimesh.Streams.change_channel(channel, %{status: status})
+    |> Glimesh.Repo.update()
+  end
+end


### PR DESCRIPTION
## Summary
Hosting is a process by which a streamer may select other streams to promote to their community when their stream is offline.  Typically the streamer will manage a list of other streams to promote ahead of time and the hosting process will commence without their direct intervention.  This is in stark contrast to Raiding which must be initiated while live and will actively pull the viewers from the initiating live stream to the target live stream.

## Feature Scope (Minimum Viable Feature)
- This feature is not available to viewers.  A user must have a channel to participate.
- Streamers must be able to manage the list of channels they wish to host.
- Streamers must meet minimum qualifications to host others.  This is to not only make it more difficult for automated systems to create unwanted spam hosting but also to give the recipients of hosts options to block hosts who break their community's rules.
- Viewers who land on a host's channel page will be redirected to the channel the streamer is hosting without the need for manual intervention.  Viewers will also be presented with a message that the channel is being hosted to alleviate any confusion the sudden redirect may incur.
- A channel that is live cannot host another channel until they go offline.
- Hosting tends to be an invisible feature on most other streaming sites and is thus largely ineffectual.  To help make this feature more useful (ie. visible) to the community, viewers who follow a channel that is hosting another will see those hosted channels in their "Following" page.
- The act of hosting another channel is passive from the perspective of the streamers.  This will necessitate the need for a background job to run periodically to manage this process.
- Since hosting is automated and unconstrained by time periods, it should not participate in live notifications (viewers will probably not appreciate a message from us at 2am for a channel they don't directly follow).

## Features Outside Initial Scope
- Chat notifications when a channel is hosted by another.  This could have implications to the various chat bots the community's streamers use and thus should be a specific change with its own scope.
- Hosting statistics to show how many times a stream was hosted.  This was originally in-scope, but I am having difficulty understanding how the statistics are tabulated in the codebase.  I will revisit this at a later date.
- Moderators of hosting channels will redirect to the channel being hosted just like normal viewers (the channel owner does not redirect).  This seems like a low priority right now but could be addressed in the future (especially if an editor role is introduced to the platform).
- Stopping or clearing a host.  We have a persistent issue on the platform where occasionally channels will "get stuck" in live status even though they are not live.  If that stuck channel is being hosted it will not be un-hosted until its status returns to "offline".  As of this initial release, hosting streamers do not have direct control over what channel the system picks as its hosting target from the list.
- UI design work.  I've done my best to keep the design of the feature consistent with the overall site design but there are rough edges (type-ahead field suggestions is one example) and it would not hurt to have someone with a better eye for UI/UX design to give this a once-over.
- API hooks/Mobile hooks.  These will have to be explored in the future as I will need to learn what is involved with that type of change.

## New Channel Settings Page: Hosting
![settings-section](https://user-images.githubusercontent.com/5142625/147987019-4a955160-fee8-44a1-9513-78beb3b3e88d.png)

![settings-page](https://user-images.githubusercontent.com/5142625/147990845-c85bace5-db8c-4f9d-851e-784d7bff7214.png)

From the new hosting settings page, streamers can add/remove channels to host and choose whether or not to allow other streamers to host their channel.  Hosting other channels does NOT require a streamer allow others to host them.

### Hosting Qualifications
To host other channels a user must meet these qualifications:
- They must have a channel that is active: (channel.inaccessible = false, channel.can_stream = true)
- They must have streamed at least 10 hours: (streams.get_channel_hours() >= 10)
- Their user account must be at least 5 days old: (accounts.get_account_age_in_days() >= 5; user.inserted_at >= 5 days ago)
- They must not be banned from the platform: (user.is_banned = false)

Furthermore, a streamer can only select channels for hosting that meet these qualifications:
- The streamer MUST NOT be banned from the target chat, but CAN be timed out (channel_ban.expires_at != nil)
- The target must allow hosting (channel.allow_hosting = true)
- The target must have an active channel: (channel.inaccessible = false, channel.can_stream = true)
- The target must not be banned from the platform: (user.is_banned = false)

NOTE: The auto hosting job will check these qualifications on each run and should handle scenarios where a host or target is temporarily disqualified (for instance, banned then un-banned) without intervention from the streamers.

### Allow hosting toggle
"Other streamers may host my channel" is a simple true/false toggle that will save automatically upon change.  It defaults to not allow (false) so all new and existing streamers will have to turn it on if they so desire.  It affects a new column added to the "channels" database table ("allow_hosting", boolean, nullable: true, default: false)

### Add channel field/button
Streamers can type/paste the name of another channel into the add channel field then click the button to attempt to add that channel to their hosting list.  The add may fail if the channel in question does not meet the hosting qualifications listed in the previous section.  

![typeahead](https://user-images.githubusercontent.com/5142625/147993560-1242c80e-2759-4da2-b386-2baf2f299e41.png)

The input field supports case-insensitive, type-ahead functionality and will provide up to 10 suggestions for channels whose name starts with the text input, meet the hosting qualifications specified above, and are not already on the streamer's hosting list.  The maximum length of the input field is 24 since that is the maximum username/displayname size enforced by the system when creating users.  The input field is sanitized against the following characters that have special meaning in an "ilike" sql statement: ('\\', '_', '%')  Though security researchers do not recommend using "like" statements, attempting to sanitize the postgres text search mechanisms looked far more daunting.  My hope is the 24 character max length, the sanitization regex, and the use of sql replacement tokens will be sufficient to curtail sql injection attempts against this field.

#### Development notes
The Typeahead field is separated into it's own live_component so it can potentially be re-used in future pages.  It is composed of the following files: "channel_lookup_typeahead.ex", "channel-lookup-typeahead.scss", and "ChannelLookupTypeahead.js".


### Hosting channel list
![hosting-channels-list](https://user-images.githubusercontent.com/5142625/147993801-4c1f7dfb-1b61-4678-9edc-9e1310e72281.png)

The hosting channel list displays what channels the streamer has selected for their hosting rotation, the status of the hosting target, the last time the target was hosted by the system, and a remove button to remove the target from the list.


#### Status codes
![status-ready](https://user-images.githubusercontent.com/5142625/147998017-6e3d2e39-1cc4-4bb7-87ab-53ab84ee2bcd.png) = "ready"; The target channel is in the hosting rotation.
![status-hosting](https://user-images.githubusercontent.com/5142625/147998089-945cb94f-9819-4fd8-813e-950f6f21a367.png) = "hosting"; The target channel is currently being hosted.  A maximum of one such target can be in this status.
![status-error](https://user-images.githubusercontent.com/5142625/147998172-2aebbfae-3efa-4295-93a9-89f4cc9ed63e.png) = "error"; The target channel no longer qualifies for hosting and is not in rotation.  This can be a temporary status as it is based on all the hosting qualification checks enumerated earlier in this document and will be re-checked every time the auto-hosting background job runs.

#### Last hosted and selection of next channel to host
The auto host job selects the next channel to host from the hosting list as follows:
- Is the hosting channel offline (channel.status = "offline")?
- Is the target in "ready" status (channel_hosts.status = "ready")?
- Is the target channel live (channel.status = "live")?
- Select the target channel with the longest amount of time since last hosted (order by: channel_hosts.last_hosted, asc)
- Target channels that have never been hosted by the streamer take priority (channel_hosts.last_hosted is nil => 1/1/1970 00:00:00)
- In the event of a tie, whichever database record is delivered to us first wins (the outcome can be random).

#### Development notes
This list is stored in a new database table with the following structure:

![channel_hosts_table](https://user-images.githubusercontent.com/5142625/148007611-26d94f0b-d087-49d2-a8e2-d77689ca47be.png)

## Being Hosted, Channel Page
Viewers who arrive on an offline channel page that is hosting another channel will be automatically redirected to the hosted channel and presented with a message at the top of the screen informing them that the channel they originally went to is hosting another channel.  Viewers can dismiss the message by clicking the "x" icon at the top right of the message box.  Viewers can return to the hosting channel by clicking the "Return to host" button.  The message has the following format:
"{host avatar} {host channel name} is hosting {target channel name} {target channel avatar}"

![being-hosted](https://user-images.githubusercontent.com/5142625/148001071-9bdb51ce-90c1-4c70-92a9-6c6a10b23b7f.png)

## Hosting Another Channel, Channel Page
The owner of the hosting channel, viewers who have clicked "Return to Host", or viewers that have followed a link to a host's channel page that contains "?follow_host=false" at the end of the URL will be presented with a message that this channel is hosting another channel.  Viewers may then click the "Go There" button to go to the stream being hosted or can dismiss the message by clicking the "x" at the top-right corner of the message box. 

![hosting](https://user-images.githubusercontent.com/5142625/148001766-e96b2fd4-79f8-4eb7-8699-c8a57517dbf9.png)

The channel owner will not automatically redirect to a channel they are hosting as this would be inconvenient if they are prepping to go live or change their stream title/tags/category (channel moderators WILL redirect in this current iteration).  A channel owner that wishes to advertise a link to their channel (for instance in a pinned tweet or a linktr.ee page) can add "?follow_host=false" to the end of their channel URL so visitors will not automatically redirect to a channel being hosted.  For example:

` https://glimesh.tv/memtest86/?follow_host=false `

#### Development Notes
- The URL on the hosting target page has "?host=username" appended to it.  I've tried to stay clear of putting primary key ids in the URL as that is generally frowned upon in the security community.  Since the username is already a known entity used in channel URLs (and not a primary key), I felt that was secure enough.
- I check whether the channel is hosting in the initial mount of the page then do a hard 302 redirect from there when appropriate.  I felt this was a more straightforward and reliable way of handling this then attempting a push_redirect inline and hoping the page profile, support modal, stream, and chat channel would change appropriately.

## The Following Page
Viewers who follow channels that are hosting other channels will now see those hosted channels in their following page with a special "Hosted" badge on them.  This is in addition to seeing live channels they follow.

![following-live](https://user-images.githubusercontent.com/5142625/148005209-bc42aeb8-6999-4e94-b4e8-08d27eaf8ece.png)

The database query that populates this page attempts to do the following:
- **Remove duplicates.**  If a viewer directly follows "Channel A" which is live and "Channel B" which is not live but is hosting "Channel A", they should only see "Channel A" on the following page (without the "hosted" badge).
- **Prefer directly followed live channels over hosted ones.**  If a user follows two channels "Channel Z" which is live and "Channel K" which is hosting "Channel J", "Channel Z" should show first on the following page and "Channel J" should appear last.

## The Following Badge (count)
Viewers will see a notification badge next to the "Following" category at the top of the page when one or more channels they are following are live.  This "call to action" is presented as a white number on a red background.

![following-badge-live](https://user-images.githubusercontent.com/5142625/148006511-b2b67cff-6f7b-4f31-a52e-1344d7f1336e.png)

In an effort to find a middle ground where we can promote hosted streams without making the following badge too noisy (thus prompting users to ignore it), I've added a white number on blue badge case.  This number will ONLY appear when all the channels a viewer is following are offline but at least some of them are hosting other channels.  Similar to the red badge, the blue badge number reflects the total number of hosted channels.

![following-badge-not-live](https://user-images.githubusercontent.com/5142625/148006949-729f794c-6e05-4b45-84d8-c082b46a9ba6.png)

![following-hosted](https://user-images.githubusercontent.com/5142625/148007055-4bfd6faa-39a0-4197-a07e-fa05c363d3ca.png)

## Auto Host Job
The linchpin of the hosting feature is the auto hosting job.  This job utilizes Rihanna to run every 10 minutes, so streamers should not expect to see their channel begin to host others immediately upon going offline.  That said, viewers will no longer be redirected to a host-ed channel when the host-ing channel goes live (even though it may take up to 10 minutes for the database to reflect that the channel is no longer host-ing another).  This job has the following tasks to perform in order:

1. Check all hosting targets that are in error status (channel_hosts.status = "error") and see if they re-qualify for hosting and can return to "ready" status.
2. Un-host any target channels that are no longer live (channel.status = "offline") or are the target of host channels that are now live (channel.status = "live").
3. Check all hosting targets that are in ready status (channel_hosts.status = "ready") and see if they still qualify for hosting.  If they no longer qualify, set them to error status.
4. Look at all channels currently live (channel.status = "live"), determine if they are host targets, and then select channels to host them that are not currently hosting other channels.

After each step above, the job will write an info level log with the number of records updated.  I decided to keep these update statements as raw sql since they are fairly complex and were becoming hard to read in Ecto.Query form.  The job does not attempt to retry if it fails.

## Security Considerations
The following are points to consider when evaluating this feature from a security standpoint.  I've made every effort to code in a secure manner but that does not mean I haven't goofed; especially given my inexperience with the Elixir language.
- The add channel input field on the hosting settings page can potentially be subject to sql injection attacks.  I do sanitize the input and use the standard Ecto query syntax to perform the "ilike" database operation.
- I use Bodyguard to prevent anyone besides the channel owner from adding or removing hosted channel targets.  My inexperience with Elixir though means that I don't know if I've implemented those security checks properly or completely.
- The auto hosting background job does not take user input so it should be relatively safe.
- A hosted channel will now show the host username in the URL query string.  As this username is utilized in a standard channel URL I don't believe this will pose any additional security risk.

## Performance Considerations
The following are points to consider when evaluating this feature from a performance standpoint.  Whenever possible, I have offloaded much of the heavy lifting to the database.  However, I only have a small development database with few records in it so I'm not able to really test this feature under load.

- ChannelLookups.search_hostable_channels_by_name() will run for each character entered in the add channels text input field and utilizes two sub-queries with a limit of 10.
- ChannelLookups.list_live_followed_channels_and_hosts() will run whenever a user goes to their "Following" page.  It uses several joins and a "union all".  On my local machine, postgres ranks the explain plan as between 12 and 46 but it seems to utilize only indexed and primary keys.
-  The following update queries are somewhat complex and are run by the auto host job every 10 minutes: ChannelHostsLookups.unhost_channels_not_live(), ChannelHostsLookups.invalidate_hosting_channels_where_necessary(), ChannelHostsLookups.recheck_error_status_channels(), ChannelHostsLookups.host_some_channels()

## Additional Considerations
This is my first feature I've written in the Elixir language so a thorough code review would be much appreciated.  Any feedback on code style/structure would also be welcome.  I'm not completely unfamiliar with programming; I've worked professionally in Java for 18 years and 1 year in Ruby on Rails (and dabbled in other languages as hobby projects).

