### PR TITLE
Fix duplicate streams showing on following page when users follow themselves while hosting another user they follow

### DIFF
--- a/lib/glimesh/channel_lookups.ex
+++ b/lib/glimesh/channel_lookups.ex
@@ -124,7 +124,12 @@ defmodule Glimesh.ChannelLookups do
       where: ch.status == "hosting",
       where: target.status == "live",
       where: f.user_id == ^user.id,
-      where: fragment("not exists(select true from followers where user_id = ? and streamer_id = ?)", ^user.id, target.user_id),
+      where:
+        fragment(
+          "not exists(select true from followers where user_id = ? and streamer_id = ?)",
+          ^user.id,
+          target.user_id
+        ),
       distinct: target.id,
       select: [target]
     )
@@ -144,7 +149,12 @@ defmodule Glimesh.ChannelLookups do
         where: ch.status == "hosting",
         where: target.status == "live",
         where: f.user_id == ^user.id,
-        where: fragment("not exists(select true from followers where user_id = ? and streamer_id = ?)", ^user.id, target.user_id),
+        where:
+          fragment(
+            "not exists(select true from followers where user_id = ? and streamer_id = ?)",
+            ^user.id,
+            target.user_id
+          ),
         distinct: target.id,
         select: [target],
         select_merge: %{match_type: "hosting"}

--- a/lib/glimesh/channel_lookups.ex
+++ b/lib/glimesh/channel_lookups.ex
@@ -121,12 +121,10 @@ defmodule Glimesh.ChannelLookups do
       on: c.id == ch.hosting_channel_id,
       join: target in Channel,
       on: target.id == ch.target_channel_id,
-      left_join: target_followers in Follower,
-      on: target.user_id == target_followers.streamer_id,
       where: ch.status == "hosting",
       where: target.status == "live",
       where: f.user_id == ^user.id,
-      where: target_followers.user_id != ^user.id or is_nil(target_followers.user_id),
+      where: fragment("not exists(select true from followers where user_id = ? and streamer_id = ?)", ^user.id, target.user_id),
       distinct: target.id,
       select: [target]
     )
@@ -143,12 +141,10 @@ defmodule Glimesh.ChannelLookups do
         on: c.id == ch.hosting_channel_id,
         join: target in Channel,
         on: target.id == ch.target_channel_id,
-        left_join: target_followers in Follower,
-        on: target.user_id == target_followers.streamer_id,
         where: ch.status == "hosting",
         where: target.status == "live",
         where: f.user_id == ^user.id,
-        where: target_followers.user_id != ^user.id or is_nil(target_followers.user_id),
+        where: fragment("not exists(select true from followers where user_id = ? and streamer_id = ?)", ^user.id, target.user_id),
         distinct: target.id,
         select: [target],
         select_merge: %{match_type: "hosting"}

--- a/test/glimesh/channel_lookups_test.exs
+++ b/test/glimesh/channel_lookups_test.exs
@@ -393,7 +393,8 @@ defmodule Glimesh.ChannelLookupsTest do
     |> Repo.update()
 
     live_channel_hosted = streamer_fixture(%{}, %{status: "live"})
-    Glimesh.AccountFollows.follow(live_channel_hosted, additional_follower)  # make sure hosted channels have more than one follower
+    # make sure hosted channels have more than one follower
+    Glimesh.AccountFollows.follow(live_channel_hosted, additional_follower)
 
     Ecto.Changeset.change(live_channel_hosted.channel)
     |> Ecto.Changeset.force_change(:status, "live")
@@ -543,10 +544,11 @@ defmodule Glimesh.ChannelLookupsTest do
       assert length(ChannelLookups.list_live_followed_channels(user)) == 2
     end
 
-    test "a host who follows themselves should not see a channel they follow and are hosting duplicated on the following page", %{
-      host: host,
-      live_channel_hosted: live_hosted
-    } do
+    test "a host who follows themselves should not see a channel they follow and are hosting duplicated on the following page",
+         %{
+           host: host,
+           live_channel_hosted: live_hosted
+         } do
       Glimesh.AccountFollows.follow(host, host)
       Glimesh.AccountFollows.follow(live_hosted, host)
       results = ChannelLookups.list_live_followed_channels_and_hosts(host)

--- a/test/glimesh/channel_lookups_test.exs
+++ b/test/glimesh/channel_lookups_test.exs
@@ -385,6 +385,7 @@ defmodule Glimesh.ChannelLookupsTest do
 
   defp create_followed_hosting_data(_) do
     user = user_fixture()
+    additional_follower = user_fixture()
     non_followed_live_channel = streamer_fixture()
 
     Ecto.Changeset.change(non_followed_live_channel.channel)
@@ -392,6 +393,7 @@ defmodule Glimesh.ChannelLookupsTest do
     |> Repo.update()
 
     live_channel_hosted = streamer_fixture(%{}, %{status: "live"})
+    Glimesh.AccountFollows.follow(live_channel_hosted, additional_follower)  # make sure hosted channels have more than one follower
 
     Ecto.Changeset.change(live_channel_hosted.channel)
     |> Ecto.Changeset.force_change(:status, "live")
@@ -407,6 +409,7 @@ defmodule Glimesh.ChannelLookupsTest do
     |> Repo.insert()
 
     Glimesh.AccountFollows.follow(host, user)
+    Glimesh.AccountFollows.follow(host, additional_follower)
 
     live_channel_hosted_but_not_followed = streamer_fixture()
 
@@ -430,6 +433,7 @@ defmodule Glimesh.ChannelLookupsTest do
     |> Repo.update()
 
     Glimesh.AccountFollows.follow(live_channel_followed_but_not_hosted, user)
+    Glimesh.AccountFollows.follow(live_channel_followed_but_not_hosted, additional_follower)
 
     %{
       user: user,
@@ -537,6 +541,16 @@ defmodule Glimesh.ChannelLookupsTest do
       Glimesh.AccountFollows.follow(live_hosted, user)
       assert ChannelLookups.count_live_followed_channels_that_are_hosting(user) == 0
       assert length(ChannelLookups.list_live_followed_channels(user)) == 2
+    end
+
+    test "a host who follows themselves should not see a channel they follow and are hosting duplicated on the following page", %{
+      host: host,
+      live_channel_hosted: live_hosted
+    } do
+      Glimesh.AccountFollows.follow(host, host)
+      Glimesh.AccountFollows.follow(live_hosted, host)
+      results = ChannelLookups.list_live_followed_channels_and_hosts(host)
+      assert length(results) == 1
     end
   end
 end


### PR DESCRIPTION
fixes #793 The query to bring back followed live channels and followed channels that are hosting was not correctly de-duplicating the streams returned when a user followed themselves and were hosting another channel that they also directly followed.  I removed the left outer join to the target's followers and changed it to a not exists sub-select which correctly takes into account users that have multiple followers.  I've also updated the tests to have target channels that have multiple followers.