### PR TITLE
Highlight new streamers with a badge and filter option

### DIFF
--- a/config/releases.exs
+++ b/config/releases.exs
@@ -256,7 +256,8 @@ config :glimesh, Oban,
        {"* * * * *", Glimesh.Jobs.StreamMetricsCron},
        {"*/10 * * * *", Glimesh.Jobs.AutoHostCron},
        {"*/5 * * * *", Glimesh.Jobs.HomepageCron},
-       {"*/5 * * * *", Glimesh.Jobs.StreamPrunerCron}
+       {"*/5 * * * *", Glimesh.Jobs.StreamPrunerCron},
+       {"*/60 * * * *", Glimesh.Jobs.IsNewStreamerFlagger}
      ]}
   ]
 

--- a/lib/glimesh/jobs/is_new_streamer_flagger.ex
+++ b/lib/glimesh/jobs/is_new_streamer_flagger.ex
@@ -1,0 +1,34 @@
+defmodule Glimesh.Jobs.IsNewStreamerFlagger do
+  @moduledoc false
+  use Oban.Worker
+
+  require Logger
+
+  alias Glimesh.ChannelLookups
+
+  @impl Oban.Worker
+  def perform(_) do
+    Logger.info("Starting New Streamer Flagger runner")
+    start = NaiveDateTime.utc_now()
+
+    {rows, _} = ChannelLookups.clear_new_channel_flags()
+    Logger.info("New Streamer Flagger cleared #{rows} flags to false")
+
+    {setrows, _} = ChannelLookups.set_new_channel_flags()
+    Logger.info("New Streamer Flagger set #{setrows} flags to true")
+
+    {clearrows, _} =
+      ChannelLookups.clear_new_channel_flags_for_channels_with_fifty_hours_or_more()
+
+    Logger.info("New Streamer Flagger cleared #{clearrows} flags on 50 hour or greater channels")
+
+    complete = NaiveDateTime.utc_now()
+    time = NaiveDateTime.diff(complete, start, :millisecond)
+    Logger.info("New Streamer Flagger runner finished in #{time} ms")
+
+    :ok
+  rescue
+    e ->
+      {:error, e}
+  end
+end

--- a/lib/glimesh/streams/channel.ex
+++ b/lib/glimesh/streams/channel.ex
@@ -46,6 +46,8 @@ defmodule Glimesh.Streams.Channel do
     field :poster, Glimesh.ChannelPoster.Type
     field :chat_bg, Glimesh.ChatBackground.Type
 
+    field :is_new_streamer, :boolean, default: false
+
     # This is used when searching for live channels that are live or hosted
     field :match_type, :string, virtual: true
 
@@ -105,7 +107,8 @@ defmodule Glimesh.Streams.Channel do
       :require_confirmed_email,
       :minimum_account_age,
       :allow_hosting,
-      :backend
+      :backend,
+      :is_new_streamer
     ])
     |> validate_length(:chat_rules_md, max: 8192)
     |> validate_length(:title, max: 250)
@@ -293,5 +296,10 @@ defmodule Glimesh.Streams.Channel do
     |> maybe_put_tags(:tags, attrs)
     |> maybe_put_subcategory(:subcategory, attrs)
     |> unique_constraint([:user_id])
+  end
+
+  def update_is_new_streamer_changeset(channel, attrs \\ %{}) do
+    channel
+    |> cast(attrs, [:is_new_streamer])
   end
 end

