### PR TITLE
Add mutations to create/modify/delete follows

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -2,7 +2,7 @@ FROM elixir:1.12.1
 
 # Install package dependencies
 RUN apt-get update
-RUN apt-get install -y build-essential postgresql-client inotify-tools imagemagick-6.q16 rsvg-convert
+RUN apt-get install -y build-essential postgresql-client inotify-tools imagemagick-6.q16 librsvg2-bin
 
 # install hex + rebar
 RUN mix local.hex --force

--- a/lib/glimesh/account_follows.ex
+++ b/lib/glimesh/account_follows.ex
@@ -31,10 +31,11 @@ defmodule Glimesh.AccountFollows do
     changeset =
       %Follower{
         streamer: streamer,
-        user: user,
-        has_live_notifications: live_notifications
+        user: user
       }
-      |> Follower.changeset()
+      |> Follower.changeset(%{
+        has_live_notifications: live_notifications
+      })
 
     case Repo.insert(changeset) do
       {:ok, follower} ->

--- a/lib/glimesh/account_follows/followers.ex
+++ b/lib/glimesh/account_follows/followers.ex
@@ -14,7 +14,7 @@ defmodule Glimesh.AccountFollows.Follower do
   end
 
   @doc false
-  def changeset(followers, attrs \\ %{}) do
+  def changeset(followers, attrs) do
     followers
     |> cast(attrs, [:has_live_notifications])
     |> validate_required([:streamer, :user, :has_live_notifications])

--- a/lib/glimesh/account_follows/followers.ex
+++ b/lib/glimesh/account_follows/followers.ex
@@ -14,7 +14,7 @@ defmodule Glimesh.AccountFollows.Follower do
   end
 
   @doc false
-  def changeset(followers, attrs) do
+  def changeset(followers, attrs \\ %{}) do
     followers
     |> cast(attrs, [:has_live_notifications])
     |> validate_required([:streamer, :user, :has_live_notifications])

--- a/lib/glimesh/api.ex
+++ b/lib/glimesh/api.ex
@@ -17,7 +17,8 @@ defmodule Glimesh.Api do
                 public: false,
                 email: false,
                 chat: false,
-                streamkey: false
+                streamkey: false,
+                follow: false,
               }
   end
 
@@ -58,11 +59,13 @@ defmodule Glimesh.Api do
   Parse a list of changeset errors into actionable API errors
   """
   def parse_ecto_changeset_errors(%Ecto.Changeset{} = changeset) do
-    Ecto.Changeset.traverse_errors(changeset, fn {msg, opts} ->
-      Enum.reduce(opts, msg, fn {key, value}, acc ->
-        String.replace(acc, "%{#{key}}", to_string(value))
-      end)
-    end)
+    changeset
+      |> Ecto.Changeset.traverse_errors(fn {msg, opts} ->
+           Enum.reduce(opts, msg, fn {key, value}, acc ->
+             String.replace(acc, "%{#{key}}", to_string(value))
+           end)
+         end)
+      |> Enum.map(fn {key, value} -> "#{key}: #{value}" end)
   end
 
   @doc """

--- a/lib/glimesh/api.ex
+++ b/lib/glimesh/api.ex
@@ -18,7 +18,7 @@ defmodule Glimesh.Api do
                 email: false,
                 chat: false,
                 streamkey: false,
-                follow: false,
+                follow: false
               }
   end
 
@@ -60,12 +60,12 @@ defmodule Glimesh.Api do
   """
   def parse_ecto_changeset_errors(%Ecto.Changeset{} = changeset) do
     changeset
-      |> Ecto.Changeset.traverse_errors(fn {msg, opts} ->
-           Enum.reduce(opts, msg, fn {key, value}, acc ->
-             String.replace(acc, "%{#{key}}", to_string(value))
-           end)
-         end)
-      |> Enum.map(fn {key, value} -> "#{key}: #{value}" end)
+    |> Ecto.Changeset.traverse_errors(fn {msg, opts} ->
+      Enum.reduce(opts, msg, fn {key, value}, acc ->
+        String.replace(acc, "%{#{key}}", to_string(value))
+      end)
+    end)
+    |> Enum.map(fn {key, value} -> "#{key}: #{value}" end)
   end
 
   @doc """

