### PR TITLE
Prompt streamers when they are eligible to be shown on the homepage

### DIFF
--- a/config/releases.exs
+++ b/config/releases.exs
@@ -256,7 +256,8 @@ config :glimesh, Oban,
        {"* * * * *", Glimesh.Jobs.StreamMetricsCron},
        {"*/10 * * * *", Glimesh.Jobs.AutoHostCron},
        {"*/5 * * * *", Glimesh.Jobs.HomepageCron},
-       {"*/5 * * * *", Glimesh.Jobs.StreamPrunerCron}
+       {"*/5 * * * *", Glimesh.Jobs.StreamPrunerCron},
+       {"*/30 * * * *", Glimesh.Jobs.PromptHomepageOptIn}
      ]}
   ]
 

--- a/lib/glimesh/jobs/prompt_homepage_opt_in.ex
+++ b/lib/glimesh/jobs/prompt_homepage_opt_in.ex
@@ -1,0 +1,35 @@
+defmodule Glimesh.Jobs.PromptHomepageOptIn do
+  @moduledoc false
+  use Oban.Worker
+
+  require Logger
+
+  alias Glimesh.ChannelLookups
+
+  @impl Oban.Worker
+  def perform(_) do
+    Logger.info("Starting Homepage Opt-in Prompt runner")
+    start = NaiveDateTime.utc_now()
+
+    {num_ignore_rows, _} = ChannelLookups.update_channels_opted_in_for_homepage()
+
+    Logger.info(
+      "Homepage Opt-in Prompt runner - Changed #{num_ignore_rows} of entries to ignore."
+    )
+
+    {num_prompt_rows, _} = ChannelLookups.update_prompt_channel_opt_in_for_homepage()
+
+    Logger.info(
+      "Homepage Opt-in Prompt runner - Changed #{num_prompt_rows} of entries to prompt."
+    )
+
+    complete = NaiveDateTime.utc_now()
+    time = NaiveDateTime.diff(complete, start, :millisecond)
+    Logger.info("Homepage Opt-in Prompt runner finished in #{time} ms")
+
+    :ok
+  rescue
+    e ->
+      {:error, e}
+  end
+end

--- a/lib/glimesh/streams/channel.ex
+++ b/lib/glimesh/streams/channel.ex
@@ -43,6 +43,10 @@ defmodule Glimesh.Streams.Channel do
     field :show_donate_button, :boolean, default: true
     field :show_streamloots_button, :boolean, default: true
 
+    field :prompt_for_homepage, Ecto.Enum,
+      values: [:ineligible, :prompt, :ignore],
+      default: :ineligible
+
     field :poster, Glimesh.ChannelPoster.Type
     field :chat_bg, Glimesh.ChatBackground.Type
 
@@ -105,7 +109,8 @@ defmodule Glimesh.Streams.Channel do
       :require_confirmed_email,
       :minimum_account_age,
       :allow_hosting,
-      :backend
+      :backend,
+      :prompt_for_homepage
     ])
     |> validate_length(:chat_rules_md, max: 8192)
     |> validate_length(:title, max: 250)

--- a/lib/glimesh/streams/policy.ex
+++ b/lib/glimesh/streams/policy.ex
@@ -21,6 +21,7 @@ defmodule Glimesh.Streams.Policy do
   # Admins
   def authorize(:update_channel, %User{is_admin: true}, _channel), do: true
   def authorize(:delete_channel, %User{is_admin: true}, _channel), do: true
+  def authorize(:dismiss_homepage_opt_in_notification, %User{is_admin: true}, _channel), do: true
 
   def authorize(:show_channel_moderator, %User{is_admin: true}, _channel), do: true
   def authorize(:create_channel_moderator, %User{is_admin: true}, _channel), do: true
@@ -33,6 +34,7 @@ defmodule Glimesh.Streams.Policy do
   # GCT
   def authorize(:update_channel, %User{is_gct: true}, _channel), do: true
   def authorize(:delete_channel, %User{is_gct: true}, _channel), do: true
+  def authorize(:dismiss_homepage_opt_in_notification, %User{is_gct: true}, _channel), do: true
 
   def authorize(:show_channel_moderator, %User{is_gct: true}, _channel), do: true
   def authorize(:create_channel_moderator, %User{is_gct: true}, _channel), do: true
@@ -54,6 +56,12 @@ defmodule Glimesh.Streams.Policy do
       do: true
 
   def authorize(:delete_channel, %User{id: user_id}, %Channel{user_id: channel_user_id})
+      when user_id == channel_user_id,
+      do: true
+
+  def authorize(:dismiss_homepage_opt_in_notification, %User{id: user_id}, %Channel{
+        user_id: channel_user_id
+      })
       when user_id == channel_user_id,
       do: true
 

