### PR TITLE
Feature/community pride tags

### DIFF
--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -219,3 +219,10 @@ $fa-font-path: "/fa-fonts";
     -webkit-backdrop-filter: blur(12px) saturate(160%);
     background-blend-mode: exclusion;
 }
+
+// Addind rainbow colour effect to Community Pride tag
+.bg-pride {
+    background: linear-gradient(to right,
+    #FFD2E9 12.5%, #FFB3B3 12.5% 25%, #FFDDB3 25% 37.5%, #FFFFB3 37.5% 50%, #B3DDB3 50% 62.5%, #B3ECEC 62.5% 75%, #C6B3E0 75% 87.5%, #DDB3DD 87.5%);
+
+}

--- a/assets/css/glimesh/components/calendar.scss
+++ b/assets/css/glimesh/components/calendar.scss
@@ -97,7 +97,7 @@
 }
 
 .calendar-event {
-    border: 3px solid black;
+    border: 3px solid pink;
     border-radius: 25px;
     margin: 0px;
     display: inline-block;

--- a/config/config.exs
+++ b/config/config.exs
@@ -233,12 +233,20 @@ config :glimesh, :event_type,
     nil: "-",
     "GCT Event": "GCT Event",
     "Community Event": "Community Event",
-    "Glimesh Event": "Glimesh Event"
+    "Glimesh Event": "Glimesh Event",
+
+    # Adding in Pride Event tag for Pride Month in june
+    "Pride Event": "Pride Event"
   ],
   event_colors: [
     "GCT Event": "var(--success)",
     "Community Event": "#00AFEF",
-    "Glimesh Event": "var(--danger)"
+    "Glimesh Event": "var(--danger)",
+
+    # Adding in color set for Pride tag
+    "Pride Event":
+      "linear-gradient(to right,
+         #FFD2E9 12.5%, #FFB3B3 12.5% 25%, #FFDDB3 25% 37.5%, #FFFFB3 37.5% 50%, #B3DDB3 50% 62.5%, #B3ECEC 62.5% 75%, #C6B3E0 75% 87.5%, #DDB3DD 87.5%);"
   ]
 
 config :hcaptcha,

--- a/lib/glimesh_web/live/events_team/calendar_live.html.heex
+++ b/lib/glimesh_web/live/events_team/calendar_live.html.heex
@@ -119,8 +119,9 @@
 <div class="calendar" style="width: 100%">
   <div class="d-flex justify-content-around calendar_footer py-2">
     <%= for event_type <- @event_types_key do %>
+      <!--Temporary text color change to enhance readability on Pride tag-->
       <span
-        class="badge badge-pill"
+        class="badge badge-pill text-dark"
         style={
           "vertical-align: middle; border-color: #{event_type.color}; background: #{event_type.color}"
         }

--- a/lib/glimesh_web/live/events_team/events_admin_live.html.heex
+++ b/lib/glimesh_web/live/events_team/events_admin_live.html.heex
@@ -115,6 +115,7 @@
               </div>
               *Times are Glimtime (Eastern)
               <br />
+
               <br />
 
               <div class="row">

--- a/lib/glimesh_web/live/homepage_live.ex
+++ b/lib/glimesh_web/live/homepage_live.ex
@@ -128,7 +128,7 @@ defmodule GlimeshWeb.HomepageLive do
 
                   <div class="card-stream-tags">
                     <%= if channel.subcategory do %>
-                      <span class="badge "><%= channel.subcategory.name %></span>
+                      <span class="badge badge-info"><%= channel.subcategory.name %></span>
                     <% end %>
                   </div>
                 </div>

--- a/lib/glimesh_web/live/homepage_live.ex
+++ b/lib/glimesh_web/live/homepage_live.ex
@@ -128,7 +128,7 @@ defmodule GlimeshWeb.HomepageLive do
 
                   <div class="card-stream-tags">
                     <%= if channel.subcategory do %>
-                      <span class="badge badge-info"><%= channel.subcategory.name %></span>
+                      <span class="badge "><%= channel.subcategory.name %></span>
                     <% end %>
                   </div>
                 </div>

--- a/lib/glimesh_web/live/streams_live/following.html.heex
+++ b/lib/glimesh_web/live/streams_live/following.html.heex
@@ -35,7 +35,11 @@
                     <span class="badge badge-info"><%= channel.subcategory.name %></span>
                   <% end %>
                   <%= for tag <- channel.tags do %>
-                    <span class="badge badge-primary"><%= tag.name %></span>
+                    <%= if tag.name == "Community Pride" do %>
+                      <span class="badge text-dark bg-pride"><%= tag.name %></span>
+                    <%= else %>
+                      <span class="badge badge-primary"><%= tag.name %></span>
+                    <%= end %>
                   <% end %>
                 </div>
               </div>

--- a/lib/glimesh_web/live/streams_live/list.html.heex
+++ b/lib/glimesh_web/live/streams_live/list.html.heex
@@ -112,7 +112,11 @@
                             <span class="badge badge-info"><%= channel.subcategory.name %></span>
                           <% end %>
                           <%= for tag <- channel.tags do %>
