### PR TITLE
Adding new roles

### DIFF
--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -318,3 +318,11 @@ $fa-font-path: "/fa-fonts";
     -webkit-transform: skewY(10deg);
     transform: skewY(10deg);
 }
+
+.bg-EventsTeam {
+    background: #288b8c
+}
+
+.EventsTeam_Font {
+    color: #288b8c
+}

--- a/lib/glimesh/accounts/profile.ex
+++ b/lib/glimesh/accounts/profile.ex
@@ -5,10 +5,13 @@ defmodule Glimesh.Accounts.Profile do
 
   def user_role_color(%User{team_role: team_role}) do
     case team_role do
-      "Core Team" ->
+      "Glimesh Staff" ->
         "bg-danger"
 
-      "Community Team" ->
+      "Core Team" ->
+        "bg-primary"
+
+      "Community Champion" ->
         "bg-success"
 
       "Design Team" ->
@@ -16,6 +19,9 @@ defmodule Glimesh.Accounts.Profile do
 
       "Product Dev Team" ->
         "bg-secondary"
+
+      "Events Team" ->
+        "bg-EventsTeam"
 
       _ ->
         ""

--- a/lib/glimesh/accounts/user.ex
+++ b/lib/glimesh/accounts/user.ex
@@ -27,6 +27,7 @@ defmodule Glimesh.Accounts.User do
     field :is_admin, :boolean, default: false
     field :is_gct, :boolean, default: false
     field :gct_level, :integer
+    field :is_community_champion, :boolean, default: false
     field :is_events_team, :boolean, default: false
     field :is_banned, :boolean, default: false
     field :ban_reason, :string
@@ -288,6 +289,7 @@ defmodule Glimesh.Accounts.User do
       :is_gct,
       :gct_level,
       :team_role,
+      :is_community_champion,
       :is_events_team
     ])
     |> validate_length(:ban_reason, max: 8192)

--- a/lib/glimesh/chat/effects.ex
+++ b/lib/glimesh/chat/effects.ex
@@ -31,7 +31,9 @@ defmodule Glimesh.Chat.Effects do
   def get_username_color(user, default \\ "text-color-link") do
     cond do
       user.is_admin -> "text-danger"
-      user.is_gct -> "text-success"
+      user.is_gct -> "text-primary"
+      user.is_community_champion -> "text-success"
+      user.is_events_team -> "EventsTeam_Font"
       Payments.is_platform_founder_subscriber?(user) -> "text-warning"
       true -> default
     end
@@ -43,7 +45,8 @@ defmodule Glimesh.Chat.Effects do
       ) do
     cond do
       user.is_admin -> "text-danger"
-      user.is_gct -> "text-success"
+      user.is_gct -> "text-primary"
+      user.is_community_champion -> "text-success"
       metadata.platform_founder_subscriber -> "text-warning"
       true -> default
     end
@@ -61,7 +64,13 @@ defmodule Glimesh.Chat.Effects do
         user.is_gct ->
           [
             "data-toggle": "tooltip",
-            title: gettext("Glimesh Community Team")
+            title: gettext("Core Team")
+          ]
+
+        user.is_community_champion ->
+          [
+            "data-toggle": "tooltip",
+            title: gettext("Community Champion")
           ]
 
         metadata.platform_founder_subscriber ->

--- a/lib/glimesh_web/live/channel_settings_live/channel_emotes.html.heex
+++ b/lib/glimesh_web/live/channel_settings_live/channel_emotes.html.heex
@@ -112,7 +112,7 @@
   <div class="card-body">
     <p>
       <%= gettext(
-        "After you submit your emotes they'll be reviewed by our Glimesh Community Team for compliance. If they are approved they will be automatically available on your channel. If they are rejected you'll see them below with a reason why. You can delete rejected emotes and reupload them if you want to try again."
+        "After you submit your emotes they'll be reviewed by our Core Team for compliance. If they are approved they will be automatically available on your channel. If they are rejected you'll see them below with a reason why. You can delete rejected emotes and reupload them if you want to try again."
       ) %>
     </p>
     <div class="row">

--- a/lib/glimesh_web/live/channel_settings_live/upload_emotes.ex
+++ b/lib/glimesh_web/live/channel_settings_live/upload_emotes.ex
@@ -70,7 +70,7 @@ defmodule GlimeshWeb.ChannelSettingsLive.UploadEmotes do
        socket
        |> put_flash(
          :emote_info,
-         "Successfully uploaded emotes, pending review by the Glimesh Community Team"
+         "Successfully uploaded emotes, pending review by the Core Team"
        )
        |> redirect(to: Routes.user_settings_path(socket, :emotes))}
     end

--- a/lib/glimesh_web/templates/gct/edit_user.html.eex
+++ b/lib/glimesh_web/templates/gct/edit_user.html.eex
@@ -113,23 +113,37 @@
                 </div>
             </div>
             <hr>
-            <h5><%= gettext("GCT Settings") %></h5>
+            <h5><%= gettext("Core Team Settings") %></h5>
             <div class="row mt-1">
                 <div class="col-sm-6">
-                    <%= label f, gettext("Is GCT") %>
+                    <%= label f, gettext("Is Core Team") %>
                     <%= select f, :is_gct, [Yes: true, No: false], [class: "form-control"] %>
                     <%= error_tag f, :is_gct %>
                 </div>
                 <div class="col-sm-6">
-                    <%= label f, gettext("GCT Access Level") %>
+                    <%= label f, gettext("Core Team Access Level") %>
                     <%= number_input f, :gct_level, [class: "form-control"] %>
                     <%= error_tag f, :gct_level %>
                 </div>
             </div>
             <% end %>
 
