### PR TITLE
Adding ultrawide support for videos

### DIFF
--- a/assets/js/hooks/FtlVideo.js
+++ b/assets/js/hooks/FtlVideo.js
@@ -11,6 +11,21 @@ export default {
         let videoLoadingContainer = document.getElementById("video-loading-container");
         let forceMuted = container.dataset.muted;
         let saveVolumeChanges = false;
+        let currentlyInUltrawide = false;
+
+        // Handle 21:9 aspect ratio monitors/browers
+        let containerParent = container.parentElement;
+        // Get browser aspect ratio
+        let size = {
+            width: window.innerWidth || document.body.clientWidth,
+            height: window.innerHeight || document.body.clientHeight
+        }
+        let currentAspectRatio = size.width / size.height;
+        if (currentAspectRatio > 2.3) {
+            // We assume this is an ultrawide of some sort
+            parent.pushEvent("ultrawide", {enabled: true});
+            currentlyInUltrawide = true;
+        }
 
         this.handleEvent("load_video", ({janus_url, channel_id}) => {
             player = new FtlPlayer(container, janus_url, {
@@ -73,6 +88,26 @@ export default {
         container.addEventListener("playing", function() {
             videoLoadingContainer.classList.remove("loading");
         });
+
+        window.onresize = function() {
+            // Get current aspect ratio
+            let size = {
+                width: window.innerWidth || document.body.clientWidth,
+                height: window.innerHeight || document.body.clientHeight
+            }
+            let currentAspectRatio = size.width / size.height;
+            if (currentAspectRatio > 2.3) {
+                if (!currentlyInUltrawide) {
+                    parent.pushEvent("ultrawide", {enabled: true});
+                }
+                currentlyInUltrawide = true;
+            } else {
+                if (currentlyInUltrawide) {
+                    parent.pushEvent("ultrawide", {enabled: false});
+                }
+                currentlyInUltrawide = false;
+            }
+        }
     },
     destroyed() {
         if(player) {

--- a/lib/glimesh_web/live/user_live/stream.ex
+++ b/lib/glimesh_web/live/user_live/stream.ex
@@ -62,7 +62,8 @@ defmodule GlimeshWeb.UserLive.Stream do
            |> assign(:lost_packets, 0)
            |> assign(:stream_metadata, get_last_stream_metadata(channel.stream))
            |> assign(:player_error, nil)
-           |> assign(:user, maybe_user)}
+           |> assign(:user, maybe_user)
+           |> assign(:ultrawide, false)}
         end
 
       nil ->
@@ -186,6 +187,10 @@ defmodule GlimeshWeb.UserLive.Stream do
 
   def handle_event("lost_packets", _, socket) do
     {:noreply, socket}
+  end
+
+  def handle_event("ultrawide", %{"enabled" => enabled}, socket) do
+    {:noreply, socket |> assign(:ultrawide, enabled)}
   end
 
   defp get_stream_thumbnail(channel) do

--- a/lib/glimesh_web/live/user_live/stream.html.leex
+++ b/lib/glimesh_web/live/user_live/stream.html.leex
@@ -67,7 +67,7 @@
                     </div>
 
                     <% else %>
-                    <div id="video-container" class="embed-responsive embed-responsive-16by9">
+                    <div id="video-container" class="embed-responsive <%= if @ultrawide, do: "embed-responsive-21by9", else: "embed-responsive-16by9"%>">
                         <video id="video-player" class="embed-responsive-item" phx-hook="FtlVideo" controls playsinline poster="<%= @channel_poster %>"></video>
                         <div id="video-loading-container" class="">
                             <div class="lds-ring">


### PR DESCRIPTION
Currently when watching a stream on Glimesh while using an ultrawide(21:9 aspect ratio) it looks like this: 
![image](https://user-images.githubusercontent.com/11252574/154805445-0920bf9b-1ec3-48cc-a6df-d798feb80b7f.png)

Which cuts off a large portion of the bottom of the stream. This is due to using the `embed-responsive-16by9` class from Bootstrap which forces the container to be 16:9. 

This PR uses Phoenix's hooking system to send back info if the current user's browser is at least 21:9(a 2.3 ratio) and updates the DOM accordingly. This is done by calculating the ratio and if it's over a certain threshold it will fire an event to update the DOM with the `embed-responsive-21by9` class for the video container. This shouldn't fill up the websocket as it only fires an event if it absolutely needs to. I did try to do it fully client side but Phoenix kept hijacking the container and I really just didn't want to fight with it. 

Resulting in a stream that looks like this: 
![image](https://user-images.githubusercontent.com/11252574/154805524-b4095bb3-ad0f-4228-b85a-c467bc525aa1.png)

While yes there's bars on the side of the video now, that's common with 16:9 video and basically unavoidable. 

Let me know if anything is wrong/funky, been a while since I touched any of this :P 
