### PR TITLE
Fix extra tag

### DIFF
--- a/lib/glimesh_web/live/chat_live/message_form.html.heex
+++ b/lib/glimesh_web/live/chat_live/message_form.html.heex
@@ -43,7 +43,7 @@
                         phx-value-user={@user.username}>
                         <%= if @show_mod_icons, do: gettext("Hide Mod Icons"), else: gettext("Show Mod Icons") %>
                     </a>
-                    <% else %> %>
+                    <% else %>
                     <a id="toggle-timestamps" class="dropdown-item" href="#"
                         phx-click="toggle_timestamps"><%= if @show_timestamps, do: gettext("Hide Timestamps"), else: gettext("Show Timestamps") %>
                     </a>


### PR DESCRIPTION
When not signed in the chat popup menu has an extra tag added. This PR removes it.

Before:
![image](https://user-images.githubusercontent.com/58316242/164943009-d4f51837-bfe3-4f69-aa83-7970bd4a6ad1.png)


After: 
![image](https://user-images.githubusercontent.com/58316242/164942961-2bdcd043-d16b-4ca2-9671-95f2398c3041.png)
