### PR TITLE
fixing duplicate emotes issue

### DIFF
--- a/lib/glimesh/emotes.ex
+++ b/lib/glimesh/emotes.ex
@@ -170,6 +170,7 @@ defmodule Glimesh.Emotes do
             e.emote_display_off == false and
             (e.require_channel_sub == false or
                (e.require_channel_sub == true and (s.is_active == true or c.user_id == ^userid))),
+        distinct: e.id,
         order_by: e.emote
       )
     )


### PR DESCRIPTION
https://github.com/Glimesh/glimesh.tv/issues/868

Fix for this issue, upon Blitz having the same issue it was discovered that the problem was lying with people who had lapsed subs to channels, and then took out another sub later on for the same channel. Table was recognising both lapsed and live subscription thus leading to 2 sets of emotes being displayed - but only one when a sub emote was toggled. 

I can't take credit for this one, while Blitz enabled me to help isolate the cause, FrozenShadowDragon enabled with the quick fix, I just wrote what he told me too :D 