### PR TITLE
Fix typos

### DIFF
--- a/assets/js/hooks/FtlVideo.js
+++ b/assets/js/hooks/FtlVideo.js
@@ -13,7 +13,7 @@ export default {
         let saveVolumeChanges = false;
         let currentlyInUltrawide = false;
 
-        // Handle 21:9 aspect ratio monitors/browers
+        // Handle 21:9 aspect ratio monitors/browsers
         let containerParent = container.parentElement;
         // Get browser aspect ratio
         let size = {

--- a/lib/glimesh/api/schema/channel_types.ex
+++ b/lib/glimesh/api/schema/channel_types.ex
@@ -231,7 +231,7 @@ defmodule Glimesh.Api.ChannelTypes do
     field :id, :id, description: "Unique channel identifier"
 
     field :title, :string, description: "The title of the current stream, live or offline."
-    field :status, :channel_status, description: "The current status of the channnel"
+    field :status, :channel_status, description: "The current status of the channel"
 
     field :category, :category,
       resolve: dataloader(Repo),

--- a/lib/glimesh/apps/app.ex
+++ b/lib/glimesh/apps/app.ex
@@ -86,7 +86,7 @@ defmodule Glimesh.Apps.App do
 
       _ ->
         {:error,
-         "If using unsecure http, you must be using a local loopback address like [localhost, 127.0.0.1, ::1]"}
+         "If using insecure http, you must be using a local loopback address like [localhost, 127.0.0.1, ::1]"}
     end
   end
 end

--- a/lib/glimesh/channel_categories.ex
+++ b/lib/glimesh/channel_categories.ex
@@ -449,7 +449,7 @@ defmodule Glimesh.ChannelCategories do
   end
 
   @doc """
-  Creates or updates a subcategory based on source+source_id existance
+  Creates or updates a subcategory based on source+source_id existence
   """
   def upsert_subcategory_from_source(source, source_id, attrs) do
     if subcategory = subcategory_source_exists?(source, source_id) do

--- a/lib/glimesh/chat.ex
+++ b/lib/glimesh/chat.ex
@@ -332,7 +332,7 @@ defmodule Glimesh.Chat do
     message = if attrs["message"], do: attrs["message"], else: attrs.message
 
     # Dumb fast check to see if there's something that smells like a link
-    # If the channel has links disabled it still wont do anything
+    # If the channel has links disabled it still won't do anything
     if is_bitstring(message) and String.contains?(message, "http") and
          String.contains?(message, "://") do
       !channel.block_links

--- a/lib/glimesh/emotes/emote.ex
+++ b/lib/glimesh/emotes/emote.ex
@@ -54,7 +54,7 @@ defmodule Glimesh.Emotes.Emote do
     |> prefix_emote(channel.emote_prefix)
     |> validate_length(:emote, min: 2, max: 15)
     |> validate_format(:emote, ~r/^[a-zA-Z0-9]+$/i,
-      message: "Emote must be only contain alpha-numeric characters"
+      message: "Emote must be only contain alphanumeric characters"
     )
     |> validate_channel_max_emotes(channel)
     |> validate_channel_allow_animated()

--- a/lib/glimesh/homepage.ex
+++ b/lib/glimesh/homepage.ex
@@ -59,7 +59,7 @@ defmodule Glimesh.Homepage do
         :first_run
 
       NaiveDateTime.compare(now, slot_max_time) == :gt ->
-        # If somehow we missed the 15 minute windo
+        # If somehow we missed the 15 minute window
         push_new_homepage_batch(now)
         :late
 

--- a/lib/glimesh/old_graphql/schema/channel_types.ex
+++ b/lib/glimesh/old_graphql/schema/channel_types.ex
@@ -188,7 +188,7 @@ defmodule Glimesh.OldSchema.ChannelTypes do
   object :channel do
     field :id, :id, description: "Unique channel identifier"
 
-    field :status, :channel_status, description: "The current status of the channnel"
+    field :status, :channel_status, description: "The current status of the channel"
     field :title, :string, description: "The title of the current stream, live or offline."
 
     field :category, :category,

--- a/lib/glimesh/payment_providers/stripe/transfers.ex
+++ b/lib/glimesh/payment_providers/stripe/transfers.ex
@@ -2,7 +2,7 @@ defmodule Glimesh.PaymentProviders.StripeProvider.Transfers do
   @moduledoc """
   Stripe Transfers Logic
 
-  This module is responsible for packaging all of the viewer-paid, but streamer-unpaidout payables, and transfering them to the Streamer's connected account.
+  This module is responsible for packaging all of the viewer-paid, but streamer-unpaidout payables, and transferring them to the Streamer's connected account.
 
   Includes:
    * Subscriptions

--- a/lib/glimesh/streams/channel.ex
+++ b/lib/glimesh/streams/channel.ex
@@ -124,7 +124,7 @@ defmodule Glimesh.Streams.Channel do
     |> cast(attrs, [:emote_prefix])
     |> validate_required(:emote_prefix)
     |> validate_format(:emote_prefix, ~r/^[a-zA-Z0-9]+$/i,
-      message: "Emote prefix must be only alpha-numeric characters"
+      message: "Emote prefix must be only alphanumeric characters"
     )
     |> validate_length(:emote_prefix, is: 5)
     |> validate_no_active_emotes()

--- a/lib/glimesh_web/templates/about/dmca.html.eex
+++ b/lib/glimesh_web/templates/about/dmca.html.eex
@@ -195,7 +195,7 @@
                             <%= gettext("Glimesh aims to be as fair as possible. While we cannot condone improper use of copyright material we know that not all DMCA claims are fair. We will be open to help in whatever ways possible to ensure you have the best opportunity to correct DMCA claims. While we are not lawyers and cannot offer legal advice we will do our best to help you get in the right direction for correcting any claims in a fair manner.") %>
                         </li>
                         <li>
-                            <%= gettext("Lastly Glimesh is working to partner with music providers or independant artists who will provide proper music licenses for you to use.") %>
+                            <%= gettext("Lastly Glimesh is working to partner with music providers or independent artists who will provide proper music licenses for you to use.") %>
                         </li>
                     </ul>
 

--- a/lib/glimesh_web/templates/email/channel_live.html.eex
+++ b/lib/glimesh_web/templates/email/channel_live.html.eex
@@ -39,7 +39,7 @@
                             <tr>
                                 <td class="text pb20"
                                     style="color:#ffffff; font-family:Arial,sans-serif; font-size:14px; line-height:26px; text-align:left; padding-top:20px; padding-bottom:20px;">
-                                    You are recieving this email because you have chosen to receive email notifications
+                                    You are receiving this email because you have chosen to receive email notifications
                                     when <%= @streamer_name %> goes live. To unsubscribe go to your <a
                                         href="<%= @unsubscribe_link %>">notification preferences</a> page.
 

--- a/lib/glimesh_web/templates/email/channel_live.text.eex
+++ b/lib/glimesh_web/templates/email/channel_live.text.eex
@@ -4,5 +4,5 @@
 
 Watch The Stream at <%= @stream_link %>
 
-You are recieving this email because you have chosen to receive email notifications
+You are receiving this email because you have chosen to receive email notifications
 when <%= @streamer_name %> goes live. To unsubscribe go to <%= @unsubscribe_link %>

--- a/lib/glimesh_web/templates/email/sub_button.html.eex
+++ b/lib/glimesh_web/templates/email/sub_button.html.eex
@@ -11,7 +11,7 @@
                             </tr>
                             <tr>
                                 <td class="text-center pb25" style="color:#ebedf2; font-family:'Roboto', Arial,sans-serif; font-size:16px; line-height:30px; text-align:center; padding-bottom:25px;">
-                                    Hi <%= @user.displayname %>! We're happy to let you know we have processed all of your infomation, and your subscribe & donate buttons are now live on Glimesh. If you have any questions please reach out to us at <a href="mailto:support@glimesh.tv">support@glimesh.tv</a>.</td>
+                                    Hi <%= @user.displayname %>! We're happy to let you know we have processed all of your information, and your subscribe & donate buttons are now live on Glimesh. If you have any questions please reach out to us at <a href="mailto:support@glimesh.tv">support@glimesh.tv</a>.</td>
                             </tr>
                             <!-- Button -->
                             <tr>

--- a/lib/glimesh_web/templates/email/sub_button.text.eex
+++ b/lib/glimesh_web/templates/email/sub_button.text.eex
@@ -1,6 +1,6 @@
 Congratulations! 
 Your Sub Button is LIVE!
 
-Hi <%= @user.displayname %>! We're happy to let you know we have processed all of your infomation, and your Sub Button is now live on Glimesh. If you have any questions please reach out to us at support@glimesh.tv.
+Hi <%= @user.displayname %>! We're happy to let you know we have processed all of your information, and your Sub Button is now live on Glimesh. If you have any questions please reach out to us at support@glimesh.tv.
 
 You can check it out at: <%= @url %>

--- a/lib/glimesh_web/templates/oauth/error.html.eex
+++ b/lib/glimesh_web/templates/oauth/error.html.eex
@@ -1,4 +1,4 @@
 <div class="container text-center">
-  <h1><%= @error %> - An error occured while authorizing request, check client OAuth configuration</h1>
+  <h1><%= @error %> - An error occurred while authorizing request, check client OAuth configuration</h1>
   <p><%= @error_description %></p>
 </div>

--- a/lib/glimesh_web/uploaders/static_emote.ex
+++ b/lib/glimesh_web/uploaders/static_emote.ex
@@ -9,7 +9,7 @@ defmodule Glimesh.Uploaders.StaticEmote do
   Image Tags - not vulnerable - The SVG is referenced through image tags which prevent scripts.
   Image Tags With CSP - not vulnerable - Image tags and the same CSP as above for double protection.
 
-  Since we cannot manually set CSP headers with most CDNs, we're utilizing both sanitizing the image with svgo, serving it through an img tag so js cannot run, and setting the content-disposition to attachment so the browser wont automatically run it.
+  Since we cannot manually set CSP headers with most CDNs, we're utilizing both sanitizing the image with svgo, serving it through an img tag so js cannot run, and setting the content-disposition to attachment so the browser won't automatically run it.
   """
 
   use Waffle.Definition

--- a/test/glimesh/apps_test.exs
+++ b/test/glimesh/apps_test.exs
@@ -150,7 +150,7 @@ defmodule Glimesh.AppsTest do
                })
 
       assert changeset.changes[:client].errors[:redirect_uris] ==
