### PR TITLE
Show random live subcategories and tags on homepage

### DIFF
--- a/lib/glimesh_web/live/homepage_live.ex
+++ b/lib/glimesh_web/live/homepage_live.ex
@@ -156,6 +156,23 @@ defmodule GlimeshWeb.HomepageLive do
         </div>
       {/if}
 
+      {#if length(@live_tag_cloud) > 0}
+        <div class="container my-5 position-relative">
+          <h2>{gettext("Search Live Streams")}</h2>
+          <h2>
+            {#for item <- @live_tag_cloud}
+              {link(item[:tag_name],
+                to:
+                  Routes.streams_list_path(@socket, :index, item[:cat_slug], %{
+                    "#{item[:type]}[]" => item[:tag_slug]
+                  }),
+                class: "badge badge-info subcat-badge-search"
+              )}
+            {/for}
+          </h2>
+        </div>
+      {/if}
+
       <div class="container">
         <div class="mt-4 px-4 px-lg-0">
           <h2>{gettext("Categories Made Simpler")}</h2>
@@ -193,6 +210,8 @@ defmodule GlimeshWeb.HomepageLive do
 
     user_count = Glimesh.Accounts.count_users()
 
+    live_tag_cloud = Glimesh.ChannelLookups.list_live_homepage_tags()
+
     if connected?(socket) do
       live_channel_id =
         cond do
@@ -219,6 +238,7 @@ defmodule GlimeshWeb.HomepageLive do
      |> assign(:upcoming_event, upcoming_event)
      |> assign(:live_featured_event, live_featured_event)
      |> assign(:live_featured_event_channel, live_featured_event_channel)
+     |> assign(:live_tag_cloud, live_tag_cloud)
      |> assign(:channels, channels)
      |> assign(:random_channel, random_channel)
      |> assign(:random_channel_thumbnail, get_stream_thumbnail(random_channel))

--- a/test/glimesh/channel_lookups_test.exs
+++ b/test/glimesh/channel_lookups_test.exs
@@ -555,4 +555,240 @@ defmodule Glimesh.ChannelLookupsTest do
       assert length(results) == 1
     end
   end
+
+  defp create_live_channels_with_tags(_) do
+    gaming_id = ChannelCategories.get_category("gaming").id
+    education_id = ChannelCategories.get_category("education").id
+
+    {:ok, gaming_subcat_1} =
+      ChannelCategories.create_subcategory(%{name: "testa", category_id: gaming_id})
+
+    {:ok, gaming_subcat_2} =
+      ChannelCategories.create_subcategory(%{name: "testb", category_id: gaming_id})
+
+    {:ok, gaming_subcat_3} =
+      ChannelCategories.create_subcategory(%{name: "testc", category_id: gaming_id})
+
+    {:ok, education_subcat_1} =
+      ChannelCategories.create_subcategory(%{name: "testa", category_id: education_id})
+
+    {:ok, education_subcat_2} =
+      ChannelCategories.create_subcategory(%{name: "testb", category_id: education_id})
+
+    {:ok, education_subcat_3} =
+      ChannelCategories.create_subcategory(%{name: "testc", category_id: education_id})
+
+    streamer_1 =
+      streamer_fixture(%{}, %{
+        category_id: gaming_id,
+        subcategory_id: gaming_subcat_1.id,
+        language: "en"
+      })
+
+    streamer_2 =
+      streamer_fixture(%{}, %{
+        category_id: gaming_id,
+        subcategory_id: gaming_subcat_2.id,
+        language: "en"
+      })
+
+    streamer_3 =
+      streamer_fixture(%{}, %{
+        category_id: gaming_id,
+        subcategory_id: gaming_subcat_3.id,
+        language: "en"
+      })
+
+    streamer_4 =
+      streamer_fixture(%{}, %{
+        category_id: education_id,
+        subcategory_id: education_subcat_1.id,
+        language: "en"
+      })
+
+    streamer_5 =
+      streamer_fixture(%{}, %{
+        category_id: education_id,
+        subcategory_id: education_subcat_2.id,
+        language: "en"
+      })
+
+    streamer_6 =
+      streamer_fixture(%{}, %{
+        category_id: education_id,
+        subcategory_id: education_subcat_3.id,
+        language: "en"
+      })
+
+    streamer_7 =
+      streamer_fixture(%{}, %{
+        category_id: education_id,
+        subcategory_id: education_subcat_2.id,
+        language: "en"
+      })
+
+    streamer_8 =
+      streamer_fixture(%{}, %{
+        category_id: education_id,
+        subcategory_id: education_subcat_1.id,
+        language: "en"
+      })
+
+    streamer_9 =
+      streamer_fixture(%{}, %{
+        category_id: gaming_id,
+        subcategory_id: gaming_subcat_2.id,
+        language: "en"
+      })
+
+    streamer_10 =
+      streamer_fixture(%{}, %{
+        category_id: gaming_id,
+        subcategory_id: gaming_subcat_1.id,
+        language: "en"
+      })
+
+    gaming_tag_1 = tag_fixture(%{name: "taga", category_id: gaming_id})
+    gaming_tag_2 = tag_fixture(%{name: "tagb", category_id: gaming_id})
+    gaming_tag_3 = tag_fixture(%{name: "tagc", category_id: gaming_id})
+    education_tag_1 = tag_fixture(%{name: "taga", category_id: education_id})
+    education_tag_2 = tag_fixture(%{name: "tagb", category_id: education_id})
+    education_tag_3 = tag_fixture(%{name: "tagc", category_id: education_id})
+
+    {:ok, gaming_channel_1} =
+      streamer_1.channel
+      |> Ecto.Changeset.change()
+      |> Ecto.Changeset.put_assoc(:tags, [gaming_tag_1, gaming_tag_2])
+      |> Glimesh.Repo.update()
+
+    {:ok, gaming_channel_2} =
+      streamer_2.channel
+      |> Ecto.Changeset.change()
+      |> Ecto.Changeset.put_assoc(:tags, [gaming_tag_3, gaming_tag_1])
+      |> Glimesh.Repo.update()
+
+    {:ok, gaming_channel_3} =
+      streamer_3.channel
+      |> Ecto.Changeset.change()
+      |> Ecto.Changeset.put_assoc(:tags, [gaming_tag_2, gaming_tag_3])
+      |> Glimesh.Repo.update()
+
+    {:ok, education_channel_4} =
+      streamer_4.channel
+      |> Ecto.Changeset.change()
+      |> Ecto.Changeset.put_assoc(:tags, [education_tag_1, education_tag_2])
+      |> Glimesh.Repo.update()
+
+    {:ok, education_channel_5} =
+      streamer_5.channel
+      |> Ecto.Changeset.change()
+      |> Ecto.Changeset.put_assoc(:tags, [education_tag_2, education_tag_3])
+      |> Glimesh.Repo.update()
+
+    {:ok, education_channel_6} =
+      streamer_6.channel
+      |> Ecto.Changeset.change()
+      |> Ecto.Changeset.put_assoc(:tags, [education_tag_1, education_tag_3])
+      |> Glimesh.Repo.update()
+
+    {:ok, education_channel_7} =
+      streamer_7.channel
+      |> Ecto.Changeset.change()
+      |> Ecto.Changeset.put_assoc(:tags, [education_tag_2, education_tag_3])
+      |> Glimesh.Repo.update()
+
+    {:ok, education_channel_8} =
+      streamer_8.channel
+      |> Ecto.Changeset.change()
+      |> Ecto.Changeset.put_assoc(:tags, [education_tag_1, education_tag_2])
+      |> Glimesh.Repo.update()
+
+    {:ok, gaming_channel_9} =
+      streamer_9.channel
+      |> Ecto.Changeset.change()
+      |> Ecto.Changeset.put_assoc(:tags, [gaming_tag_2, gaming_tag_3])
+      |> Glimesh.Repo.update()
+
+    {:ok, gaming_channel_10} =
+      streamer_10.channel
+      |> Ecto.Changeset.change()
+      |> Ecto.Changeset.put_assoc(:tags, [gaming_tag_3, gaming_tag_1])
+      |> Glimesh.Repo.update()
+
+    {:ok, _} = Glimesh.Streams.start_stream(gaming_channel_1)
+    {:ok, _} = Glimesh.Streams.start_stream(gaming_channel_2)
+    {:ok, _} = Glimesh.Streams.start_stream(gaming_channel_3)
+    {:ok, _} = Glimesh.Streams.start_stream(education_channel_4)
+    {:ok, _} = Glimesh.Streams.start_stream(education_channel_5)
+    {:ok, _} = Glimesh.Streams.start_stream(education_channel_6)
+    {:ok, _} = Glimesh.Streams.start_stream(education_channel_7)
+    {:ok, _} = Glimesh.Streams.start_stream(education_channel_8)
+    {:ok, _} = Glimesh.Streams.start_stream(gaming_channel_9)
+    {:ok, _} = Glimesh.Streams.start_stream(gaming_channel_10)
+
+    %{
+      gaming_subcategories: [gaming_subcat_1, gaming_subcat_2, gaming_subcat_3],
+      education_subcategories: [education_subcat_1, education_subcat_2, education_subcat_3],
+      gaming_tags: [gaming_tag_1, gaming_tag_2, gaming_tag_3],
+      education_tags: [education_tag_1, education_tag_2, education_tag_3],
+      gaming_channels: [
+        gaming_channel_1,
+        gaming_channel_2,
+        gaming_channel_3,
+        gaming_channel_9,
+        gaming_channel_10
+      ],
+      education_channels: [
+        education_channel_4,
+        education_channel_5,
+        education_channel_6,
+        education_channel_7,
+        education_channel_8
+      ],
+      streamers: [
+        streamer_1,
+        streamer_2,
+        streamer_3,
+        streamer_4,
+        streamer_5,
+        streamer_6,
+        streamer_7,
+        streamer_8,
+        streamer_9,
+        streamer_10
+      ]
+    }
+  end
+
+  describe "Homepage live tags cloud" do
+    setup :create_live_channels_with_tags
+
+    test "Shows mix of live channel subcategories and tags", %{
+      gaming_subcategories: gaming_subs,
+      education_subcategories: edu_subs,
+      gaming_tags: gaming_tags,
+      education_tags: edu_tags
+    } do
+      live_tags = ChannelLookups.list_live_homepage_tags()
+
+      assert Enum.count(live_tags) > 0
+
+      assert Enum.any?(live_tags, fn tags ->
+               Enum.any?(gaming_subs ++ edu_subs, fn subs ->
+                 tags[:tag_name] == subs.name
+               end) or
+                 Enum.any?(gaming_tags ++ edu_tags, fn item ->
+                   tags[:tag_name] == item.name
+                 end)
+             end)
+    end
+
+    test "Does not show duplicates" do
+      live_tags = ChannelLookups.list_live_homepage_tags()
+
+      unique_tags = Enum.uniq_by(live_tags, fn x -> x[:tag_name] end)
+
+      assert Enum.count(live_tags) == Enum.count(unique_tags)
+    end
+  end
 end

--- a/test/glimesh_web/live/homepage_live_test.exs
+++ b/test/glimesh_web/live/homepage_live_test.exs
@@ -15,7 +15,7 @@ defmodule GlimeshWeb.HomepageLiveTest do
     test "general text", %{conn: conn} do
       user_fixture()
 
-      {:ok, _, html} = live(conn, Routes.homepage_path(conn, :index))
+      {:ok, _, _html} = live(conn, Routes.homepage_path(conn, :index))
 
       # Commented out for now
       # assert html =~ "Join 1 others!"
@@ -46,6 +46,22 @@ defmodule GlimeshWeb.HomepageLiveTest do
 
       {:ok, _, html} = live(conn, Routes.homepage_path(conn, :index))
       assert html =~ hd(streams).title
+    end
+
+    test "shows live tags cloud when there are live channels", %{conn: conn} do
+      subcat = subcategory_fixture()
+      _stream = create_viable_mock_stream(nil, %{subcategory_id: subcat.id})
+
+      {:ok, _, html} = live(conn, Routes.homepage_path(conn, :index))
+      assert html =~ "subcat-badge-search"
+    end
+
+    test "does not show live tags cloud when there are no live channels with tags/subcategories",
+         %{conn: conn} do
+      _stream = create_viable_mock_stream()
+
+      {:ok, _, html} = live(conn, Routes.homepage_path(conn, :index))
+      refute html =~ "subcat-badge-search"
     end
   end
 end

--- a/test/support/fixtures/homepage_fixtures.ex
+++ b/test/support/fixtures/homepage_fixtures.ex
@@ -1,9 +1,15 @@
 defmodule Glimesh.HomepageFixtures do
-  def create_viable_mock_stream(mock_time \\ nil) do
+  def create_viable_mock_stream(mock_time \\ nil, channel_attribs \\ %{}) do
     random_stream =
-      Glimesh.AccountsFixtures.streamer_fixture(%{}, %{
-        show_on_homepage: true
-      })
+      Glimesh.AccountsFixtures.streamer_fixture(
+        %{},
+        Map.merge(
+          %{
+            show_on_homepage: true
+          },
+          channel_attribs
+        )
+      )
 
     start_time =
       if mock_time, do: mock_time, else: NaiveDateTime.add(NaiveDateTime.utc_now(), -(16 * 60))


### PR DESCRIPTION
## Description
To help surface more live streams on the homepage and introduce users to the category search function, I've added a tag cloud on the homepage.  The cloud will be a random mix of both subcategories and tags taken from currently live channels across the platform regardless of time streamed.

![image](https://user-images.githubusercontent.com/5142625/208587248-3f7d4d8c-7d41-4558-92f5-18de24e3e08d.png)

Clicking a tag will automatically take the user to the appropriate category search page with the subcategory or tag already selected in the filter at the top of the page:

![image](https://user-images.githubusercontent.com/5142625/208587468-4ea79f00-abc4-427f-a451-b3586c6ee8b6.png)

![image](https://user-images.githubusercontent.com/5142625/208587591-59444575-8e48-4dc2-a337-f4bd44bbef5e.png)

## Limitations
- A maximum of 20 subcategories/tags will show on the homepage.
- Despite my best efforts, the database query tends to favor some categories over others when it comes to removing duplicate tags.  For example, having two live streams -- one in the Art category and one in the Gaming category -- that both use the "Community Pride" tag will predominately surface one category over the other thus showing only one of the streams.  This could be solved by having a more generic tag search that spans across categories.