--- a/lib/glimesh_web/live/homepage_live.ex
+++ b/lib/glimesh_web/live/homepage_live.ex
@@ -57,6 +57,11 @@ defmodule GlimeshWeb.HomepageLive do
                         {#if @random_channel.mature_content}
                           <span class="badge badge-warning ml-1">{gettext("Mature")}</span>
                         {/if}
+                        {#if @random_channel.is_new_streamer}
+                          <span class="badge badge-danger ml-1 new-streamer-badge">
+                            {gettext("New")}
+                          </span>
+                        {/if}
                       </p>
                     </div>
                     <LivePatch

--- a/lib/glimesh_web/live/streams_live/following.html.heex
+++ b/lib/glimesh_web/live/streams_live/following.html.heex
@@ -69,6 +69,11 @@
                     <%= if channel.mature_content do %>
                       <span class="badge badge-warning"><%= gettext("Mature") %></span>
                     <% end %>
+                    <%= if channel.is_new_streamer do %>
+                      <span class="badge badge-danger ml-1 new-streamer-badge">
+                        <%= gettext("New") %>
+                      </span>
+                    <% end %>
                   </p>
                 </div>
               </div>

--- a/lib/glimesh_web/live/streams_live/list.ex
+++ b/lib/glimesh_web/live/streams_live/list.ex
@@ -94,9 +94,9 @@ defmodule GlimeshWeb.StreamsLive.List do
 
     prefilled_language = Map.get(params, "language", "Any Language")
 
-    has_filters =
-      Map.has_key?(params, "subcategory") or Map.has_key?(params, "tags") or
-        Map.has_key?(params, "language")
+    prefilled_new_streamers_filter = Map.get(params, "is_new_streamer", false)
+
+    has_filters = has_filters?(params)
 
     {:noreply,
      socket
@@ -105,9 +105,15 @@ defmodule GlimeshWeb.StreamsLive.List do
      |> assign(:prefilled_tags, prefilled_tags)
      |> assign(:prefilled_subcategory, prefilled_subcategory)
      |> assign(:prefilled_language, prefilled_language)
+     |> assign(:prefilled_new_streamers, prefilled_new_streamers_filter)
      |> assign(:shown_channels, shown_channels)
      |> assign(:total_channels, total_channels)
      |> assign(:channels, channels)}
+  end
+
+  defp has_filters?(params) do
+    Map.has_key?(params, "subcategory") or Map.has_key?(params, "tags") or
+      Map.has_key?(params, "language") or Map.has_key?(params, "is_new_streamer")
   end
 
   @impl true
@@ -122,6 +128,7 @@ defmodule GlimeshWeb.StreamsLive.List do
       |> append_json_param(:tags, Map.get(form_data, "tag_search"))
       |> append_json_param(:subcategory, Map.get(form_data, "subcategory_search"))
       |> append_param(:language, Map.get(form_data, "language"))
+      |> append_param(:is_new_streamer, Map.get(form_data, "is_new_streamer"))
 
     {:noreply,
      socket

--- a/lib/glimesh_web/live/streams_live/list.html.heex
+++ b/lib/glimesh_web/live/streams_live/list.html.heex
@@ -50,6 +50,15 @@
             placeholder: gettext("Search for a stream by tags")
           ) %>
         </div>
+        <div class="custom-control custom-switch">
+          <%= checkbox(:form, :is_new_streamer,
+            value: @prefilled_new_streamers,
+            class: "custom-control-input"
+          ) %>
+          <%= label(:form, :is_new_streamer, gettext("Show new streamers only"),
+            class: "custom-control-label"
+          ) %>
+        </div>
       </div>
       <div class="col-md-6 col-lg-3 mb-2">
         <label for="validationCustom02"><%= gettext("Language") %></label>
@@ -146,6 +155,11 @@
                             <%= if channel.mature_content do %>
                               <span class="badge badge-warning ml-1">
                                 <%= gettext("Mature") %>
+                              </span>
+                            <% end %>
+                            <%= if channel.is_new_streamer do %>
+                              <span class="badge badge-danger ml-1 new-streamer-badge">
+                                <%= gettext("New") %>
                               </span>
                             <% end %>
                           </p>

--- a/priv/repo/migrations/20221126045630_add_new_streamer_flag_to_channels.exs
+++ b/priv/repo/migrations/20221126045630_add_new_streamer_flag_to_channels.exs
@@ -1,0 +1,9 @@
+defmodule Glimesh.Repo.Migrations.AddNewStreamerFlagToChannels do
+  use Ecto.Migration
+
+  def change do
+    alter table(:channels) do
+      add :is_new_streamer, :boolean, default: false
+    end
+  end
+end

--- a/test/glimesh_web/live/homepage_live_test.exs
+++ b/test/glimesh_web/live/homepage_live_test.exs
@@ -15,7 +15,7 @@ defmodule GlimeshWeb.HomepageLiveTest do
     test "general text", %{conn: conn} do
       user_fixture()
 
-      {:ok, _, html} = live(conn, Routes.homepage_path(conn, :index))
+      {:ok, _, _html} = live(conn, Routes.homepage_path(conn, :index))
 
       # Commented out for now
       # assert html =~ "Join 1 others!"
@@ -46,6 +46,20 @@ defmodule GlimeshWeb.HomepageLiveTest do
 
       {:ok, _, html} = live(conn, Routes.homepage_path(conn, :index))
       assert html =~ hd(streams).title
+    end
+
+    test "shows streams section with new streamer badges", %{conn: conn} do
+      streams =
+        Enum.map(1..6, fn _ ->
+          {:ok, stream} = create_viable_mock_stream(nil, %{is_new_streamer: true})
+          stream
+        end)
+
+      assert Glimesh.Homepage.update_homepage() == :first_run
+
+      {:ok, _, html} = live(conn, Routes.homepage_path(conn, :index))
+      assert html =~ hd(streams).title
+      assert html =~ "new-streamer-badge"
     end
   end
 end

--- a/test/glimesh_web/streams_live/following_test.exs
+++ b/test/glimesh_web/streams_live/following_test.exs
@@ -43,6 +43,24 @@ defmodule GlimeshWeb.StreamsLive.FollowingTest do
       assert html =~ channel.title
     end
 
+    test "shows new streamer badge on followed streams", %{
+      conn: conn,
+      user: user
+    } do
+      streamer = streamer_fixture(%{}, %{is_new_streamer: true})
+      channel = streamer.channel
+      Glimesh.Streams.start_stream(channel)
+
+      Glimesh.AccountFollows.follow(streamer, user)
+
+      {:ok, _, html} = live(conn, Routes.streams_list_path(conn, :index, "following"))
+
+      assert html =~ "Followed Streams"
+      assert html =~ streamer.displayname
+      assert html =~ channel.title
+      assert html =~ "new-streamer-badge"
+    end
+
     test "lists users that are offline", %{
       conn: conn,
       user: user

--- a/test/glimesh_web/streams_live/list_test.exs
+++ b/test/glimesh_web/streams_live/list_test.exs
@@ -48,6 +48,28 @@ defmodule GlimeshWeb.StreamsLive.ListTest do
       assert html =~ channel.title
     end
 
+    test "lists some streams and shows new streamer badge", %{
+      conn: conn,
+      channel: channel,
+      streamer: streamer,
+      category: category
+    } do
+      random_stream =
+        streamer_fixture(%{}, %{
+          category_id: category.id,
+          is_new_streamer: true
+        })
+
+      Glimesh.Streams.start_stream(random_stream.channel)
+
+      {:ok, _, html} = live(conn, Routes.streams_list_path(conn, :index, category.slug))
+
+      assert html =~ "#{category.name} Streams"
+      assert html =~ streamer.displayname
+      assert html =~ channel.title
+      assert html =~ "new-streamer-badge"
+    end
+
     test "can filter streams by tags", %{
       conn: conn,
       category: category,
@@ -117,6 +139,42 @@ defmodule GlimeshWeb.StreamsLive.ListTest do
       assert html =~ "Showing 1 of 2 Live Channels"
       assert html =~ subcategory.name
       assert html =~ channel.title
+    end
+
+    test "can filter streams by new streamers", %{
+      conn: conn,
+      category: category,
+      subcategory: subcategory,
+      channel: channel
+    } do
+      random_stream =
+        streamer_fixture(%{}, %{
+          category_id: category.id,
+          is_new_streamer: true
+        })
+
+      Glimesh.Streams.start_stream(random_stream.channel)
+
+      {:ok, view, html} = live(conn, Routes.streams_list_path(conn, :index, category.slug))
+
+      assert html =~ "Showing 2 of 2 Live Channels"
+      assert html =~ "new-streamer-badge"
+
+      html =
+        render_change(view, "filter_change", %{
+          "form" => %{
+            "tag_search" => "",
+            "language" => "",
+            "subcategory_search" => "",
+            "is_new_streamer" => "true"
+          }
+        })
+
+      assert html =~ "#{category.name} Streams"
+      assert html =~ "Showing 1 of 2 Live Channels"
+      assert html =~ subcategory.name
+      assert html =~ channel.title
+      assert html =~ "new-streamer-badge"
     end
 
     test "can show more streams if necessary", %{

--- a/test/jobs/is_new_streamer_flagger_test.exs
+++ b/test/jobs/is_new_streamer_flagger_test.exs
@@ -1,0 +1,128 @@
+defmodule Glimesh.Jobs.IsNewStreamerFlaggerTest do
+  use Glimesh.DataCase
+  use Bamboo.Test
+
+  import Glimesh.AccountsFixtures
+
+  alias Glimesh.Streams
+  alias Glimesh.Streams.{Channel}
+  alias Glimesh.Jobs.IsNewStreamerFlagger
+
+  describe "New Streamer Flagger Job tests" do
+    test "Will flag streamers under seven days old" do
+      streamer = streamer_fixture()
+      create_eight_hour_stream(streamer.channel, -6)
+
+      assert :ok == IsNewStreamerFlagger.perform([])
+      updated_channel = Glimesh.Repo.get(Channel, streamer.channel.id)
+      assert updated_channel.is_new_streamer == true
+    end
+
+    test "Will flag streamers over seven days old with less than five streams" do
+      streamer = streamer_fixture()
+      create_eight_hour_stream(streamer.channel, -9)
+      create_eight_hour_stream(streamer.channel, -8)
+
+      assert :ok == IsNewStreamerFlagger.perform([])
+      updated_channel = Glimesh.Repo.get(Channel, streamer.channel.id)
+      assert updated_channel.is_new_streamer == true
+    end
+
+    test "Will NOT flag streamers over seven days old with more than five streams" do
+      streamer = streamer_fixture()
+      create_eight_hour_stream(streamer.channel, -13)
+      create_eight_hour_stream(streamer.channel, -12)
+      create_eight_hour_stream(streamer.channel, -11)
+      create_eight_hour_stream(streamer.channel, -10)
+      create_eight_hour_stream(streamer.channel, -9)
+      create_eight_hour_stream(streamer.channel, -8)
+
+      assert :ok == IsNewStreamerFlagger.perform([])
+      updated_channel = Glimesh.Repo.get(Channel, streamer.channel.id)
+      assert updated_channel.is_new_streamer == false
+    end
+
+    test "Will clear flag when streamers no longer qualify" do
+      streamer = streamer_fixture(%{}, %{is_new_streamer: true})
+      create_eight_hour_stream(streamer.channel, -13)
+      create_eight_hour_stream(streamer.channel, -12)
+      create_eight_hour_stream(streamer.channel, -11)
+      create_eight_hour_stream(streamer.channel, -10)
+      create_eight_hour_stream(streamer.channel, -9)
+      create_eight_hour_stream(streamer.channel, -8)
+
+      assert :ok == IsNewStreamerFlagger.perform([])
+      updated_channel = Glimesh.Repo.get(Channel, streamer.channel.id)
+      assert updated_channel.is_new_streamer == false
+    end
+
+    test "Will NOT set flag when streamers have no streams" do
+      streamer = streamer_fixture()
+
+      assert :ok == IsNewStreamerFlagger.perform([])
+      updated_channel = Glimesh.Repo.get(Channel, streamer.channel.id)
+      assert updated_channel.is_new_streamer == false
+    end
+
+    test "Will NOT set flag when streamers have disabled their channel" do
+      streamer = streamer_fixture(%{}, %{inaccessible: true})
+      create_eight_hour_stream(streamer.channel, -1)
+
+      assert :ok == IsNewStreamerFlagger.perform([])
+      updated_channel = Glimesh.Repo.get(Channel, streamer.channel.id)
+      assert updated_channel.is_new_streamer == false
+    end
+
+    test "Will clear flag when streamers have disabled their channel" do
+      streamer = streamer_fixture(%{}, %{inaccessible: true, is_new_streamer: true})
+      create_eight_hour_stream(streamer.channel, -1)
+
+      assert :ok == IsNewStreamerFlagger.perform([])
+      updated_channel = Glimesh.Repo.get(Channel, streamer.channel.id)
+      assert updated_channel.is_new_streamer == false
+    end
+
+    test "Will clear flag if streamers have more than 50 hours streamed" do
+      streamer = streamer_fixture(%{}, %{is_new_streamer: true})
+      create_a_stream(streamer.channel, -3)
+
+      assert :ok == IsNewStreamerFlagger.perform([])
+      updated_channel = Glimesh.Repo.get(Channel, streamer.channel.id)
+      assert updated_channel.is_new_streamer == false
+    end
+
+    test "Will clear flag if streamers are within 7 days but have more then 50 hours streamed" do
+      streamer = streamer_fixture()
+      create_eight_hour_stream(streamer.channel, -5)
+      create_eight_hour_stream(streamer.channel, -4)
+      create_eight_hour_stream(streamer.channel, -3)
+      create_eight_hour_stream(streamer.channel, -2)
+      create_a_stream(streamer.channel, -1)
+
+      assert :ok == IsNewStreamerFlagger.perform([])
+      updated_channel = Glimesh.Repo.get(Channel, streamer.channel.id)
+      assert updated_channel.is_new_streamer == false
+    end
+  end
+
+  defp create_a_stream(%Channel{} = channel, num_days_ago, ended_at \\ get_utc_now()) do
+    Streams.create_stream(channel, %{
+      started_at:
+        NaiveDateTime.add(NaiveDateTime.utc_now(), 60 * 60 * 24 * num_days_ago)
+        |> NaiveDateTime.truncate(:second),
+      ended_at: ended_at
+    })
+  end
+
+  defp create_eight_hour_stream(%Channel{} = channel, num_days_ago) do
+    ended_at =
+      NaiveDateTime.add(NaiveDateTime.utc_now(), 60 * 60 * 24 * num_days_ago + 28_800)
+      |> NaiveDateTime.truncate(:second)
+
+    create_a_stream(channel, num_days_ago, ended_at)
+  end
+
+  defp get_utc_now do
+    NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
+  end
+end

--- a/test/support/fixtures/homepage_fixtures.ex
+++ b/test/support/fixtures/homepage_fixtures.ex
@@ -1,9 +1,12 @@
 defmodule Glimesh.HomepageFixtures do
-  def create_viable_mock_stream(mock_time \\ nil) do
+  def create_viable_mock_stream(mock_time \\ nil, channel_attribs \\ %{}) do
     random_stream =
-      Glimesh.AccountsFixtures.streamer_fixture(%{}, %{
-        show_on_homepage: true
-      })
+      Glimesh.AccountsFixtures.streamer_fixture(
+        %{},
+        Map.merge(channel_attribs, %{
+          show_on_homepage: true
+        })
+      )
 
     start_time =
       if mock_time, do: mock_time, else: NaiveDateTime.add(NaiveDateTime.utc_now(), -(16 * 60))


### PR DESCRIPTION
It may be beneficial to community-building if we can quickly identify new streamers on the platform and welcome them to Glimesh. To this end, we can add a special “tag” that can be selected from the filters at the top of category pages. We can also put a special badge next to the streamer’s tile to indicate that they are new to Glimesh.

## New filter option on category pages
At the top of the category pages viewers will now be able to filter the live streams to show only those from new streamers on the platform:
![image](https://user-images.githubusercontent.com/5142625/204156965-89f197ca-1d41-4b32-ad86-ab534bec9cbd.png)

![image](https://user-images.githubusercontent.com/5142625/204156991-b49e2f94-f652-4d1a-9e06-faa7cb3ef63a.png)

Clicking the toggle button will apply the new streamer filter to any existing filters already active.

## New badge on category pages, homepage, and following page
Streamers flagged as new on the platform will have a red badge that will appear on their stream panel next to their language/mature badges as shown below:
![image](https://user-images.githubusercontent.com/5142625/204157163-ac88478c-11e9-4466-9d1c-bfb3d30e6305.png)
![image](https://user-images.githubusercontent.com/5142625/204157201-a4adb845-1821-427e-b469-ba3c35694d89.png)

## How we determine if a streamer is new
I've introduced a new background job called "is_new_streamer_flagger" that runs once per hour and will use the following criteria to determine if a channel qualifies as new:
- is it within 7 days of the channel's first stream (as determined by the stream start time)
- does the channel have 5 or fewer streams (this is to not unfairly punish streamers who can only stream a few times a week or who run a test stream then start streaming the next week).
- the channel must NOT have greater than 50 total hours streamed (this is to prevent 24/7 streams from having the new badge well after their initial period).

## Development details
- A new boolean column "is_new_streamer" has been added to the channels table.
- The new field should only be written to from the new "is_new_streamer_flagger" job.
- The API should NOT have access to this new channel field as it could allow gaming the system.
- I've added a new job called "is_new_streamer_flagger" which will run every hour and perform updates against the new column for channels that are not flagged as inaccessible (inaccessible = false).
- UI only reads the new column.
- Added filter option to the category pages.