--- a/lib/glimesh_web/live/user_live/stream.html.heex
+++ b/lib/glimesh_web/live/user_live/stream.html.heex
@@ -1,4 +1,30 @@
+<%= if @prompt_ready_for_homepage == true do %>
+  <!-- **** Prompt Streamer they are eligible for homepage **** -->
+  <div id="homepage-prompt-banner" class="col-12 mb-0 alert alert-info collapse show">
+    <div class="float-right">
+      <button class="btn btn-close" data-toggle="collapse" data-target="#homepage-prompt-banner">
+        &times;
+      </button>
+    </div>
+    <div class="row">
+      <div class="col-9 text-center">
+        <h5>
+          <%= gettext("You are now eligible to be randomly featured on the homepage!") %>
+        </h5>
+      </div>
+      <div class="col-3 text-center">
+        <a class="btn btn-primary mr-1" href={Routes.user_settings_path(@socket, :stream)}>
+          <%= gettext("Settings") %>
+        </a>
+        <a class="btn btn-danger" phx-click="dismiss_homepage_prompt">
+          <%= gettext("Dismiss") %>
+        </a>
+      </div>
+    </div>
+  </div>
+<% end %>
 <%= if @hosting_channel != nil and @hosting_channel.target.id == @channel.id do %>
+  <!-- **** Being Hosted Banner **** -->
   <div id="hosted-banner" class="container bg-secondary collapse show">
     <div class="float-right">
       <button class="btn btn-close" data-toggle="collapse" data-target="#hosted-banner">
@@ -53,6 +79,7 @@
 <% end %>
 
 <%= if @hosting_channel != nil and @hosting_channel.host.id == @channel.id do %>
+  <!-- **** Hosting Someone Banner **** -->
   <div id="hosting-banner" class="container bg-secondary collapse show">
     <div class="float-right">
       <button class="btn btn-close" data-toggle="collapse" data-target="#hosting-banner">

--- a/priv/repo/migrations/20221119042526_add_prompt_for_homepage_eligibility.exs
+++ b/priv/repo/migrations/20221119042526_add_prompt_for_homepage_eligibility.exs
@@ -1,0 +1,16 @@
+defmodule Glimesh.Repo.Migrations.AddPromptForHomepageEligibility do
+  use Ecto.Migration
+
+  def change do
+    create_prompt_homepage_type_enum =
+      "CREATE TYPE homepage_prompt_type AS ENUM('ineligible', 'prompt', 'ignore')"
+
+    drop_prompt_homepage_type_enum = "DROP TYPE homepage_prompt_type"
+
+    execute(create_prompt_homepage_type_enum, drop_prompt_homepage_type_enum)
+
+    alter table(:channels) do
+      add :prompt_for_homepage, :homepage_prompt_type, default: "ineligible"
+    end
+  end
+end

