### PR TITLE
Show recently used subcategories and tags per category on the stream info edit modal

### DIFF
--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -59,6 +59,7 @@ $fa-font-path: "/fa-fonts";
 @import "glimesh/components/apex-charts";
 @import "glimesh/components/video";
 @import "glimesh/components/channel-lookup-typeahead";
+@import "glimesh/components/recent-tags.scss";
 
 @import "glimesh/pages/dmca";
 @import "glimesh/pages/hosting.scss";

--- a/assets/css/glimesh/components/recent-tags.scss
+++ b/assets/css/glimesh/components/recent-tags.scss
@@ -1,0 +1,7 @@
+.recent-tag {
+    cursor: pointer;
+    font-size: medium;
+    margin-left: 0.5vh;
+    margin-right: 0.5vh;
+    margin-top: 1.25vh;
+}

--- a/assets/css/glimesh/variables.scss
+++ b/assets/css/glimesh/variables.scss
@@ -40,6 +40,8 @@ $color-teal: #48D1BD;
     --chat-bubble-background: #0e1726;
 
     --text-muted-color: #6c757d;
+
+    --hr-bg-color: #ffffff;
 }
 
 [data-theme="light"] {
@@ -72,6 +74,8 @@ $color-teal: #48D1BD;
     --chat-bubble-background: #fff;
 
     --text-muted-color: #000;
+
+    --hr-bg-color: #000;
 }
 
 $font-family-base: 'Roboto',
@@ -143,6 +147,9 @@ $close-color: var(--secondary-color);
         color: var(--body-color);
     }
 }
