### PR TITLE
fixes #837 -- hosting banner links incorrectly open the host's or target's support modal page

### DIFF
--- a/lib/glimesh_web/live/user_live/stream.html.heex
+++ b/lib/glimesh_web/live/user_live/stream.html.heex
@@ -41,7 +41,7 @@
         <a
           class="btn btn-primary"
           href={
-            Routes.user_stream_path(@socket, :support, @hosting_channel.host.user.username, %{
+            Routes.user_stream_path(@socket, :index, @hosting_channel.host.user.username, %{
               "follow_host" => "false"
             })
           }
@@ -96,7 +96,7 @@
         <a
           class="btn btn-primary"
           href={
-            Routes.user_stream_path(@socket, :support, @hosting_channel.target.user.username, %{
+            Routes.user_stream_path(@socket, :index, @hosting_channel.target.user.username, %{
               "host" => @hosting_channel.host.user.username
             })
           }


### PR DESCRIPTION
This change will restore the previous functionality of the hosting banner links to only redirect the user to the stream index page without opening the support modal.