### PR TITLE
Homepage redesign and Live stream category counts

### DIFF
--- a/lib/glimesh/channel_lookups.ex
+++ b/lib/glimesh/channel_lookups.ex
@@ -301,4 +301,16 @@ defmodule Glimesh.ChannelLookups do
       []
     end
   end
+
+  def count_live_channels_by_category do
+    Repo.replica().all(
+      from c in Channel,
+        join: cat in Category,
+        on: c.category_id == cat.id,
+        where: c.inaccessible == false,
+        where: c.status == "live",
+        select: %{category: cat.name, count: count()},
+        group_by: cat.name
+    )
+  end
 end

--- a/lib/glimesh_web/live/homepage_live.ex
+++ b/lib/glimesh_web/live/homepage_live.ex
@@ -14,22 +14,46 @@ defmodule GlimeshWeb.HomepageLive do
   def render(assigns) do
     ~F"""
     <div class="fancy-bg pt-4">
-      {#if @random_channel}
-        <div class="container">
-          {#if not is_nil(@live_featured_event_channel)}
-            <div class="card shadow rounded">
-              <div class="row">
-                <div class="col-md-7">
-                  <VideoPlayer id="homepage-video-player" muted channel={@live_featured_event_channel} />
-                </div>
-                <div class="col-md-5 py-4 pr-4">
-                  <EventMedia event={@live_featured_event} show_img={false} />
+      <!-- categories -->
+      <div class="container">
+        <div class="row mb-4">
+          {#for {name, link, icon, live_count} <- list_categories()}
+            <div class="col">
+              <LivePatch to={link} class="btn btn-outline-primary btn-lg btn-block py-2">
+                <i class={"fas fa-2x fa-fw", icon} />
+                <br>
+                <small class="text-color-link">{name}</small>
+                <br>
+                {#if not is_nil(live_count)}
+                  <small class={"text-warning font-weight-bold count-#{name}"}>{live_count} Streams Live!</small>
+                {#else}
+                  <small class={"text-warning font-weight-bold count-#{name}"}>&nbsp;</small>
+                {/if}
+              </LivePatch>
+            </div>
+          {/for}
+        </div>
+      </div>
+
+      <div class="col-12">
+        <!-- top line -->
+        <div class="row align-items-center">
+          {#if @random_channel}
+            {#if not is_nil(@live_featured_event_channel)}
+              <div class="col-md-6">
+                <div class="card shadow rounded">
+                  <div class="row">
+                    <div class="col-md-7 pl-0">
+                      <VideoPlayer id="homepage-video-player" muted channel={@live_featured_event_channel} />
+                    </div>
+                    <div class="col-md-5 pl-2">
+                      <EventMedia event={@live_featured_event} show_img={false} />
+                    </div>
+                  </div>
                 </div>
               </div>
-            </div>
-          {#else}
-            <div class="row">
-              <div class="col-md-7">
+            {#else}
+              <div class="col-md-6">
                 <div class="card shadow rounded">
                   <VideoPlayer id="homepage-video-player" muted channel={@random_channel} />
                   <div class="d-flex align-items-start p-2">
@@ -68,109 +92,56 @@ defmodule GlimeshWeb.HomepageLive do
                   </div>
                 </div>
               </div>
-              <div class="col-md-5 py-4 pr-4">
-                <div class="d-flex flex-column align-items-center justify-content-center h-100">
-                  <h2 class="font-weight-bold">
-                    <span class="text-color-alpha">{gettext("Next-Gen")}</span>
-                    {gettext("Live Streaming!")}
-                  </h2>
-                  <p class="lead">
-                    {gettext(
-                      "The first live streaming platform built around truly real time interactivity. Our streams are warp speed, our chat is blazing, and our community is thriving."
-                    )}
-                  </p>
+            {/if}
+          {#else}
+            <div class="position-relative overflow-hidden p-3 p-md-5">
+              <div class="col-md-12 p-lg-4 mx-auto">
+                <h1 class="display-3 font-weight-bold">
+                  <span class="text-color-alpha">{gettext("Next-Gen")}</span>
+                  {gettext("Live Streaming!")}
+                </h1>
+                <p class="lead" style="max-width: 550px;">
+                  {gettext(
+                    "The first live streaming platform built around truly real time interactivity. Our streams are warp speed, our chat is blazing, and our community is thriving."
+                  )}
+                </p>
 
-                  {#if @current_user}
-                    <div class="d-flex flex-row justify-content-around mt-3">
-                      {link(gettext("Create Your Channel"),
-                        to: Routes.user_settings_path(@socket, :stream),
-                        class: "btn btn-info mr-4"
-                      )}
-                      {link(gettext("Setup Payouts"),
-                        to: "/users/settings/profile",
-                        class: "btn btn-info"
-                      )}
-                    </div>
-                  {#else}
-                    <p class="lead">
-                      {gettext("Join %{user_count} others!", user_count: @user_count)}
-                    </p>
-                    {link(gettext("Register Your Account"),
-                      to: Routes.user_registration_path(@socket, :new),
-                      class: "btn btn-primary btn-lg"
-                    )}
-                  {/if}
-                </div>
+                {#if @current_user}
+                  {link(gettext("Customize Your Profile"),
+                    to: Routes.user_settings_path(@socket, :profile),
+                    class: "btn btn-info mt-3"
+                  )}
+                  {link(gettext("Create Your Channel"),
+                    to: Routes.user_settings_path(@socket, :stream),
+                    class: "btn btn-info mt-3"
+                  )}
+                  {link(gettext("Setup Payouts"),
+                    to: "/users/settings/profile",
+                    class: "btn btn-info mt-3"
+                  )}
+                {#else}
+                  <p class="lead">
+                    {gettext("Join %{user_count} others!", user_count: @user_count)}
+                  </p>
+                  {link(gettext("Register Your Account"),
+                    to: Routes.user_registration_path(@socket, :new),
+                    class: "btn btn-primary btn-lg mt-3"
+                  )}
+                {/if}
               </div>
             </div>
           {/if}
-        </div>
-      {#else}
-        <div class="container">
-          <div class="position-relative overflow-hidden p-3 p-md-5">
-            <div class="col-md-12 p-lg-4 mx-auto">
-              <h1 class="display-3 font-weight-bold">
-                <span class="text-color-alpha">{gettext("Next-Gen")}</span>
-                {gettext("Live Streaming!")}
-              </h1>
-              <p class="lead" style="max-width: 550px;">
-                {gettext(
-                  "The first live streaming platform built around truly real time interactivity. Our streams are warp speed, our chat is blazing, and our community is thriving."
-                )}
-              </p>
 
-              {#if @current_user}
-                {link(gettext("Customize Your Profile"),
-                  to: Routes.user_settings_path(@socket, :profile),
-                  class: "btn btn-info mt-3"
-                )}
-                {link(gettext("Create Your Channel"),
-                  to: Routes.user_settings_path(@socket, :stream),
-                  class: "btn btn-info mt-3"
-                )}
-                {link(gettext("Setup Payouts"),
-                  to: "/users/settings/profile",
-                  class: "btn btn-info mt-3"
-                )}
-              {#else}
-                <p class="lead">
-                  {gettext("Join %{user_count} others!", user_count: @user_count)}
-                </p>
-                {link(gettext("Register Your Account"),
-                  to: Routes.user_registration_path(@socket, :new),
-                  class: "btn btn-primary btn-lg mt-3"
-                )}
-              {/if}
+          <!-- Stream list -->
+          {#if length(@channels) > 0}
+            <div class="col-6 container-stream-list d-flex flex-wrap">
+              <div class="row">
+                {#for channel <- @channels}
+                  <ChannelPreview channel={channel} class="col-6" />
+                {/for}
+              </div>
             </div>
-          </div>
-        </div>
-      {/if}
-
-      {#if length(@channels) > 0}
-        <div class="container container-stream-list">
-          <div class="row">
-            {#for channel <- @channels}
-              <ChannelPreview channel={channel} class="col-sm-12 col-md-6 col-xl-4 mt-2 mt-md-4" />
-            {/for}
-          </div>
-        </div>
-      {/if}
-
-      <div class="container">
-        <div class="mt-4 px-4 px-lg-0">
-          <h2>{gettext("Categories Made Simpler")}</h2>
-          <p class="lead">{gettext("Explore our categories and find your new home!")}</p>
-        </div>
-        <div class="row mt-2 mb-4">
-          {#for {name, link, icon} <- list_categories()}
-            <div class="col">
-              <LivePatch to={link} class="btn btn-outline-primary btn-lg btn-block py-4">
-                <i class={"fas fa-2x fa-fw", icon} />
-                <br>
-                <small class="text-color-link">{name}</small>
-              </LivePatch>
-            </div>
-          {/for}
+          {/if}
         </div>
       </div>
     </div>
@@ -227,36 +198,44 @@ defmodule GlimeshWeb.HomepageLive do
   end
 
   def list_categories do
+    category_counts = Glimesh.ChannelLookups.count_live_channels_by_category()
+
     [
       {
         gettext("Gaming"),
         Routes.streams_list_path(GlimeshWeb.Endpoint, :index, "gaming"),
-        "fa-gamepad"
+        "fa-gamepad",
+        Enum.find_value(category_counts, fn x -> if x[:category] == "Gaming", do: x[:count] end)
       },
       {
         gettext("Art"),
         Routes.streams_list_path(GlimeshWeb.Endpoint, :index, "art"),
-        "fa-palette"
+        "fa-palette",
+        Enum.find_value(category_counts, fn x -> if x[:category] == "Art", do: x[:count] end)
       },
       {
         gettext("Music"),
         Routes.streams_list_path(GlimeshWeb.Endpoint, :index, "music"),
-        "fa-headphones"
+        "fa-headphones",
+        Enum.find_value(category_counts, fn x -> if x[:category] == "Music", do: x[:count] end)
       },
       {
         gettext("Tech"),
         Routes.streams_list_path(GlimeshWeb.Endpoint, :index, "tech"),
-        "fa-microchip"
+        "fa-microchip",
+        Enum.find_value(category_counts, fn x -> if x[:category] == "Tech", do: x[:count] end)
       },
       {
         gettext("IRL"),
         Routes.streams_list_path(GlimeshWeb.Endpoint, :index, "irl"),
-        "fa-camera-retro"
+        "fa-camera-retro",
+        Enum.find_value(category_counts, fn x -> if x[:category] == "IRL", do: x[:count] end)
       },
       {
         gettext("Education"),
         Routes.streams_list_path(GlimeshWeb.Endpoint, :index, "education"),
-        "fa-graduation-cap"
+        "fa-graduation-cap",
+        Enum.find_value(category_counts, fn x -> if x[:category] == "Education", do: x[:count] end)
       }
     ]
   end

--- a/test/glimesh/channel_lookups_test.exs
+++ b/test/glimesh/channel_lookups_test.exs
@@ -4,6 +4,7 @@ defmodule Glimesh.ChannelLookupsTest do
 
   import Glimesh.AccountsFixtures
   import Glimesh.StreamsFixtures
+  import Glimesh.HomepageFixtures
   alias Glimesh.ChannelLookups
   alias Glimesh.ChannelCategories
   alias Glimesh.Streams
@@ -553,6 +554,34 @@ defmodule Glimesh.ChannelLookupsTest do
       Glimesh.AccountFollows.follow(live_hosted, host)
       results = ChannelLookups.list_live_followed_channels_and_hosts(host)
       assert length(results) == 1
+    end
+  end
+
+  describe "Live channel count by category" do
+    test "can get count of live channels by category" do
+      art_streams =
+        Enum.map(1..:rand.uniform(12), fn _ ->
+          {:ok, _stream} = create_viable_mock_stream(nil, %{category_id: 1})
+        end)
+
+      irl_streams =
+        Enum.map(1..:rand.uniform(12), fn _ ->
+          {:ok, _stream} = create_viable_mock_stream(nil, %{category_id: 4})
+        end)
+
+      category_counts = ChannelLookups.count_live_channels_by_category()
+
+      assert Enum.find_value(category_counts, fn x -> if x[:category] == "Art", do: x[:count] end) ==
+               Enum.count(art_streams)
+
+      assert Enum.find_value(category_counts, fn x -> if x[:category] == "IRL", do: x[:count] end) ==
+               Enum.count(irl_streams)
+
+      assert is_nil(
+               Enum.find_value(category_counts, fn x ->
+                 if x[:category] == "Gaming", do: x[:count]
+               end)
+             )
     end
   end
 end

--- a/test/glimesh_web/live/homepage_live_test.exs
+++ b/test/glimesh_web/live/homepage_live_test.exs
@@ -15,7 +15,7 @@ defmodule GlimeshWeb.HomepageLiveTest do
     test "general text", %{conn: conn} do
       user_fixture()
 
-      {:ok, _, html} = live(conn, Routes.homepage_path(conn, :index))
+      {:ok, _, _html} = live(conn, Routes.homepage_path(conn, :index))
 
       # Commented out for now
       # assert html =~ "Join 1 others!"
@@ -46,6 +46,32 @@ defmodule GlimeshWeb.HomepageLiveTest do
 
       {:ok, _, html} = live(conn, Routes.homepage_path(conn, :index))
       assert html =~ hd(streams).title
+    end
+
+    test "shows live stream counts per category", %{conn: conn} do
+      tech_streams =
+        Enum.map(1..:rand.uniform(12), fn _ ->
+          {:ok, _stream} = create_viable_mock_stream(nil, %{category_id: 3})
+        end)
+
+      gaming_streams =
+        Enum.map(1..:rand.uniform(12), fn _ ->
+          {:ok, _stream} = create_viable_mock_stream(nil, %{category_id: 6})
+        end)
+
+      {:ok, view, _html} = live(conn, Routes.homepage_path(conn, :index))
+
+      assert view
+             |> element(".count-Tech")
+             |> render() =~ "#{Enum.count(tech_streams)} Streams Live!"
+
+      assert view
+             |> element(".count-Gaming")
+             |> render() =~ "#{Enum.count(gaming_streams)} Streams Live!"
+
+      refute view
+             |> element(".count-Art")
+             |> render() =~ "Live!"
     end
   end
 end

--- a/test/support/fixtures/homepage_fixtures.ex
+++ b/test/support/fixtures/homepage_fixtures.ex
@@ -1,9 +1,15 @@
 defmodule Glimesh.HomepageFixtures do
-  def create_viable_mock_stream(mock_time \\ nil) do
+  def create_viable_mock_stream(mock_time \\ nil, channel_attribs \\ %{}) do
     random_stream =
-      Glimesh.AccountsFixtures.streamer_fixture(%{}, %{
-        show_on_homepage: true
-      })
+      Glimesh.AccountsFixtures.streamer_fixture(
+        %{},
+        Map.merge(
+          %{
+            show_on_homepage: true
+          },
+          channel_attribs
+        )
+      )
 
     start_time =
       if mock_time, do: mock_time, else: NaiveDateTime.add(NaiveDateTime.utc_now(), -(16 * 60))


### PR DESCRIPTION
I have reorganized the homepage layout so highlighted streams appear above the fold and our categories show above the streams.  In addition, I've added the count of live streams per category under the category buttons so viewers are more aware that there are more then just 6 streams live on the site on any given time.  I've also removed most of the "marketing" text on the homepage as it detracts from the user content and is not relevant to returning viewers.

## Homepage with Community Event and spotlighted streams
![image](https://user-images.githubusercontent.com/5142625/206927505-603027c7-0b40-451a-8b97-4e68b63dd590.png)

## Homepage without an event but with spotlighted streams
![image](https://user-images.githubusercontent.com/5142625/206927610-681c64ff-5d57-4fcb-abe8-3f71a5d31762.png)

## Homepage with no spotlighted streams but user logged in
![image](https://user-images.githubusercontent.com/5142625/206927674-5c3b06dd-028f-420d-b41d-b41bca594b81.png)

## Homepage with no spotlighted streams and user NOT logged in
![image](https://user-images.githubusercontent.com/5142625/206927722-30766168-b6ab-4483-89d3-a3e8d389a7d2.png)