--- a/test/jobs/prompt_homepage_opt_in_test.exs
+++ b/test/jobs/prompt_homepage_opt_in_test.exs
@@ -1,0 +1,105 @@
+defmodule Glimesh.Jobs.PromptHomepageOptInTest do
+  use Glimesh.DataCase
+  use Bamboo.Test
+
+  import Glimesh.AccountsFixtures
+
+  alias Glimesh.Repo
+  alias Glimesh.Streams
+  alias Glimesh.Streams.Channel
+  alias Glimesh.Jobs.PromptHomepageOptIn
+
+  describe "Prompt user when they are homepage eligible job" do
+    test "Streamer does not have enough hours streamed" do
+      streamer = streamer_fixture()
+      PromptHomepageOptIn.perform([])
+      updated_channel = Repo.get(Channel, streamer.channel.id)
+      assert updated_channel.prompt_for_homepage == :ineligible
+    end
+
+    test "Streamer has enough hours streamed" do
+      streamer = streamer_fixture()
+      create_ten_hours_of_streams(streamer.channel)
+
+      PromptHomepageOptIn.perform([])
+      updated_channel = Repo.get(Channel, streamer.channel.id)
+      assert updated_channel.prompt_for_homepage == :prompt
+    end
+
+    test "Streamer has enough hours streamed and is already opted-in" do
+      streamer = streamer_fixture(%{}, %{show_on_homepage: true})
+      create_ten_hours_of_streams(streamer.channel)
+
+      PromptHomepageOptIn.perform([])
+      updated_channel = Repo.get(Channel, streamer.channel.id)
+      assert updated_channel.prompt_for_homepage == :ignore
+    end
+
+    test "Streamer is already set to be prompted" do
+      streamer = streamer_fixture(%{}, %{show_on_homepage: false, prompt_for_homepage: :prompt})
+      create_ten_hours_of_streams(streamer.channel)
+
+      PromptHomepageOptIn.perform([])
+      updated_channel = Repo.get(Channel, streamer.channel.id)
+      assert updated_channel.prompt_for_homepage == :prompt
+    end
+
+    test "Streamer has acknowledged prompt and should not be prompted again" do
+      streamer = streamer_fixture(%{}, %{show_on_homepage: false, prompt_for_homepage: :ignore})
+      create_ten_hours_of_streams(streamer.channel)
+
+      PromptHomepageOptIn.perform([])
+      updated_channel = Repo.get(Channel, streamer.channel.id)
+      assert updated_channel.prompt_for_homepage == :ignore
+    end
+
+    test "Streamer has deactivated channel and should be skipped" do
+      streamer_one =
+        streamer_fixture(%{}, %{
+          inaccessible: true,
+          show_on_homepage: false,
+          prompt_for_homepage: :prompt
+        })
+
+      streamer_two =
+        streamer_fixture(%{}, %{
+          inaccessible: true,
+          show_on_homepage: false,
+          prompt_for_homepage: :ineligible
+        })
+
+      streamer_three =
+        streamer_fixture(%{}, %{
+          inaccessible: true,
+          show_on_homepage: false,
+          prompt_for_homepage: :ignore
+        })
+
+      create_ten_hours_of_streams(streamer_one.channel)
+      create_ten_hours_of_streams(streamer_two.channel)
+      create_ten_hours_of_streams(streamer_three.channel)
+
+      PromptHomepageOptIn.perform([])
+      updated_channel_one = Repo.get(Channel, streamer_one.channel.id)
+      updated_channel_two = Repo.get(Channel, streamer_two.channel.id)
+      updated_channel_three = Repo.get(Channel, streamer_three.channel.id)
+
+      assert updated_channel_one.prompt_for_homepage == :prompt
+      assert updated_channel_two.prompt_for_homepage == :ineligible
+      assert updated_channel_three.prompt_for_homepage == :ignore
+    end
+  end
+
+  defp create_ten_hours_of_streams(channel) do
+    Streams.create_stream(channel, %{
+      started_at:
+        NaiveDateTime.add(NaiveDateTime.utc_now(), 60 * 60 * -10)
+        |> NaiveDateTime.truncate(:second),
+      ended_at: NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
+    })
+
+    Ecto.Changeset.change(channel)
+    |> Ecto.Changeset.force_change(:status, "offline")
+    |> Repo.update()
+  end
+end


### PR DESCRIPTION
# Description
We provide streamers with the option of potentially being featured on the homepage after they have streamed at least ten hours on the platform.  It has been suggested on the building Glimesh forum that we remind streamers when they are eligible for homepage placement as it appears many new streamers may have missed that setting on the stream settings page.  To that end, I will display the following banner to the channel owner only on their channel page:

![image](https://user-images.githubusercontent.com/5142625/202962690-244138c3-b63e-48c6-8962-0dc9f9ad8538.png)

The above banner will only display if the following conditions are met:
- The person viewing the channel page is the channel owner
- The channel owner has streamed at least 10 hours
- The channel owner has not already opted in to being displayed on the homepage
- The channel owner has not clicked the "Dismiss" button on the banner

## Notification banner buttons
The notification banner has a "Go to Settings" and a "Dismiss" button.  The "Go to Settings" button will redirect the owner to the stream settings page which contains the homepage opt-in button at the bottom.  The "Dismiss" button will set a flag on the channel to dismiss the notification and never prompt about it again.

# Technical Details
## New background job
I've created a new background Oban job called "prompt_homepage_opt_in" that is set to run every 30 minutes and will accomplish the following tasks:
- Find all channels that are accessible (inaccessible = false) and are opted in to be displayed on the homepage (show_on_homepage = true) then set "prompt_for_homepage" to "ignore" so those channel owners will not be prompted as they are already opted in.
- Find all channels that are accessible (inaccessible = false), are NOT opted in to be displayed on the homepage (show_on_homepage = false), and have at least 10 hours of streaming time then set "prompt_for_homepage" to "prompt".  The owners of those channels will see the notification banner the next time they go to their channel page.

## New column and enumeration
I've added the column "prompt_for_homepage" that defaults to "ineligible" to the channels table.  It refers to a defined database enumeration called "homepage_prompt_type" which can take on one of the following values: "ineligible", "prompt", or "ignore".  The column is only set to "prompt" by the background job.  The UI will only update the column to "ignore".
