### PR TITLE
Fixed video container height for ultralarge viewports

### DIFF
--- a/assets/css/glimesh/components/video.scss
+++ b/assets/css/glimesh/components/video.scss
@@ -58,3 +58,18 @@
 
     }
 }
+
+@media (min-width: 992px) {
+    #video-column {
+        max-height: calc(100vh - 90px);
+        overflow: hidden;
+
+        > .card {
+            height: 100%;
+
+            > .card-body {
+                display: flex;
+            }
+        }
+    }
+}

--- a/assets/js/hooks/FtlVideo.js
+++ b/assets/js/hooks/FtlVideo.js
@@ -11,6 +11,21 @@ export default {
         let videoLoadingContainer = document.getElementById("video-loading-container");
         let forceMuted = container.dataset.muted;
         let saveVolumeChanges = false;
+        let currentlyInUltrawide = false;
+
+        // Handle 21:9 aspect ratio monitors/browers
+        let containerParent = container.parentElement;
+        // Get browser aspect ratio
+        let size = {
+            width: window.innerWidth || document.body.clientWidth,
+            height: window.innerHeight || document.body.clientHeight
+        }
+        let currentAspectRatio = size.width / size.height;
+        if (currentAspectRatio > 2.3) {
+            // We assume this is an ultrawide of some sort
+            parent.pushEvent("ultrawide", {enabled: true});
+            currentlyInUltrawide = true;
+        }
 
         this.handleEvent("load_video", ({janus_url, channel_id}) => {
             player = new FtlPlayer(container, janus_url, {
@@ -73,6 +88,26 @@ export default {
         container.addEventListener("playing", function() {
             videoLoadingContainer.classList.remove("loading");
         });
+
+        window.onresize = function() {
+            // Get current aspect ratio
+            let size = {
+                width: window.innerWidth || document.body.clientWidth,
+                height: window.innerHeight || document.body.clientHeight
+            }
+            let currentAspectRatio = size.width / size.height;
+            if (currentAspectRatio > 2.3) {
+                if (!currentlyInUltrawide) {
+                    parent.pushEvent("ultrawide", {enabled: true});
+                }
+                currentlyInUltrawide = true;
+            } else {
+                if (currentlyInUltrawide) {
+                    parent.pushEvent("ultrawide", {enabled: false});
+                }
+                currentlyInUltrawide = false;
+            }
+        }
     },
     destroyed() {
         if(player) {

--- a/lib/glimesh_web/live/user_live/stream.ex
+++ b/lib/glimesh_web/live/user_live/stream.ex
@@ -62,7 +62,8 @@ defmodule GlimeshWeb.UserLive.Stream do
            |> assign(:lost_packets, 0)
            |> assign(:stream_metadata, get_last_stream_metadata(channel.stream))
            |> assign(:player_error, nil)
-           |> assign(:user, maybe_user)}
+           |> assign(:user, maybe_user)
+           |> assign(:ultrawide, false)}
         end
 
       nil ->
@@ -186,6 +187,10 @@ defmodule GlimeshWeb.UserLive.Stream do
 
   def handle_event("lost_packets", _, socket) do
     {:noreply, socket}
+  end
+
+  def handle_event("ultrawide", %{"enabled" => enabled}, socket) do
+    {:noreply, socket |> assign(:ultrawide, enabled)}
   end
 
   defp get_stream_thumbnail(channel) do

--- a/lib/glimesh_web/live/user_live/stream.html.leex
+++ b/lib/glimesh_web/live/user_live/stream.html.leex
@@ -67,7 +67,7 @@
                     </div>
 
                     <% else %>
-                    <div id="video-container" class="embed-responsive embed-responsive-16by9">
+                    <div id="video-container" class="embed-responsive <%= if @ultrawide, do: "embed-responsive-21by9", else: "embed-responsive-16by9"%>">
                         <video id="video-player" class="embed-responsive-item" phx-hook="FtlVideo" controls playsinline poster="<%= @channel_poster %>"></video>
                         <div id="video-loading-container" class="">
                             <div class="lds-ring">


### PR DESCRIPTION
This PR is based on #811, but adds simple CSS to ensure the video container height doesn't exceed the viewport height in whichever arbitrary viewport the user might be using.

**Before:**
![image](https://user-images.githubusercontent.com/5056880/162098459-9846a781-4b2e-49d2-8c6c-34eb33064adb.png)

**After:**
![image](https://user-images.githubusercontent.com/5056880/162098454-75c28598-a553-4a4f-979c-08217690039b.png)
