### PR TITLE
Giving users the power to turn off receipt of Gift Subs

### DIFF
--- a/lib/glimesh/accounts/user_preference.ex
+++ b/lib/glimesh/accounts/user_preference.ex
@@ -13,6 +13,7 @@ defmodule Glimesh.Accounts.UserPreference do
     field :show_timestamps, :boolean, default: false
     field :show_mod_icons, :boolean, default: true
     field :show_mature_content, :boolean, default: false
+    field :gift_subs_enabled, :boolean, default: true
 
     timestamps()
   end
@@ -27,7 +28,8 @@ defmodule Glimesh.Accounts.UserPreference do
       :site_theme,
       :show_timestamps,
       :show_mature_content,
-      :show_mod_icons
+      :show_mod_icons,
+      :gift_subs_enabled
     ])
     |> unique_constraint(:user_id)
   end

--- a/lib/glimesh/api/resolvers/channel_resolver.ex
+++ b/lib/glimesh/api/resolvers/channel_resolver.ex
@@ -31,17 +31,20 @@ defmodule Glimesh.Api.ChannelResolver do
     end
   end
 
-  def update_stream_info(_parent, %{channel_id: channel_id, title: title},
-        %{context: %{access: access}
+  def update_stream_info(_parent, %{channel_id: channel_id, title: title}, %{
+        context: %{access: access}
       }) do
     with :ok <- Bodyguard.permit(Glimesh.Api.Scopes, :stream_info, access) do
       channel = Glimesh.ChannelLookups.get_channel(channel_id)
+
       if channel !== nil do
         case Streams.update_channel(access.user, channel, %{title: title}) do
           {:ok, changeset} ->
             {:ok, changeset}
+
           {:error, %Ecto.Changeset{} = changeset} ->
             {:error, Api.parse_ecto_changeset_errors(changeset)}
+
           {:error, :unauthorized} ->
             {:error, :unauthorized}
         end

--- a/lib/glimesh/oauth_migration.ex
+++ b/lib/glimesh/oauth_migration.ex
@@ -70,7 +70,7 @@ defmodule Glimesh.OauthMigration do
       %{label: "Chat", name: "chat", public: true},
       %{label: "Stream Key", name: "streamkey", public: true},
       %{label: "Follow Channel", name: "follow", public: true},
-      %{label: "Update Stream Info", name: "stream_info", public: true},
+      %{label: "Update Stream Info", name: "stream_info", public: true}
     ]
 
     Enum.each(scopes, fn attrs ->

--- a/lib/glimesh_web/templates/user_settings/preference.html.eex
+++ b/lib/glimesh_web/templates/user_settings/preference.html.eex
@@ -29,6 +29,16 @@
                 <small class="form-text text-muted"><%= gettext("Automatically bypass our Mature Content warning by enabling this preference.") %></small>
             </div>
 
+            <div class="form-group">
+                <%= label f, gettext("Gift Subscription Options:") %>
+                <div class="custom-control custom-switch">
+                    <%= checkbox f, :gift_subs_enabled, class: "custom-control-input" %>
+                    <label class="custom-control-label" for="<%= input_id(f, :gift_subs_enabled) %>"><%= gettext("Receive Gift Subscriptions") %></label>
+                </div>
+                <%= error_tag f, :gift_subs_enabled %>
+
+                <small class="form-text text-muted"><%= gettext("By turning this off you will no longer be able to receive gift subscriptions") %></small>
+            </div>
 
             <h3 class="mt-4"><%= gettext("Look & Feel") %></h3>
 

--- a/priv/repo/migrations/20220903123948_add_user_gift_sub_options.exs
+++ b/priv/repo/migrations/20220903123948_add_user_gift_sub_options.exs
@@ -1,0 +1,9 @@
+defmodule Glimesh.Repo.Migrations.AddUserGiftSubOptions do
+  use Ecto.Migration
+
+  def change do
+    alter table(:user_preferences) do
+      add :gift_subs_enabled, :boolean, default: true
+    end
+  end
+end


### PR DESCRIPTION
Small QoL Update after a conversation in discord recently. 

Giving users the power to turn off receiving gift subscriptions. Some users prefer not to bad able to receive them, this could be a host of reasons as to why a user may not want to receive gift subs. With this in mind, and inkeeping with the Glimesh ethos of giving everyone a choice over how their accounts can function, I have now added this capacity. 

Located under user preferences is a toggle, this is on by default but users may turn it off if they wish. 

![unknown1](https://user-images.githubusercontent.com/77231604/188274968-9877d8b5-3f97-43b3-aabf-0e2fac39bd6c.png)

![unknown](https://user-images.githubusercontent.com/77231604/188274966-7b0889a2-eeb2-4b89-a8a8-744595328464.png)

If this is toggled off any user trying to give that person a gift sub will be notified by an error message before proceeding to checkout, which will prevent the person gifting from being charged. 

Further discussion will be available in a Building Glimesh thread. 

Thanks all!