-               {"If using unsecure http, you must be using a local loopback address like [localhost, 127.0.0.1, ::1]",
+               {"If using insecure http, you must be using a local loopback address like [localhost, 127.0.0.1, ::1]",
                 []}
     end
 
@@ -201,7 +201,7 @@ defmodule Glimesh.AppsTest do
       {"http://localhost:8080/", {:ok, "localhost"}},
       {"http://example.com/",
        {:error,
-        "If using unsecure http, you must be using a local loopback address like [localhost, 127.0.0.1, ::1]"}},
+        "If using insecure http, you must be using a local loopback address like [localhost, 127.0.0.1, ::1]"}},
       {"https://example.com/", {:ok, "example.com"}}
     ]
 

--- a/test/glimesh/emotes_test.exs
+++ b/test/glimesh/emotes_test.exs
@@ -74,7 +74,7 @@ defmodule Glimesh.EmotesTest do
       assert emote.emote == "testgsomeemote"
     end
 
-    test "create_channel_emote/3 doesnt work if you dont have a prefix", %{} do
+    test "create_channel_emote/3 doesn't work if you dont have a prefix", %{} do
       streamer = streamer_fixture()
 
       assert {:error, changeset_error} =
@@ -213,7 +213,7 @@ defmodule Glimesh.EmotesTest do
 
       assert changeset_error.errors == [
                emote:
-                 {"Emote must be only contain alpha-numeric characters", [validation: :format]}
+                 {"Emote must be only contain alphanumeric characters", [validation: :format]}
              ]
     end
   end

