### PR TITLE
Fixed disabled status on channel settings dropdown

### DIFF
--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -118,6 +118,11 @@ $fa-font-path: "/fa-fonts";
     text-shadow: 0 0 10px var(--input-color);
 }
 
+.settings-field:disabled {
+    color: var(--text-muted-color);
+    opacity: 0.6;
+}
+
 .fancy-bg {
 
     position: relative;

--- a/lib/glimesh_web/live/user_settings/components/channel_settings_live.html.heex
+++ b/lib/glimesh_web/live/user_settings/components/channel_settings_live.html.heex
@@ -275,17 +275,17 @@
         <%= error_tag(f, :show_recent_chat_messages_only) %>
       </div>
       <div class="form-group">
-        <%= label(f, :disable_hyperlinks, gettext("Should links automatically be clickable?")) %>
-        <%= select(f, :disable_hyperlinks, [Yes: false, No: true],
-          class: "form-control",
-          disabled: @channel.block_links
-        ) %>
-        <%= error_tag(f, :disable_hyperlinks) %>
-      </div>
-      <div class="form-group">
         <%= label(f, :block_links, gettext("Block viewers from posting links?")) %>
         <%= select(f, :block_links, [Yes: true, No: false], class: "form-control") %>
         <%= error_tag(f, :block_links) %>
+      </div>
+      <div class="form-group">
+        <%= label(f, :disable_hyperlinks, gettext("Should links automatically be clickable?")) %>
+        <%= select(f, :disable_hyperlinks, [Yes: false, No: true],
+          class: ["form-control", "settings-field"],
+          disabled: @channel.block_links
+        ) %>
+        <%= error_tag(f, :disable_hyperlinks) %>
       </div>
       <div class="form-group">
         <%= label(


### PR DESCRIPTION
Fixes #896 Changed the "Should links be automatically clickable" drop-down to be more obvious when it is disabled:

![image](https://user-images.githubusercontent.com/5142625/210124158-84798f00-1189-4f63-b508-ca5c60cdceec.png)

Also changed the order of the "Should links be automatically clickable" and "block viewers from posting links" drop-downs so they make a little more logical sense:

![image](https://user-images.githubusercontent.com/5142625/210124206-f79a6245-54a0-4dc1-b42a-276b14d517bd.png)
