### PR TITLE
Bug fix for channel hosting, the hosting banner/redirect does not take into account if the host target is still live

### DIFF
--- a/test/glimesh_web/live/user_live/stream_test.exs
+++ b/test/glimesh_web/live/user_live/stream_test.exs
@@ -240,6 +240,20 @@ defmodule GlimeshWeb.UserLive.StreamTest do
              |> has_element?("#hosting_banner")
     end
 
+    test "does not redirect if the target user is no longer live", %{
+      conn: conn,
+      host: host,
+      streamer: streamer
+    } do
+      {:ok, _} = Glimesh.Streams.end_stream(streamer.channel)
+
+      assert {:ok, view, html} = live(conn, Routes.user_stream_path(conn, :index, host.username))
+      refute html =~ "#{host.displayname} is hosting #{streamer.displayname}"
+
+      refute view
+             |> has_element?("#hosting_banner")
+    end
+
     test "will not redirect the twitter bot to hosted channel", %{
       conn: conn,
       streamer: streamer,


### PR DESCRIPTION
Under normal circumstances, the auto host job will un-host target channels that are no longer live.  There have been instances, however, where the flag does not get un-set properly and the hosting channel will continue to redirect to a no-longer live channel and display the hosting banner.  To help prevent this in the future, I've changed the get_hosting_target method's query to take into account both the hosting flag and the target channel's status flag.