### PR TITLE
Changing the stream title should also change the page title

### DIFF
--- a/lib/glimesh_web/live/user_live/components/channel_title.ex
+++ b/lib/glimesh_web/live/user_live/components/channel_title.ex
@@ -91,6 +91,7 @@ defmodule GlimeshWeb.UserLive.Components.ChannelTitle do
       {:ok, channel} ->
         {:noreply,
          socket
+         |> put_page_title(channel.title)
          |> assign_subcategory(channel.category)
          |> assign_existing_tags(channel)
          |> assign(:editing, false)

--- a/test/glimesh_web/live/user_live_components/channel_title_test.exs
+++ b/test/glimesh_web/live/user_live_components/channel_title_test.exs
@@ -100,6 +100,8 @@ defmodule GlimeshWeb.UserLive.Components.ChannelTitleTest do
                  "title" => "Foobar"
                }
              }) =~ "Foobar"
+
+      assert page_title(view) =~ "Foobar"
     end
   end
 end


### PR DESCRIPTION
Fixes #789  When changing the stream title the page title should now update to reflect the change.