--- a/test/glimesh/payment_providers/stripe_test.exs
+++ b/test/glimesh/payment_providers/stripe_test.exs
@@ -102,7 +102,7 @@ defmodule Glimesh.PaymentProviders.StripeProviderTest do
     end
   end
 
-  describe "Witholding Payouts 30%" do
+  describe "Withholding Payouts 30%" do
     setup do
       {:ok, streamer} =
         Glimesh.Accounts.set_stripe_attrs(streamer_fixture(), %{
@@ -140,7 +140,7 @@ defmodule Glimesh.PaymentProviders.StripeProviderTest do
     end
   end
 
-  describe "Witholding Payouts 5%" do
+  describe "Withholding Payouts 5%" do
     setup do
       {:ok, streamer} =
         Glimesh.Accounts.set_stripe_attrs(streamer_fixture(), %{
@@ -235,7 +235,7 @@ defmodule Glimesh.PaymentProviders.StripeProviderTest do
       assert url == new_url
     end
 
-    test "start_connect/4 wont allow you to change country", %{streamer: streamer} do
+    test "start_connect/4 won't allow you to change country", %{streamer: streamer} do
       assert {:ok, _} =
                StripeProvider.start_connect(
                  streamer,

--- a/test/glimesh/socials_test.exs
+++ b/test/glimesh/socials_test.exs
@@ -44,7 +44,7 @@ defmodule Glimesh.SocialsTest do
       assert social.identifier == "1234"
     end
 
-    test "connect_user_social/4 doens't duplicate socials" do
+    test "connect_user_social/4 doesn't duplicate socials" do
       user = user_fixture()
 
       assert {:ok, %UserSocial{}} =

--- a/test/glimesh/streams/channel_notifier_test.exs
+++ b/test/glimesh/streams/channel_notifier_test.exs
@@ -46,7 +46,7 @@ defmodule Glimesh.Streams.ChannelNotifierTest do
       )
     end
 
-    test "deliver_live_channel_notifications/2 wont spam users for the same channel" do
+    test "deliver_live_channel_notifications/2 won't spam users for the same channel" do
       streamer = streamer_fixture()
       user = user_fixture()
       Glimesh.AccountFollows.follow(streamer, user, true)
@@ -70,7 +70,7 @@ defmodule Glimesh.Streams.ChannelNotifierTest do
       assert_no_emails_delivered()
     end
 
-    test "deliver_live_channel_notifications/2 wont send more than 5 emails to a user" do
+    test "deliver_live_channel_notifications/2 won't send more than 5 emails to a user" do
       user = user_fixture()
 
       Enum.map(1..5, fn _ ->

--- a/test/glimesh_web/live/user_live/stream_test.exs
+++ b/test/glimesh_web/live/user_live/stream_test.exs
@@ -110,11 +110,11 @@ defmodule GlimeshWeb.UserLive.StreamTest do
       }
     end
 
-    test "lost_packets doesnt crash", %{conn: conn, streamer: streamer} do
+    test "lost_packets doesn't crash", %{conn: conn, streamer: streamer} do
       {:ok, view, _} = live(conn, Routes.user_stream_path(conn, :index, streamer.username))
 
       params = %{
-        "uplink" => "doesnt matter",
+        "uplink" => "doesn't matter",
         "lostPackets" => 1
       }
 
@@ -129,7 +129,7 @@ defmodule GlimeshWeb.UserLive.StreamTest do
       {:ok, view, _} = live(conn, Routes.user_stream_path(conn, :index, streamer.username))
 
       params = %{
-        "uplink" => "doesnt matter",
+        "uplink" => "doesn't matter",
         "lostPackets" => nil
       }
 
@@ -144,7 +144,7 @@ defmodule GlimeshWeb.UserLive.StreamTest do
       {:ok, view, _} = live(conn, Routes.user_stream_path(conn, :index, streamer.username))
 
       params = %{
-        "uplink" => "doesnt matter",
+        "uplink" => "doesn't matter",
         "lostPackets" => <<123, 123, 123, 123, 123, 123>>
       }
 


### PR DESCRIPTION
Found via `codespell -S priv,deps,_build,*.svg -L nd,ro,nam,wth,ue,fof,cliente,beastiality,  extacy,masterbation,shat,toke`