-                            <span class="badge badge-primary"><%= tag.name %></span>
+                            <%= if tag.name == "Community Pride" do %>
+                              <span class="badge text-dark bg-pride"><%= tag.name %></span>
+                            <%= else %>
+                              <span class="badge badge-primary"><%= tag.name %></span>
+                            <%= end %>
                           <% end %>
                         </div>
                       </div>

--- a/lib/glimesh_web/live/user_live/components/channel_title.html.heex
+++ b/lib/glimesh_web/live/user_live/components/channel_title.html.heex
@@ -25,18 +25,10 @@
   <% end %>
   <!--Adding in color change for Community Pride Tag in Streams-->
   <%= for tag <- @channel.tags do %>
-    <%= if tag.name == "Community Pride" do %>
-      <%= live_patch(tag.name,
+         <%= live_patch(tag.name,
         to: Routes.streams_list_path(@socket, :index, @channel.category.slug, tags: [tag.slug]),
-        class: "badge badge-pill bg-pride text-dark"
+        class: ["badge badge-pill text-dark", if(tag.name == "Community Pride", do: "bg-pride", else: "badge-primary")]
       ) %>
-    <% end %>
-    <%= if tag.name != "Community Pride" do %>
-      <%= live_patch(tag.name,
-        to: Routes.streams_list_path(@socket, :index, @channel.category.slug, tags: [tag.slug]),
-        class: "badge badge-pill badge-primary"
-      ) %>
-    <% end %>
   <% end %>
 </div>
 

--- a/lib/glimesh_web/live/user_live/components/channel_title.html.heex
+++ b/lib/glimesh_web/live/user_live/components/channel_title.html.heex
@@ -23,11 +23,20 @@
       class: "badge badge-pill badge-info"
     ) %>
   <% end %>
+  <!--Adding in color change for Community Pride Tag in Streams-->
   <%= for tag <- @channel.tags do %>
-    <%= live_patch(tag.name,
-      to: Routes.streams_list_path(@socket, :index, @channel.category.slug, tags: [tag.slug]),
-      class: "badge badge-pill badge-primary"
-    ) %>
+    <%= if tag.name == "Community Pride" do %>
+      <%= live_patch(tag.name,
+        to: Routes.streams_list_path(@socket, :index, @channel.category.slug, tags: [tag.slug]),
+        class: "badge badge-pill bg-pride text-dark"
+      ) %>
+    <% end %>
+    <%= if tag.name != "Community Pride" do %>
+      <%= live_patch(tag.name,
+        to: Routes.streams_list_path(@socket, :index, @channel.category.slug, tags: [tag.slug]),
+        class: "badge badge-pill badge-primary"
+      ) %>
+    <% end %>
   <% end %>
 </div>
 

--- a/lib/glimesh_web/templates/events_team/events_team.html.eex
+++ b/lib/glimesh_web/templates/events_team/events_team.html.eex
@@ -27,7 +27,7 @@
                         <div class="media">
                             <img src="<%= Glimesh.EventImage.url({event.image, event.image}, :original) %>" style="max-height: 225px" alt="<%= event.label %>">
                             <div class="media-body ml-4">
-                                <span class="badge badge-pill" style="vertical-align: middle; border-color: <%= Glimesh.EventsTeam.get_event_color(event) %>; background: <%= Glimesh.EventsTeam.get_event_color(event) %>;"><%= event.type %></span>
+                                <span class="badge badge-pill text-dark" style="vertical-align: middle; border-color: <%= Glimesh.EventsTeam.get_event_color(event) %>; background: <%= Glimesh.EventsTeam.get_event_color(event) %>;"><%= event.type %></span>
                                 <h5>
                                     <%= event.label %><br>
                                     <small class="text-muted">


### PR DESCRIPTION
For Commuity Pride we wanted a way to make those who are supporting the event be easily identifiable. To that end we have added a new tag to the events page - Pride Event, which will tag it as separate to our usual community events.

![unknown](https://user-images.githubusercontent.com/77231604/168164361-1b218ed2-ca19-4ae8-8f2a-53ed48079de4.png)

![unknown](https://user-images.githubusercontent.com/77231604/168164441-d780bdf9-d482-4460-9481-9a1920d1d518.png)

(ignore the broken image link my PC is dumb sometimes)

And in addition to this anyone who uses the Community Pride tag as a channel descriptor will find it is Rainbow to match.

![unknown](https://user-images.githubusercontent.com/77231604/168164396-e3ded7dc-4c42-4fe3-929f-0fa759edb397.png)

The color change will only happen for the Community Pride tag, all other tags remain unaffected.

***UPDATES***

Made suggested code changes from @clone1018 

Added Community Pride tag colors to show on live stream page and followers page

![unknown](https://user-images.githubusercontent.com/77231604/168164554-ee428aa9-2da4-496f-b448-a18e2d86eec6.png)

![unknown](https://user-images.githubusercontent.com/77231604/168164587-e8e16c16-e39f-42a4-a42a-c3b6f02b34ae.png)

Also fixed issue with removal of blue color from the live streams page. 

