### PR TITLE
Allow streamers to hide viewer count and viewers to default the viewer count to expanded/minimized

### DIFF
--- a/lib/glimesh/accounts/user_preference.ex
+++ b/lib/glimesh/accounts/user_preference.ex
@@ -14,6 +14,7 @@ defmodule Glimesh.Accounts.UserPreference do
     field :show_mod_icons, :boolean, default: true
     field :show_mature_content, :boolean, default: false
     field :gift_subs_enabled, :boolean, default: true
+    field :maximize_viewer_count, :boolean, default: true
 
     timestamps()
   end
@@ -29,7 +30,8 @@ defmodule Glimesh.Accounts.UserPreference do
       :show_timestamps,
       :show_mature_content,
       :show_mod_icons,
-      :gift_subs_enabled
+      :gift_subs_enabled,
+      :maximize_viewer_count
     ])
     |> unique_constraint(:user_id)
   end

--- a/lib/glimesh/streams/channel.ex
+++ b/lib/glimesh/streams/channel.ex
@@ -46,6 +46,8 @@ defmodule Glimesh.Streams.Channel do
     field :poster, Glimesh.ChannelPoster.Type
     field :chat_bg, Glimesh.ChatBackground.Type
 
+    field :show_viewer_count, :boolean, default: true
+
     # This is used when searching for live channels that are live or hosted
     field :match_type, :string, virtual: true
 
@@ -105,7 +107,8 @@ defmodule Glimesh.Streams.Channel do
       :require_confirmed_email,
       :minimum_account_age,
       :allow_hosting,
-      :backend
+      :backend,
+      :show_viewer_count
     ])
     |> validate_length(:chat_rules_md, max: 8192)
     |> validate_length(:title, max: 250)

--- a/lib/glimesh_web/live/user_live/stream.ex
+++ b/lib/glimesh_web/live/user_live/stream.ex
@@ -14,6 +14,8 @@ defmodule GlimeshWeb.UserLive.Stream do
         maybe_user = Accounts.get_user_by_session_token(session["user_token"])
         streamer = Accounts.get_user!(channel.streamer_id)
 
+        viewer_count_state = get_viewer_count_state(maybe_user, channel)
+
         {:ok,
          %{
            :redirect_to_hosted_target => redirect_to_hosted_target,
@@ -64,7 +66,8 @@ defmodule GlimeshWeb.UserLive.Stream do
            |> assign(:player_error, nil)
            |> assign(:user, maybe_user)
            |> assign(:ultrawide, false)
-           |> assign(:webrtc_error, false)}
+           |> assign(:webrtc_error, false)
+           |> assign(:viewer_count_state, viewer_count_state)}
         end
 
       nil ->
@@ -236,4 +239,25 @@ defmodule GlimeshWeb.UserLive.Stream do
       image_url: avatar_url
     }
   end
+
+  defp get_viewer_count_state(
+         %Glimesh.Accounts.User{} = user,
+         %Glimesh.Streams.Channel{} = channel
+       ) do
+    %{:maximize_viewer_count => user_viewer_count_pref} =
+      Glimesh.Accounts.get_user_preference!(user)
+
+    cond do
+      channel.show_viewer_count == false ->
+        :hide
+
+      user_viewer_count_pref == false ->
+        :minimize
+
+      true ->
+        :visible
+    end
+  end
+
+  defp get_viewer_count_state(nil, _channel), do: :visible
 end

--- a/lib/glimesh_web/live/user_live/stream.html.heex
+++ b/lib/glimesh_web/live/user_live/stream.html.heex
@@ -142,7 +142,10 @@
                   <div class="btn-group" role="group" aria-label="Third group">
                     <%= live_render(@socket, GlimeshWeb.UserLive.Components.ViewerCount,
                       id: "viewer-count",
-                      session: %{"channel_id" => @channel.id}
+                      session: %{
+                        "channel_id" => @channel.id,
+                        "viewer_count_state" => @viewer_count_state
+                      }
                     ) %>
                   </div>
                 </div>