--- a/lib/glimesh/api/schema.ex
+++ b/lib/glimesh/api/schema.ex
@@ -23,6 +23,7 @@ defmodule Glimesh.Api.Schema do
   end
 
   mutation do
+    import_fields(:account_mutations)
     import_fields(:streams_mutations)
     import_fields(:chat_mutations)
   end

--- a/lib/glimesh/api/schema/account_types.ex
+++ b/lib/glimesh/api/schema/account_types.ex
@@ -37,6 +37,32 @@ defmodule Glimesh.Api.AccountTypes do
     end
   end
 
+  object :account_mutations do
+    @desc "Follow a channel"
+    field :follow_channel, type: :follower do
+      arg(:channel_id, non_null(:id))
+      arg(:live_notifications, :boolean, default_value: false)
+
+      resolve(&AccountResolver.follow_channel/3)
+    end
+
+    @desc "Unfollow a channel"
+    field :unfollow_channel, type: :follower do
+      arg(:channel_id, non_null(:id))
+
+      resolve(&AccountResolver.unfollow_channel/3)
+    end
+
+
+    @desc "Update a channel follow"
+    field :update_follow, type: :follower do
+      arg(:channel_id, non_null(:id))
+      arg(:live_notifications, :boolean, default_value: false)
+
+      resolve(&AccountResolver.update_follow/3)
+    end
+  end
+
   object :account_subscriptions do
     field :followers, :follower do
       arg(:streamer_id, :id)

--- a/lib/glimesh/api/schema/account_types.ex
+++ b/lib/glimesh/api/schema/account_types.ex
@@ -39,22 +39,15 @@ defmodule Glimesh.Api.AccountTypes do
 
   object :account_mutations do
     @desc "Follow a channel"
-    field :follow_create, type: :follower do
+    field :follow, type: :follower do
       arg(:channel_id, non_null(:id))
-      arg(:has_live_notifications, :boolean, default_value: false)
+      arg(:live_notifications, non_null(:boolean), default_value: false)
 
       resolve(&AccountResolver.follow_channel/3)
     end
 
-    @desc "Update a channel follow"
-    field :follow_update, type: :follower do
-      arg(:channel_id, non_null(:id))
-      arg(:has_live_notifications, :boolean, default_value: nil)
-
-      resolve(&AccountResolver.update_follow/3)
-    end
     @desc "Unfollow a channel"
-    field :follow_remove, type: :follower do
+    field :unfollow, type: :follower do
       arg(:channel_id, non_null(:id))
 
       resolve(&AccountResolver.unfollow_channel/3)

--- a/lib/glimesh/api/schema/account_types.ex
+++ b/lib/glimesh/api/schema/account_types.ex
@@ -41,7 +41,7 @@ defmodule Glimesh.Api.AccountTypes do
     @desc "Follow a channel"
     field :follow_create, type: :follower do
       arg(:channel_id, non_null(:id))
-      arg(:live_notifications, :boolean, default_value: false)
+      arg(:has_live_notifications, :boolean, default_value: false)
 
       resolve(&AccountResolver.follow_channel/3)
     end
@@ -49,7 +49,7 @@ defmodule Glimesh.Api.AccountTypes do
     @desc "Update a channel follow"
     field :follow_update, type: :follower do
       arg(:channel_id, non_null(:id))
-      arg(:live_notifications, :boolean, default_value: nil)
+      arg(:has_live_notifications, :boolean, default_value: nil)
 
       resolve(&AccountResolver.update_follow/3)
     end

--- a/lib/glimesh/api/schema/account_types.ex
+++ b/lib/glimesh/api/schema/account_types.ex
@@ -39,26 +39,25 @@ defmodule Glimesh.Api.AccountTypes do
 
   object :account_mutations do
     @desc "Follow a channel"
-    field :follow_channel, type: :follower do
+    field :follow_create, type: :follower do
       arg(:channel_id, non_null(:id))
       arg(:live_notifications, :boolean, default_value: false)
 
       resolve(&AccountResolver.follow_channel/3)
     end
 
+    @desc "Update a channel follow"
+    field :follow_update, type: :follower do
+      arg(:channel_id, non_null(:id))
+      arg(:live_notifications, :boolean, default_value: nil)
+
+      resolve(&AccountResolver.update_follow/3)
+    end
     @desc "Unfollow a channel"
