### PR TITLE
Various wording and bug fixes

### DIFF
--- a/lib/glimesh/emotes.ex
+++ b/lib/glimesh/emotes.ex
@@ -106,7 +106,7 @@ defmodule Glimesh.Emotes do
     )
   end
 
-  # credo:disable-for-lines:22
+  # credo:disable-for-lines:23
   def list_static_emotes(userid) do
     # Allow use of all emotes except for Glimesh animated (Platform Sub)
     Repo.replica().all(
@@ -123,6 +123,7 @@ defmodule Glimesh.Emotes do
                   (e.require_channel_sub == false or
                      (e.require_channel_sub == true and
                         (s.is_active == true or c.user_id == ^userid))))),
+        distinct: e.id,
         order_by: e.emote
       )
     )

--- a/lib/glimesh/events_team.ex
+++ b/lib/glimesh/events_team.ex
@@ -111,7 +111,7 @@ defmodule Glimesh.EventsTeam do
   def delete_event(eventid) do
     %Event{id: String.to_integer(eventid)}
     |> Event.changeset()
-    |> Repo.delete()
+    |> Repo.delete(eventid)
   end
 
   def list_types do

--- a/lib/glimesh_web/live/about/go_live_live.ex
+++ b/lib/glimesh_web/live/about/go_live_live.ex
@@ -34,7 +34,7 @@ defmodule GlimeshWeb.About.GoLiveLive do
                   "Most users who are streaming to Glimesh directly should use the \"Glimesh\" dropdown, as it has the best technology. However if you are experiencing issues, you can try the \"Glimesh - RTMP\" option."
                 )}</p>
 
-              <a href="https://support.glimesh.tv/en-us/7-stream-settings/26-obs-studio-setup-guide">{gettext("Full OBS Setup Guide")}</a>
+              <a href="https://support.glimesh.tv/en-us/75-streaming-software-station/268-obs-setup-guide">{gettext("Full OBS Setup Guide")}</a>
 
               <h3 class="mt-4">
                 <a
@@ -54,11 +54,11 @@ defmodule GlimeshWeb.About.GoLiveLive do
                   "You can stream to Glimesh with Streamlabs Desktop, however only basic features like streaming are currently supported."
                 )}</p>
 
-              <a href="https://support.glimesh.tv/en-us/7-stream-settings/113-slobs-setup-guide">{gettext("Full Streamlabs Desktop Setup Guide")}</a>
+              <a href="https://support.glimesh.tv/en-us/75-streaming-software-station/269-streamlabs-setup-guide">{gettext("Full Streamlabs Desktop Setup Guide")}</a>
 
               <div class="alert alert-primary mt-4" role="alert">
                 Looking for RTMP in OBS? Due to some delays with OBS & Streamlabs Desktop updating their services file, you may need to run the <a
-                  href="https://support.glimesh.tv/en-us/7-stream-settings/112-adding-glimesh-as-a-stream-service-in-obs-or-streamlabs-desktop"
+                  href="https://support.glimesh.tv/en-us/75-streaming-software-station/341-adding-glimesh-as-a-stream-service"
                   target="_blank"
                 >Glimesh Patcher</a> to see "Glimesh - RTMP" as an option.
               </div>

--- a/lib/glimesh_web/templates/about/faq.html.md
+++ b/lib/glimesh_web/templates/about/faq.html.md
@@ -13,7 +13,7 @@ The core inspiration of this project has been equality. At Glimesh our priority 
 
 ##### What makes Glimesh unique?
 
-We are an [Open Company](https://www.opencompany.org/) dedicated to putting true transparency and openness first. Come see for yourself by joining our [Discord](https://discord.gg/glimesh)!  
+We are an [Open Company](https://www.opencompany.org/) dedicated to putting true transparency and openness first. Come see for yourself by joining our [Discord](http://glimesh.tv/s/discord)!  
 We also are not locking features behind metrics which means that for example, everyone gets to upload both static and/or animated emotes and get the subscription button straight away. FTL & our Low Latency RTMP also sets us apart, which means sub-second delay between the streamer and viewer.
 
 ##### When will the beta be released?
@@ -36,7 +36,7 @@ From a feature perspective, we’re hyper focused on truly live streams and we a
 
 Our goal is to focus on having a live, diverse, and friendly platform where new users feel right at home after visiting your stream. We understand the need to continue to bring our user base back to the site, and make sure they know how they can find new content to watch. By showcasing all of our diverse streaming types directly in the nav bar, users can also immediately visit new types of streams they may be unaware exist.
 
-We also recognize that your growth as a streamer is our growth as a platform and we should do everything possible to make sure you are successful on Glimesh. We also recognize that your growth as a streamer is our growth as a platform and we should do everything possible to make sure you are successful on Glimesh. We want to ensure that we work closely with the community to help build the platform that you want to be a part of, and provide the tools you need to be successful.
+We also recognize that your growth as a streamer is our growth as a platform and we should do everything possible to make sure you are successful on Glimesh. We want to ensure that we work closely with the community to help build the platform that you want to be a part of, and provide the tools you need to be successful.
 
 ##### Will Glimesh use my content in advertising? If yes, how so?
 


### PR DESCRIPTION
Few things that have been piling up - 

FIXED: 

- The delete button for the events team dashboard
- Duplicate emotes showing for subscribers when an emote is made available globally (this is a separate fix to the previous fix, which only fixed them locally)
- The link on the FAQs on the main site that linked to the Glimesh Discord

CORRECTED: 

- The links on the stream setup page to the support pages, after the support revamp these links no longer worked
- FAQs on the main site had a section where a sentence was repeated twice, this is also now corrected