--- a/lib/glimesh_web/live/user_settings/components/channel_settings_live.html.heex
+++ b/lib/glimesh_web/live/user_settings/components/channel_settings_live.html.heex
@@ -54,14 +54,7 @@
       "Create and design a channel custom to you by uploading unique images and identifying what type of content viewers can expect from your channel. You can customize the content that appears under your stream on your Profile page."
     ) %>
   </p>
-  <div class="row">
-    <div class="col-sm-6">
-      <div class="form-group">
-        <%= label(f, gettext("Channel Primary Language")) %>
-        <%= select(f, :language, Application.get_env(:glimesh, :locales), class: "form-control") %>
-        <%= error_tag(f, :language) %>
-      </div>
-    </div>
+  <div class="row pt-2 pb-4">
     <div class="col-sm-6">
       <div class="form-group">
         <%= label(f, gettext("Mature Content")) %>
@@ -72,6 +65,27 @@
           </label>
         </div>
         <%= error_tag(f, :mature_content) %>
+      </div>
+    </div>
+    <div class="col-sm-6">
+      <div class="form-group">
+        <%= label(f, gettext("Show Viewer Count")) %>
+        <div class="custom-control custom-switch">
+          <%= checkbox(f, :show_viewer_count, class: "custom-control-input") %>
+          <label class="custom-control-label" for={input_id(f, :show_viewer_count)}>
+            <%= gettext("Show viewer count on channel page") %>
+          </label>
+        </div>
+        <%= error_tag(f, :mature_content) %>
+      </div>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-sm-6">
+      <div class="form-group">
+        <%= label(f, gettext("Channel Primary Language")) %>
+        <%= select(f, :language, Application.get_env(:glimesh, :locales), class: "form-control") %>
+        <%= error_tag(f, :language) %>
       </div>
     </div>
   </div>

--- a/lib/glimesh_web/templates/user_settings/preference.html.eex
+++ b/lib/glimesh_web/templates/user_settings/preference.html.eex
@@ -76,6 +76,15 @@
                 <small class="form-text text-muted"><%= gettext("Shows the timeout / ban / etc icons on a chat message.") %></small>
             </div>
 
+            <div class="form-group">
+                <%= label f, gettext("Viewer Count:") %>
+                <div class="custom-control custom-switch">
+                    <%= checkbox f, :maximize_viewer_count, class: "custom-control-input" %>
+                    <%= label f, :maximize_viewer_count, gettext("Expand the viewer count on channel pages"), class: "custom-control-label" %>
+                </div>
+                <small class="form-text text-muted"><%= gettext("Sets the default state of the viewer count on channel pages to be expanded/minimized.") %></small>
+            </div>
+
             <%= submit gettext("Update Settings"), class: "btn btn-primary mt-4" %>
 
             <% end %>

--- a/priv/repo/migrations/20221112022848_add_viewer_count_toggle_preferences.exs
+++ b/priv/repo/migrations/20221112022848_add_viewer_count_toggle_preferences.exs
@@ -1,0 +1,13 @@
+defmodule Glimesh.Repo.Migrations.AddViewerCountTogglePreferences do
+  use Ecto.Migration
+
+  def change do
+    alter table(:channels) do
+      add :show_viewer_count, :boolean, default: true
+    end
+
+    alter table(:user_preferences) do
+      add :maximize_viewer_count, :boolean, default: true
+    end
+  end
+end

--- a/test/glimesh_web/live/user_live_components/viewer_count_test.exs
+++ b/test/glimesh_web/live/user_live_components/viewer_count_test.exs
@@ -15,13 +15,20 @@ defmodule GlimeshWeb.UserLive.Components.ViewerCountTest do
     setup :create_channel
 
     test "shows no viewer without loading stream", %{conn: conn, channel: channel} do
-      {:ok, _, html} = live_isolated(conn, @component, session: %{"channel_id" => channel.id})
+      {:ok, _, html} =
+        live_isolated(conn, @component,
+          session: %{"channel_id" => channel.id, "viewer_count_state" => :visible}
+        )
 
       assert html =~ "0 Viewers"
     end
 
     test "shows one viewer by loading a stream", %{conn: conn, channel: channel} do