-    field :unfollow_channel, type: :follower do
+    field :follow_remove, type: :follower do
       arg(:channel_id, non_null(:id))
 
       resolve(&AccountResolver.unfollow_channel/3)
-    end
-
-    @desc "Update a channel follow"
-    field :update_follow, type: :follower do
-      arg(:channel_id, non_null(:id))
-      arg(:live_notifications, :boolean, default_value: false)
-
-      resolve(&AccountResolver.update_follow/3)
     end
   end
 

--- a/lib/glimesh/api/schema/account_types.ex
+++ b/lib/glimesh/api/schema/account_types.ex
@@ -53,7 +53,6 @@ defmodule Glimesh.Api.AccountTypes do
       resolve(&AccountResolver.unfollow_channel/3)
     end
 
-
     @desc "Update a channel follow"
     field :update_follow, type: :follower do
       arg(:channel_id, non_null(:id))

--- a/lib/glimesh/api/scopes.ex
+++ b/lib/glimesh/api/scopes.ex
@@ -16,6 +16,7 @@ defmodule Glimesh.Api.Scopes do
 
   def authorize(:chat, %Access{} = ua, _params), do: scope_check(ua, :chat)
   def authorize(:streamkey, %Access{} = ua, _params), do: scope_check(ua, :streamkey)
+  def authorize(:follow, %Access{} = ua, _params), do: scope_check(ua, :follow)
 
   def authorize(:stream_mutations, %Access{is_admin: true}, _params) do
     true

--- a/lib/glimesh/channel_lookups.ex
+++ b/lib/glimesh/channel_lookups.ex
@@ -195,6 +195,10 @@ defmodule Glimesh.ChannelLookups do
     |> Repo.preload([:category, :user, :streamer])
   end
 
+  def get(id, preloads \\ []) do
+    Channel |> preload(^preloads) |> Repo.get(id)
+  end
+
   def get_channel(id) do
     Repo.get_by(Channel, id: id) |> Repo.preload([:category, :subcategory, :user, :tags])
   end

--- a/lib/glimesh/channel_lookups.ex
+++ b/lib/glimesh/channel_lookups.ex
@@ -195,16 +195,12 @@ defmodule Glimesh.ChannelLookups do
     |> Repo.preload([:category, :user, :streamer])
   end
 
-  def get(id, preloads \\ []) do
+  def get_channel(id, preloads \\ [:category, :subcategory, :user, :tags]) do
     Channel |> preload(^preloads) |> Repo.get(id)
   end
 
-  def get_channel(id) do
-    Repo.get_by(Channel, id: id) |> Repo.preload([:category, :subcategory, :user, :tags])
-  end
-
-  def get_channel!(id) do
-    Repo.get_by!(Channel, id: id) |> Repo.preload([:category, :subcategory, :user, :tags])
+  def get_channel!(id, preloads \\ [:category, :subcategory, :user, :tags]) do
+    Channel |> preload(^preloads) |> Repo.get!(id)
   end
 
   def get_channel_for_username(username, ignore_banned \\ false) do

--- a/lib/glimesh/oauth/scopes.ex
+++ b/lib/glimesh/oauth/scopes.ex
@@ -9,6 +9,7 @@ defmodule Glimesh.Oauth.Scopes do
       "email" -> gettext("scopeemail")
       "chat" -> gettext("scopechat")
       "streamkey" -> gettext("scopestream")
+      "follow" -> gettext("scopefollow")
     end
   end
 end

--- a/lib/glimesh/oauth_migration.ex
+++ b/lib/glimesh/oauth_migration.ex
@@ -69,7 +69,7 @@ defmodule Glimesh.OauthMigration do
       %{label: "Email", name: "email", public: true},
       %{label: "Chat", name: "chat", public: true},
       %{label: "Stream Key", name: "streamkey", public: true},