+
+// hr
+$hr-border-color: var(--hr-bg-color);
 
 // Acrylic blur fallback for Mozilla Firefox (backdrop-filters not enabled so need to reduce transparency for legibility)
 @supports (-moz-appearance:meterbar) {

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -16,6 +16,7 @@ import TagSearch from "./hooks/TagSearch";
 import LaunchCountdown from "./hooks/LaunchCountdown";
 import Tagify from "./hooks/Tagify";
 import ChannelLookupTypeahead from "./hooks/ChannelLookupTypeahead";
+import RecentTags from "./hooks/RecentTags";
 
 // https://github.com/github/markdown-toolbar-element
 import "@github/markdown-toolbar-element";
@@ -35,6 +36,7 @@ Hooks.TagSearch = TagSearch;
 Hooks.LaunchCountdown = LaunchCountdown;
 Hooks.Tagify = Tagify;
 Hooks.ChannelLookupTypeahead = ChannelLookupTypeahead;
+Hooks.RecentTags = RecentTags;
 
 let csrfToken = document.querySelector("meta[name='csrf-token']").getAttribute("content");
 let liveSocket = new LiveSocket("/live", Socket, {

--- a/assets/js/hooks/RecentTags.js
+++ b/assets/js/hooks/RecentTags.js
@@ -1,0 +1,23 @@
+export default {
+    updated() {
+        this.mounted();
+    },
+    mounted() {
+        var target_input = this.el.dataset.fieldid;
+        var target_input_element = document.getElementById(target_input);
+        var tagify_instance = target_input_element.tagify;
+
+        this.el.addEventListener("click", e => {
+            let tagId = this.el.dataset.tagid;
+            let tagName = this.el.dataset.tagname;
+            let tagSlug = this.el.dataset.tagslug;
+            let categoryId = this.el.dataset.categoryid;
+            let operation = this.el.dataset.operation;
+            if(operation === "replace") {
+                tagify_instance.removeAllTags();
+            }
+            tagify_instance.addTags([{id: tagId, value: tagName, slug: tagSlug, label: tagName, categoryid: categoryId}]);
+        });
+
+    }
+}

--- a/assets/js/hooks/Tagify.js
+++ b/assets/js/hooks/Tagify.js
@@ -25,6 +25,8 @@ export default {
             // Target the DOM selector ID to get to the child component
             parent.pushEventTo(`#${parent.el.id}`, "suggest", { value: value });
         });
+
+        this.el.tagify = tagify;
     },
     tagify() {
         let categoryId = this.el.dataset.category;

--- a/lib/glimesh_web/live/components/tagify_component.ex
+++ b/lib/glimesh_web/live/components/tagify_component.ex
@@ -39,4 +39,8 @@ defmodule GlimeshWeb.TagifyComponent do
     {:noreply,
      push_event(socket, "suggestions-#{socket.assigns.id}", %{value: query, results: results})}
   end
+
+  def handle_event("remove", %{"value" => value}, socket) do
+    {:noreply, push_event(socket, "remove-tag", %{value: value})}
+  end
 end

--- a/lib/glimesh_web/live/user_live/components/channel_title.html.heex
+++ b/lib/glimesh_web/live/user_live/components/channel_title.html.heex
@@ -11,7 +11,14 @@
     <span class="badge badge-primary"><%= @channel.category.name %></span>
     <%= @channel.title %>
     <%= if @can_change do %>
-      <a class="fas fa-edit" phx-click="toggle-edit" href="#" aria-label={gettext("Edit")}></a>
+      <a
+        class="fas fa-edit"
+        id="stream-title-edit"
+        phx-click="toggle-edit"
+        href="#"
+        aria-label={gettext("Edit")}
+      >
+      </a>
     <% end %>
   </h5>
   <%= if @channel.subcategory do %>
@@ -68,11 +75,11 @@
               <%= select(f, :category_id, @categories, class: "form-control") %>
               <%= error_tag(f, :category_id) %>
             </div>
-            <div class="form-group">
+            <div class="form-group mb-1">
               <%= label(f, :subcategory, @subcategory_label) %>
               <%= live_component(
                 GlimeshWeb.TagifyComponent,
-                id: "category-selector",
+                id: "category-selector-#{@category.id}",
                 form: f,
                 field: :subcategory,
                 max_options: 1,
@@ -83,14 +90,21 @@
                 category: @category,
                 search_func: &search_categories/2
               ) %>
-              <p><%= @subcategory_attribution %></p>
+              <p class="mb-0"><%= @subcategory_attribution %></p>
               <%= error_tag(f, :subcategory) %>
             </div>
-            <div class="form-group">
+            <%= live_component(
+              GlimeshWeb.UserLive.Components.RecentTags,
+              fieldid: "category-selector-#{@category.id}",
+              recent_tags: @recent_subcategories,
+              operation: "replace"
+            ) %>
+
+            <div class="form-group mb-0 mt-2">
               <%= label(f, :tags, gettext("Tags")) %>
               <%= live_component(
                 GlimeshWeb.TagifyComponent,
-                id: "tag-selector",
+                id: "tag-selector-#{@category.id}",
                 form: f,
                 field: :tags,
                 value: @existing_tags,
@@ -103,8 +117,14 @@
               ) %>
               <%= error_tag(f, :tags) %>
             </div>
+            <%= live_component(
+              GlimeshWeb.UserLive.Components.RecentTags,
+              fieldid: "tag-selector-#{@category.id}",
+              recent_tags: @recent_tags,
+              operation: "append"
+            ) %>
 
-            <button type="submit" class="btn btn-primary btn-block btn-lg">
+            <button type="submit" class="btn btn-primary btn-block btn-lg mt-3">
               <%= gettext("Save") %>
             </button>
             <a

--- a/lib/glimesh_web/live/user_live/components/recent_tags.ex
+++ b/lib/glimesh_web/live/user_live/components/recent_tags.ex
@@ -1,0 +1,44 @@
+defmodule GlimeshWeb.UserLive.Components.RecentTags do
+  use GlimeshWeb, :live_component
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <%= if length(@recent_tags) > 0 do %>
+      <div class="row pb-2">
+        <div class="col-2 text-right pr-0 mt-1">
+          <p class="text-muted"><%= gettext("Recent:") %></p>
+        </div>
+        <div class="col-10 pl-1 pt-0">
+          <div class="d-flex flex-wrap">
+            <%= for recent <- @recent_tags do %>
+              <div
+                id={"recent-tag-#{@fieldid}-#{recent.id}"}
+                class="badge badge-primary recent-tag"
+                title={
+                  if Map.has_key?(recent, :count_usage),
+                    do: gettext("(%{num} Uses)", num: recent.count_usage)
+                }
+                phx-hook="RecentTags"
+                data-operation={@operation}
+                data-fieldid={@fieldid}
+                data-tagid={recent.id}
+                data-tagname={recent.name}
+                data-tagslug={recent.slug}
+                data-categoryid={recent.category_id}
+              >
+                <%= recent.name %>
+              </div>
+            <% end %>
+          </div>
+        </div>
+      </div>
+    <% end %>
+    """
+  end
+
+  @impl true
+  def mount(socket) do
+    {:ok, socket}
+  end
+end

--- a/test/glimesh_web/live/user_live_components/recent_tags_test.exs
+++ b/test/glimesh_web/live/user_live_components/recent_tags_test.exs
@@ -1,0 +1,91 @@
+defmodule GlimeshWeb.UserLive.Components.RecentTagsTest do
+  use GlimeshWeb.ConnCase
+
+  import Phoenix.LiveViewTest
+
+  alias Glimesh.ChannelCategories
+  alias Glimesh.Streams.Subcategory
+  alias Glimesh.Streams.Tag
+
+  @component GlimeshWeb.UserLive.Components.RecentTags
+
+  defp create_some_dummy_subcategories(categoryId) do
+    Enum.map(0..4, fn x ->
+      %Subcategory{id: x, name: Faker.Superhero.name(), category: categoryId}
+    end)
+  end
+
+  defp create_some_dummy_tags(categoryId) do
+    Enum.map(0..9, fn x -> %Tag{id: x, name: Faker.Food.dish(), category: categoryId} end)
+  end
+
+  describe "recent categories and tags" do
+    setup [:register_and_log_in_user]
+
+    test "shows recent subcategories" do
+      gaming_cat = ChannelCategories.get_category("gaming")
+      tech_cat = ChannelCategories.get_category("tech")
+
+      gaming_subcategories = create_some_dummy_subcategories(gaming_cat)
+
+      html =
+        render_component(@component, %{
+          operation: "replace",
+          fieldid: "category-selector",
+          recent_tags: gaming_subcategories
+        })
+
+      assert html =~ "recent-tag-category-selector-#{Enum.random(gaming_subcategories).id}"
+      assert html =~ "data-tagname=\"#{Enum.random(gaming_subcategories).name}\""
+      assert html =~ "data-operation=\"replace\""
+      assert html =~ "data-fieldid=\"category-selector\""
+
+      tech_subcategories = create_some_dummy_subcategories(tech_cat)
+
+      html =
+        render_component(@component, %{
+          operation: "replace",
+          fieldid: "category-selector",
+          recent_tags: tech_subcategories
+        })
+
+      assert html =~ "recent-tag-category-selector-#{Enum.random(tech_subcategories).id}"
+      assert html =~ "data-tagname=\"#{Enum.random(tech_subcategories).name}\""
+      assert html =~ "data-operation=\"replace\""
+      assert html =~ "data-fieldid=\"category-selector\""
+    end
+
+    test "shows recent tags" do
+      gaming_cat = ChannelCategories.get_category("gaming")
+      tech_cat = ChannelCategories.get_category("tech")
+
+      gaming_tags = create_some_dummy_tags(gaming_cat)
+
+      html =
+        render_component(@component, %{
+          operation: "append",
+          fieldid: "tag-selector",
+          recent_tags: gaming_tags
+        })
+
+      assert html =~ "recent-tag-tag-selector-#{Enum.random(gaming_tags).id}"
+      assert html =~ "data-tagname=\"#{Enum.random(gaming_tags).name}\""
+      assert html =~ "data-operation=\"append\""
+      assert html =~ "data-fieldid=\"tag-selector\""
+
+      tech_tags = create_some_dummy_tags(tech_cat)
+
+      html =
+        render_component(@component, %{
+          operation: "append",
+          fieldid: "tag-selector",
+          recent_tags: tech_tags
+        })
+
+      assert html =~ "recent-tag-tag-selector-#{Enum.random(tech_tags).id}"
+      assert html =~ "data-tagname=\"#{Enum.random(tech_tags).name}\""
+      assert html =~ "data-operation=\"append\""
+      assert html =~ "data-fieldid=\"tag-selector\""
+    end
+  end
+end


### PR DESCRIPTION
### Feature Description
When a streamer edits their stream title and details from the stream page, we present them with two tag fields: the first field allows the streamer to specify their game/activity within the current category they have selected, the second field allows the streamer to add additional tags to further describe their stream to viewers and give prospective viewers keywords to help find their stream with.  

Currently we default the edit modal to the last category, sub-category (game/activity), and tags last saved by the streamer.  For streamers who switch activities/games and tags often, it can be tedious to delete/re-apply the appropriate activity and tags each time.  This feature aims to provide the streamer with a list of recently used sub-categories (games/activities) and tags from their previous streams in the currently selected category.  The lists will update appropriately as the streamer selects different categories from our category picker on the edit modal.

### Feature Requirements
- For the purposes of this feature, recent sub-categories and recent tags ONLY include sub-categories and tags used in previous streams.  It does not include sub-categories and tags saved without a corresponding stream.  For example, a streamer that has never streamed under the IRL category will not see recent sub-categories or tags (however, if the last saved category, sub-category, and tags were in the IRL category, those will still appear in the appropriate fields just as they do prior to this change).
- If the streamer has previously streamed in the currently selected category, display up to 5 of the most recent sub-categories they have used without duplicates (including not duplicating the last saved sub-category).
- If the streamer has previously streamed in the currently selected category, display up to 10 of the most recent tags they have used without duplicates (including not duplicating the last saved tags).
- A stream currently can only specify one sub-category (activity/game), thus selecting a recent sub-category should replace any existing sub-category in the field.
- A stream can have multiple tags, thus selecting a recent tag should append that tag to the end of the tags field.

### Feature Breakdown
- View of the edit stream details modal for a category the streamer has not streamed to and has no saved settings for:
![recent-tags-no-stream-no-saved](https://user-images.githubusercontent.com/5142625/167281517-d0dcd728-8f6b-4e64-bbae-6dda046c8dd6.png)

- View of the edit stream details modal for a category the streamer has saved settings for but not streamed to:
![recent-tags-no-stream-saved-settings](https://user-images.githubusercontent.com/5142625/167281598-ddc42f22-15ee-4d1a-aadd-e9f21935842e.png)

- View of the edit stream details modal for a category the streamer has streamed to previously but does not have saved settings for:
![recent-tags-previous-stream-no-saved](https://user-images.githubusercontent.com/5142625/167281668-77fac06f-32c2-4b62-a771-3bc3d2027e75.png)

- View of the edit stream details modal for a category the streamer has streamed to previously and has saved settings for:
![recent-tags-previous-stream-saved-settings](https://user-images.githubusercontent.com/5142625/167281710-110b8c36-5cfe-4dd2-ac42-d9a98e809c21.png)

### Additional Details
- The de-duplication process only considers the internal id of the tags, thus it is possible to have similar-looking tags suggested if those exist in the database with different ids in the current category.
- The recent sub-categories should be sorted from most recently used to least recent.
- The recent tags should be grouped by stream and presented in the same order they were used in the previous stream excluding any that duplicate currently saved tags.  The list is then sorted by most recent stream to least recent preserving the grouping.
- hovering over a recent sub-category or tag will show a tooltip with the number of uses of that tag site wide.  This can help to determine which tag to use when there are several similar worded tags.
- It was considered, but it is not currently possible to pre-populate the game/activity and tags fields with the tags used in the last stream conducted in that category.  Will consider this for a future patch if there is a desire expressed by the community.
- It is still possible to edit the stream category, sub-category, and tags from the "Channel Settings" page, however, no recent tags/sub-categories will be displayed there.