-      {:ok, view, _} = live_isolated(conn, @component, session: %{"channel_id" => channel.id})
+      {:ok, view, _} =
+        live_isolated(conn, @component,
+          session: %{"channel_id" => channel.id, "viewer_count_state" => :visible}
+        )
+
       streamer = Glimesh.Accounts.get_user!(channel.user_id)
 
       assert render(view) =~ "0 Viewers"
@@ -42,9 +49,39 @@ defmodule GlimeshWeb.UserLive.Components.ViewerCountTest do
     end
 
     test "can hide the viewer count", %{conn: conn, channel: channel} do
-      {:ok, view, _} = live_isolated(conn, @component, session: %{"channel_id" => channel.id})
+      {:ok, view, _} =
+        live_isolated(conn, @component,
+          session: %{"channel_id" => channel.id, "viewer_count_state" => :visible}
+        )
 
       assert view |> element("button") |> render_click() =~ "far fa-eye-slash"
+    end
+
+    test "is minimized if preference set", %{conn: conn, channel: channel} do
+      {:ok, view, _} =
+        live_isolated(conn, @component,
+          session: %{"channel_id" => channel.id, "viewer_count_state" => :minimize}
+        )
+
+      assert render(view) =~ "far fa-eye-slash"
+    end
+
+    test "can be maximized if minimized", %{conn: conn, channel: channel} do
+      {:ok, view, _} =
+        live_isolated(conn, @component,
+          session: %{"channel_id" => channel.id, "viewer_count_state" => :minimize}
+        )
+
+      assert view |> element("button") |> render_click() =~ "Viewers"
+    end
+
+    test "is hidden if preference set", %{conn: conn, channel: channel} do
+      {:ok, view, _} =
+        live_isolated(conn, @component,
+          session: %{"channel_id" => channel.id, "viewer_count_state" => :hidden}
+        )
+
+      refute render(view) =~ "Viewers"
     end
   end
 end


### PR DESCRIPTION
# Viewer Count Toggle
Based on a suggestion on [Building Glimesh](https://build.glimesh.tv/t/viewer-count-toggle/535).
Streamers would like the ability to hide the viewer count on their channel page.  I've increased the scope of this suggestion to also allow viewers to choose whether the viewer count (when visible) is expanded or minimized.

# New Settings
## Channel Settings
The channel owner can choose whether they want the viewer count to appear on their channel.  By default, the viewer count is on.

![channel-settings](https://user-images.githubusercontent.com/5142625/201501478-66d49f7e-ca17-4235-89f9-7c187e6f1351.png)

## Preferences page
Viewers can choose if they want the viewer count on all channels to display expanded (default) or be minimized.  Regardless of the setting users can still click the viewer count button to toggle it from expanded to minimized or vice versa.  Viewers cannot make the viewer count visible on channels that have hidden the count.

![preferences](https://user-images.githubusercontent.com/5142625/201502503-bfd4dd09-fb61-482e-bf66-c2a0a1646a6d.png)

# Affects of the various settings
| Channel Owner Setting | Viewer Setting | Channel Page Result
|----------|----------|-----------|
| Show Viewer Count | Expand Viewer Count | ![visible-maximized](https://user-images.githubusercontent.com/5142625/201502605-217f2d79-14a1-4906-943e-9b829bcc74cd.png)
| Show Viewer Count | Minimize Viewer Count | ![visible-minimized](https://user-images.githubusercontent.com/5142625/201502617-051edf7f-5b69-4623-8e7c-a0d2ed951ea6.png)
| Hide Viewer Count | Any Setting | ![hidden-not-followed](https://user-images.githubusercontent.com/5142625/201502659-1239669f-ed73-4150-b0d0-045daa7c0564.png) ![hidden-followed](https://user-images.githubusercontent.com/5142625/201502665-b8a34def-ae1d-4038-906e-c203102ceb76.png)

## Default settings
| Channel Owner Setting | Viewer Setting
|------|-----|
| Show Viewer Count (On) | Expand Viewer Count (On)

# Database Changes
- Added boolean column "show_viewer_count" to table "channels" with default true.
- Added boolean column "maximize_viewer_count" to table "user_preferences" with default true.