-      %{label: "Follow Channel", name: "follow", public: true},
+      %{label: "Follow Channel", name: "follow", public: true}
     ]
 
     Enum.each(scopes, fn attrs ->

--- a/lib/glimesh/oauth_migration.ex
+++ b/lib/glimesh/oauth_migration.ex
@@ -68,7 +68,8 @@ defmodule Glimesh.OauthMigration do
       %{label: "Public", name: "public", public: true},
       %{label: "Email", name: "email", public: true},
       %{label: "Chat", name: "chat", public: true},
-      %{label: "Stream Key", name: "streamkey", public: true}
+      %{label: "Stream Key", name: "streamkey", public: true},
+      %{label: "Follow Channel", name: "follow", public: true},
     ]
 
     Enum.each(scopes, fn attrs ->

--- a/lib/glimesh/payment_providers/stripe/webhook_handler.ex
+++ b/lib/glimesh/payment_providers/stripe/webhook_handler.ex
@@ -1,4 +1,5 @@
 defmodule Glimesh.PaymentProviders.StripeProvider.StripeHandler do
+  @moduledoc false
   @behaviour Stripe.WebhookHandler
 
   @impl true

--- a/lib/glimesh_web/plugs/old_api_context_plug.ex
+++ b/lib/glimesh_web/plugs/old_api_context_plug.ex
@@ -64,7 +64,7 @@ defmodule GlimeshWeb.Plugs.OldApiContextPlug do
   defp authorize(_, conn) do
     # Since this is the old API, try a session based auth
     if user = conn.assigns[:current_user] do
-      Oauth.access_for_user(user, "public email chat streamkey")
+      Oauth.access_for_user(user, "public email chat streamkey follow")
     else
       {:error, :unauthorized}
     end

--- a/priv/repo/seeds/scopes.exs
+++ b/priv/repo/seeds/scopes.exs
@@ -2,7 +2,8 @@ scopes = [
   %{label: "Public", name: "public", public: true},
   %{label: "Email", name: "email", public: true},
   %{label: "Chat", name: "chat", public: true},
-  %{label: "Stream Key", name: "streamkey", public: true}
+  %{label: "Stream Key", name: "streamkey", public: true},
+  %{label: "Follow Channel", name: "follow", public: true},
 ]
 
 Enum.each(scopes, fn attrs ->

--- a/test/glimesh/streams_test.exs
+++ b/test/glimesh/streams_test.exs
@@ -4,6 +4,7 @@ defmodule Glimesh.StreamsTest do
 
   import Glimesh.AccountsFixtures
   alias Glimesh.AccountFollows
+  alias Glimesh.AccountFollows.Follower
   alias Glimesh.ChannelLookups
   alias Glimesh.Streams
   alias Glimesh.Repo
@@ -47,12 +48,16 @@ defmodule Glimesh.StreamsTest do
       assert AccountFollows.is_following?(streamer, user) == true
     end
 
-    test "follow/2 twice returns error changeset" do
+    test "follow/2 twice successfully updates follow" do
       streamer = streamer_fixture()
       user = user_fixture()
-
       AccountFollows.follow(streamer, user)
-      assert {:error, %Ecto.Changeset{}} = AccountFollows.follow(streamer, user)
+
+
+      assert {:ok, %Follower{}} = AccountFollows.follow(streamer, user)
+
+      followed = ChannelLookups.list_all_followed_channels(user)
+      assert Enum.map(followed, fn x -> x.user.username end) == [streamer.username]
     end
 
     test "list_all_follows/0 successfully returns data" do

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -149,7 +149,7 @@ defmodule GlimeshWeb.ConnCase do
     create_token_and_return_context(conn, user)
   end
 
-  def create_token_and_return_context(conn, user, scopes \\ "public email chat streamkey") do
+  def create_token_and_return_context(conn, user, scopes \\ "public email chat streamkey follow") do
     {:ok, app} = Glimesh.ApiFixtures.app_fixture(user)
 
     {:ok, %Boruta.Oauth.Token{value: token}} =


### PR DESCRIPTION
Fixes #718, which will be useful both for the app I'm working on and for the official app.

Change Summary:
- Add `follow` scope to allow modifying follows for the current user
  - No current scope covered this and having a "modify user" scope felt maybe too general for just wanting to follow/unfollow, but I'm open to suggestions, lots of targeted scopes is not always the answer either
- Add `follow(Create|Update|Remove)` mutations that work similar to the existing buttons on the site
- Improved error handling for the resolver and lookup code I touched

Tested locally and attempted to write some tests

My first time writing Elixr so feedback would be very welcome. I'm not confident I did the right things to add support for the new scope specifically, I just grep'd for places the existing scope were referenced and it seems to work.