### PR TITLE
fixing dark mode tag color

### DIFF
--- a/lib/glimesh_web/live/user_live/components/channel_title.html.heex
+++ b/lib/glimesh_web/live/user_live/components/channel_title.html.heex
@@ -35,8 +35,8 @@
     <%= live_patch(tag.name,
       to: Routes.streams_list_path(@socket, :index, @channel.category.slug, tags: [tag.slug]),
       class: [
-        "badge badge-pill text-dark",
-        if(tag.name == "Community Pride", do: "bg-pride", else: "badge-primary")
+        "badge badge-pill",
+        if(tag.name == "Community Pride", do: "bg-pride text-dark", else: "badge-primary")
       ]
     ) %>
   <% end %>


### PR DESCRIPTION
Fixing the tag color for all tags which aren't community pride back to default coloration when viewing streams. This is to enchance readability overall. 