### PR TITLE
Detect the twitterbot user-agent and do not redirect it when a streamer is hosting another streamer.

### DIFF
--- a/lib/glimesh/payment_providers/stripe/webhook_handler.ex
+++ b/lib/glimesh/payment_providers/stripe/webhook_handler.ex
@@ -1,4 +1,5 @@
 defmodule Glimesh.PaymentProviders.StripeProvider.StripeHandler do
+  @moduledoc false
   @behaviour Stripe.WebhookHandler
 
   @impl true

--- a/lib/glimesh_web/plugs/user_agent_plug.ex
+++ b/lib/glimesh_web/plugs/user_agent_plug.ex
@@ -1,0 +1,12 @@
+defmodule GlimeshWeb.Plugs.UserAgent do
+  import Plug.Conn
+
+  def init(_opts), do: nil
+
+  def call(conn, _opts \\ []) do
+    user_agent = get_req_header(conn, "user-agent")
+
+    conn
+    |> put_session(:user_agent, "#{user_agent}")
+  end
+end

--- a/lib/glimesh_web/router.ex
+++ b/lib/glimesh_web/router.ex
@@ -15,6 +15,7 @@ defmodule GlimeshWeb.Router do
     plug GlimeshWeb.Plugs.Locale
     plug GlimeshWeb.Plugs.CfCountryPlug
     plug GlimeshWeb.Plugs.Ban
+    plug GlimeshWeb.Plugs.UserAgent
     plug GlimeshWeb.UniqueUserPlug
     plug NavigationHistory.Tracker, excluded_paths: ["/users/log_in", "/users/register"]
   end

--- a/test/glimesh_web/plugs/user_agent_plug_test.exs
+++ b/test/glimesh_web/plugs/user_agent_plug_test.exs
@@ -1,0 +1,16 @@
+defmodule GlimeshWeb.Plugs.UserAgentTest do
+  use GlimeshWeb.ConnCase
+  use ExUnit.Case
+
+  test "adds user-agent header to the session", %{conn: conn} do
+    conn =
+      conn
+      |> Plug.Test.init_test_session(%{})
+      |> put_req_header("user-agent", "test agent")
+
+    assert conn
+           |> Plug.Conn.fetch_session()
+           |> GlimeshWeb.Plugs.UserAgent.call()
+           |> Plug.Conn.get_session("user_agent") == "test agent"
+  end
+end


### PR DESCRIPTION
When a streamer tweets their channel and they happen to be hosting another channel at that moment, the twitter card will display the channel that is being hosted instead of the hosting channel (memtest86 should be in the below picture):

![hosting twitter bug](https://user-images.githubusercontent.com/5142625/151469815-5d99b229-d674-4faf-a555-1a6694148a8f.png)

This fix adds the "User-Agent" header to the session so we can access it in our controllers.  If the "User-Agent" header contains "Twitterbot" we will not redirect it to the hosted channel so it will correctly display the host's channel when creating a twitter card.  This (hopefully) eliminates the need for streamers to have to add "?follow_host=false" to the end of their channel link when tweeting their channel.

Note: Twitter aggressively caches tweeted links, so it could take up to a week after this patch goes live to see the results.  There is a card validator that *may* clear caches, but that seems to be in question -- https://cards-dev.twitter.com/validator