+            <%= if @conn.assigns.current_user.gct_level >= 4 || @conn.assigns.current_user.is_admin do %>
+            <hr>
+
+            <h5><%= gettext("Community Champion Settings") %></h5>
+            <div class="row mt-1">
+                <div class="col-sm-6">
+                    <%= label f, gettext("Is Community Champion") %>
+                    <%= select f, :is_community_champion, [Yes: true, No: false], [class: "form-control"] %>
+                    <%= error_tag f, :is_community_champion %>
+                </div>
+            </div>
+                <% end %>
+
                 <%= if @conn.assigns.current_user.gct_level >= 4 || @conn.assigns.current_user.is_admin do %>
             <hr>
+
             <h5><%= gettext("Event Team Settings") %></h5>
             <div class="row mt-1">
                 <div class="col-sm-6">

--- a/lib/glimesh_web/templates/gct/index.html.eex
+++ b/lib/glimesh_web/templates/gct/index.html.eex
@@ -1,5 +1,5 @@
 <div class="container">
-    <h2 class="mt-4 text-center"><%= gettext("Glimesh Community Team Dashboard | Your access level is: %{level}", level: Glimesh.CommunityTeam.access_level_to_title(@conn.assigns.current_user.gct_level)) %></h2>
+    <h2 class="mt-4 text-center"><%= gettext("Core Team Dashboard | Your access level is: %{level}", level: Glimesh.CommunityTeam.access_level_to_title(@conn.assigns.current_user.gct_level)) %></h2>
     <%= if @can_view_audit_log do %>
     <div class="card mb-4">
         <div class="card-body">

--- a/lib/glimesh_web/templates/gct/lookup_user.html.eex
+++ b/lib/glimesh_web/templates/gct/lookup_user.html.eex
@@ -18,6 +18,10 @@
                                     <p><%= gettext("Banned: %{value}", value: (if @user.is_banned, do: "✅", else: "❌")) %>
                                     </p>
                                     <p><%= gettext("GCT: %{value}", value: (if @user.is_gct, do: "✅", else: "❌")) %></p>
+                                    <p><%= gettext("Community Champion: %{value}", value: (if @user.is_community_champion, do: "✅", else: "❌")) %>
+                                    </p>
+                                    <p><%= gettext("Events Team: %{value}", value: (if @user.is_events_team, do: "✅", else: "❌")) %>
+                                    </p>
                                     <p><%= gettext("Access Level: %{value}", value: Glimesh.CommunityTeam.access_level_to_title(@user.gct_level)) %>
                                     </p>
                                     <p>

--- a/priv/repo/migrations/20220818101336_add_is_community_champion_to_users.exs
+++ b/priv/repo/migrations/20220818101336_add_is_community_champion_to_users.exs
@@ -1,0 +1,9 @@
+defmodule Glimesh.Repo.Migrations.AddIsGctToUsers do
+  use Ecto.Migration
+
+  def change do
+    alter table(:users) do
+      add :is_community_champion, :boolean, default: false
+    end
+  end
+end

--- a/priv/repo/migrations/20220818101336_add_is_community_champion_to_users.exs
+++ b/priv/repo/migrations/20220818101336_add_is_community_champion_to_users.exs
@@ -1,4 +1,4 @@
-defmodule Glimesh.Repo.Migrations.AddIsGctToUsers do
+defmodule Glimesh.Repo.Migrations.AddIsCommunityChampion do
   use Ecto.Migration
 
   def change do

--- a/test/glimesh_web/controllers/gct_controller_test.exs
+++ b/test/glimesh_web/controllers/gct_controller_test.exs
@@ -23,7 +23,7 @@ defmodule GlimeshWeb.GctControllerTest do
 
     test "show index page", %{conn: conn} do
       conn = get(conn, Routes.gct_path(conn, :index))
-      assert html_response(conn, 200) =~ "Glimesh Community Team Dashboard"
+      assert html_response(conn, 200) =~ "Core Team Dashboard"
     end
   end
 

--- a/test/glimesh_web/live/channel_settings_live/upload_emotes_test.exs
+++ b/test/glimesh_web/live/channel_settings_live/upload_emotes_test.exs
@@ -54,7 +54,7 @@ defmodule GlimeshWeb.ChannelSettingsLive.UploadEmotesTest do
       flash = assert_redirected(view, "/users/settings/emotes")
 
       assert flash["emote_info"] ==
-               "Successfully uploaded emotes, pending review by the Glimesh Community Team"
+               "Successfully uploaded emotes, pending review by the Core Team"
 
       emote = Glimesh.Emotes.get_emote_by_emote("testgglimchef")
       assert emote.channel_id == channel.id


### PR DESCRIPTION
New roles have been added to reflect some core changes to the teams.

New GCT format with umbrella term for 2 teams: 

Core Team - as was GCT : Now Blue - GCT Dashboard Access will show in chat and on profile
Community Champion - New Role created under the GCT Umbrella - Green - no dashboard access, will show in chat and on profile

![unknown2](https://user-images.githubusercontent.com/77231604/185789495-7f93d9f1-8237-40e1-a891-02b34b336b4e.png)
![unknown1](https://user-images.githubusercontent.com/77231604/185789499-3a5fd1f3-ebb9-4a63-9bd9-b739d55e18b7.png)


Events team: 

New role in teal - Should anyone be added to events team in the future this color will show on their profile (not in chat) so people can identify them 

Tooltips for all of these added for in chat. These have also been created as Teams for the about us - contributors section. 
