### PR TITLE
adding png for emotes

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -273,7 +273,7 @@ config :glimesh, Glimesh.Socials.Twitter,
   access_token: "",
   access_token_secret: ""
 
-config :glimesh, Glimesh.Emotes, max_channel_emotes: 10, allow_channel_animated_emotes: true
+config :glimesh, Glimesh.Emotes, max_channel_emotes: 100, allow_channel_animated_emotes: true
 
 config :libcluster,
   topologies: []

--- a/lib/glimesh/api/resolvers/channel_resolver.ex
+++ b/lib/glimesh/api/resolvers/channel_resolver.ex
@@ -31,17 +31,20 @@ defmodule Glimesh.Api.ChannelResolver do
     end
   end
 
-  def update_stream_info(_parent, %{channel_id: channel_id, title: title},
-        %{context: %{access: access}
+  def update_stream_info(_parent, %{channel_id: channel_id, title: title}, %{
+        context: %{access: access}
       }) do
     with :ok <- Bodyguard.permit(Glimesh.Api.Scopes, :stream_info, access) do
       channel = Glimesh.ChannelLookups.get_channel(channel_id)
+
       if channel !== nil do
         case Streams.update_channel(access.user, channel, %{title: title}) do
           {:ok, changeset} ->
             {:ok, changeset}
+
           {:error, %Ecto.Changeset{} = changeset} ->
             {:error, Api.parse_ecto_changeset_errors(changeset)}
+
           {:error, :unauthorized} ->
             {:error, :unauthorized}
         end

--- a/lib/glimesh/emotes.ex
+++ b/lib/glimesh/emotes.ex
@@ -151,7 +151,7 @@ defmodule Glimesh.Emotes do
 
   def create_global_emote(%User{} = user, attrs \\ %{}) do
     with :ok <- Bodyguard.permit(__MODULE__, :create_global_emote, user) do
-      %Emote{}
+      %Emote{svg: true}
       |> Emote.changeset(attrs)
       |> Repo.insert()
     end
@@ -160,7 +160,8 @@ defmodule Glimesh.Emotes do
   def create_channel_emote(%User{} = user, %Channel{} = channel, attrs \\ %{}) do
     with :ok <- Bodyguard.permit(__MODULE__, :create_channel_emote, user, channel) do
       %Emote{
-        channel: channel
+        channel: channel,
+        svg: false
       }
       |> Emote.channel_changeset(channel, attrs)
       |> Repo.insert()
@@ -201,7 +202,11 @@ defmodule Glimesh.Emotes do
     Glimesh.Uploaders.AnimatedEmote.url({emote.animated_file, emote}, :gif)
   end
 
-  def full_url(%Emote{} = emote) do
+  def full_url(%Emote{svg: true} = emote) do
     Glimesh.Uploaders.StaticEmote.url({emote.static_file, emote}, :svg)
+  end
+
+  def full_url(%Emote{} = emote) do
+    Glimesh.Uploaders.StaticEmote.url({emote.static_file, emote}, :png)
   end
 end

--- a/lib/glimesh/emotes/emote.ex
+++ b/lib/glimesh/emotes/emote.ex
@@ -10,6 +10,7 @@ defmodule Glimesh.Emotes.Emote do
     field :emote, :string
     belongs_to :channel, Glimesh.Streams.Channel
     field :animated, :boolean
+    field :svg, :boolean
 
     field :approved_at, :naive_datetime
     field :rejected_at, :naive_datetime

--- a/lib/glimesh/oauth_migration.ex
+++ b/lib/glimesh/oauth_migration.ex
@@ -70,7 +70,7 @@ defmodule Glimesh.OauthMigration do
       %{label: "Chat", name: "chat", public: true},
       %{label: "Stream Key", name: "streamkey", public: true},
       %{label: "Follow Channel", name: "follow", public: true},
-      %{label: "Update Stream Info", name: "stream_info", public: true},
+      %{label: "Update Stream Info", name: "stream_info", public: true}
     ]
 
     Enum.each(scopes, fn attrs ->

--- a/lib/glimesh_web/live/channel_settings_live/channel_emotes.html.heex
+++ b/lib/glimesh_web/live/channel_settings_live/channel_emotes.html.heex
@@ -17,7 +17,7 @@
       <strong><%= gettext("Early Feature Alert!") %></strong>
       Hey there! Channel Emotes are still under heavy development, while we are working through how to make the best emote system we can,
       <strong>
-        we're limiting all channels to two emotes, either static, animated, or a combination
+        we are no longer limiting amount of emotes a channel can have, though while in testing we are restricting file type to PNG and GIF only
       </strong>
       ! We're continually building this new feature, and we'd love your opinion on how we should do it. Thank you!
     </div>

--- a/lib/glimesh_web/live/channel_settings_live/upload_emotes.ex
+++ b/lib/glimesh_web/live/channel_settings_live/upload_emotes.ex
@@ -21,7 +21,7 @@ defmodule GlimeshWeb.ChannelSettingsLive.UploadEmotes do
      |> assign(:emote_settings, Streams.change_emote_settings(channel))
      |> assign(:can_upload, can_upload)
      |> assign(:uploaded_files, [])
-     |> allow_upload(:emote, accept: ~w(.svg .gif), max_entries: 2)}
+     |> allow_upload(:emote, accept: ~w(.png .gif), max_entries: 2)}
   end
 
   @impl Phoenix.LiveView

--- a/lib/glimesh_web/live/channel_settings_live/upload_emotes.html.heex
+++ b/lib/glimesh_web/live/channel_settings_live/upload_emotes.html.heex
@@ -25,7 +25,7 @@
               </div>
               <p>
                 <%= gettext(
-                  "Static emotes should be square SVG vector graphics, with a max file size of 256kB. Animated emotes should be square GIFs, with minimum dimensions of 128x128 and a maximum of 256x256, max file size of 1MB."
+                  "Static emotes should be square PNG graphics, with a max file size of 256kB. Animated emotes should be square GIFs, with minimum dimensions of 128x128 and a maximum of 256x256, max file size of 1MB."
                 ) %>
               </p>
               <p>

--- a/priv/repo/migrations/20220824183447_add_svg_flag_to_emotes.exs
+++ b/priv/repo/migrations/20220824183447_add_svg_flag_to_emotes.exs
@@ -1,0 +1,9 @@
+defmodule Glimesh.Repo.Migrations.AddSvgFlagToEmotes do
+  use Ecto.Migration
+
+  def change do
+    alter table(:emotes) do
+      add :svg, :boolean, default: true
+    end
+  end
+end


### PR DESCRIPTION
So i'm not sure if this was the best way to code things but it was the best way I could figure to make it work. 

Emotes now support PNG! 

PNG would be the only way for users to upload emotes going forward - this would enable more emotes to be uploaded by the user. 

Anything SVG should be retained, this will only effect emotes going forward for channels. 

Platform Emotes are still SVG as they have always been. 

My dev environment allowed more than 2 emotes to be uploaded, so that part may need checking (it was set at 10, not something I had set myself, upped to 100 now)

Any issues need addressing let me know. 

Not really much to show screenshot wise :) 

Thanks. 