### PR TITLE
Fix for stream title/tags edit button not showing for GCT and Admin roles

### DIFF
--- a/lib/glimesh/streams/policy.ex
+++ b/lib/glimesh/streams/policy.ex
@@ -26,6 +26,7 @@ defmodule Glimesh.Streams.Policy do
   def authorize(:create_channel_moderator, %User{is_admin: true}, _channel), do: true
   def authorize(:update_channel_moderator, %User{is_admin: true}, _channel), do: true
   def authorize(:delete_channel_moderator, %User{is_admin: true}, _channel), do: true
+  def authorize(:edit_channel_title_and_tags, %User{is_admin: true}, _channel), do: true
 
   def authorize(:delete_hosting_target, %User{is_admin: true}, _channel), do: true
 
@@ -37,6 +38,7 @@ defmodule Glimesh.Streams.Policy do
   def authorize(:create_channel_moderator, %User{is_gct: true}, _channel), do: true
   def authorize(:update_channel_moderator, %User{is_gct: true}, _channel), do: true
   def authorize(:delete_channel_moderator, %User{is_gct: true}, _channel), do: true
+  def authorize(:edit_channel_title_and_tags, %User{is_gct: true}, _channel), do: true
 
   # Editors
   def authorize(:edit_channel_title_and_tags, %User{id: user_id}, [

--- a/test/glimesh_web/live/user_live/stream_test.exs
+++ b/test/glimesh_web/live/user_live/stream_test.exs
@@ -341,5 +341,25 @@ defmodule GlimeshWeb.UserLive.StreamTest do
 
       refute html =~ "stream-title-edit"
     end
+
+    test "is available to the GCT members", %{conn: conn, streamer: streamer} do
+      gct_user = gct_fixture()
+      gct_conn = log_in_user(conn, gct_user)
+
+      {:ok, _, html} =
+        live(gct_conn, Routes.user_stream_path(gct_conn, :index, streamer.username))
+
+      assert html =~ "stream-title-edit"
+    end
+
+    test "is available to the admin members", %{conn: conn, streamer: streamer} do
+      admin_user = admin_fixture()
+      admin_conn = log_in_user(conn, admin_user)
+
+      {:ok, _, html} =
+        live(admin_conn, Routes.user_stream_path(admin_conn, :index, streamer.username))
+
+      assert html =~ "stream-title-edit"
+    end
   end
 end


### PR DESCRIPTION
Fixes #887 
GCT and Admin roles should now be able to use the channel edit button again -- the new editor role changes had introduced a new Bodyguard role and I neglected to add the GCT and Admin roles to that new role.