### PR TITLE
Chat username autocomplete (Lurker Friendly)

### DIFF
--- a/assets/css/glimesh/components/chat.scss
+++ b/assets/css/glimesh/components/chat.scss
@@ -147,4 +147,22 @@
     .chat-form {
         flex: 0 0;
     }
+
+    .autocomplete-suggestions {
+        background-color: var(--input-bg-color);
+        border: 1px solid var(--input-border-color);
+        border-top-left-radius: 10px;
+        border-top-right-radius: 10px;
+    }
+    .autocomplete-suggestion-item {
+        display: flex;
+        justify-content: center;
+        font-weight: 600;
+        cursor: pointer;
+        color: var(--input-color);
+    }
+
+    .autocomplete-suggestion-item.active {
+        background-color: var(--chat-bubble-background);
+    }
 }

--- a/lib/glimesh/api/resolvers/chat_resolver.ex
+++ b/lib/glimesh/api/resolvers/chat_resolver.ex
@@ -65,6 +65,24 @@ defmodule Glimesh.Api.ChatResolver do
     end
   end
 
+  def autocomplete_recent_chat_users(
+        _parent,
+        %{channel_id: channel_id, partial_usernames: partial_usernames},
+        %{context: %{access: access}}
+      ) do
+    with :ok <- Bodyguard.permit(Glimesh.Api.Scopes, :chat, access) do
+      channel = ChannelLookups.get_channel!(channel_id)
+      suggestions = Chat.get_recent_chatters_username_autocomplete(channel, partial_usernames)
+
+      suggested_usernames =
+        Enum.into(suggestions, [], fn item ->
+          item[:suggestion]
+        end)
+
+      {:ok, suggested_usernames}
+    end
+  end
+
   defp perform_channel_action(
          _parent,
          %{channel_id: channel_id, user_id: user_id},

--- a/lib/glimesh/api/schema.ex
+++ b/lib/glimesh/api/schema.ex
@@ -20,6 +20,8 @@ defmodule Glimesh.Api.Schema do
 
     import_fields(:streams_queries)
     import_fields(:streams_connection_queries)
+
+    import_fields(:chat_autocomplete)
   end
 
   mutation do

--- a/lib/glimesh/api/schema/chat_types.ex
+++ b/lib/glimesh/api/schema/chat_types.ex
@@ -312,4 +312,14 @@ defmodule Glimesh.Api.ChatTypes do
       end
     end
   end
+
+  object :chat_autocomplete do
+    @desc "Autocomplete a partial user name"
+    field :autocomplete_recent_chat_users, list_of(:string) do
+      arg(:channel_id, non_null(:id))
+      arg(:partial_usernames, non_null(list_of(:string)))
+
+      resolve(&ChatResolver.autocomplete_recent_chat_users/3)
+    end
+  end
 end

--- a/lib/glimesh/chat.ex
+++ b/lib/glimesh/chat.ex
@@ -235,6 +235,56 @@ defmodule Glimesh.Chat do
     |> Enum.reverse()
   end
 
+  def list_recent_chatters_with_partial_username(
+        channel,
+        partial_username,
+        present_user_ids,
+        hours \\ 2
+      ) do
+    if not is_nil(partial_username) and String.length(partial_username) < 25 do
+      timeframe = NaiveDateTime.add(NaiveDateTime.utc_now(), hours * -60 * 60, :second)
+      search_username = Regex.replace(~r/(\\\\|_|%)/, partial_username, "\\\\\\1") <> "%"
+
+      from(m in ChatMessage,
+        join: u in User,
+        on: m.user_id == u.id,
+        where: m.user_id in ^present_user_ids,
+        where: m.is_visible == true,
+        where: m.channel_id == ^channel.id,
+        where: m.inserted_at >= ^timeframe,
+        where: u.username != ^partial_username and ilike(u.username, ^search_username),
+        order_by: [desc: m.inserted_at],
+        distinct: u.username,
+        select: %{suggestion: u.username, partial: ^partial_username},
+        limit: 5
+      )
+      |> Repo.replica().all()
+    else
+      []
+    end
+  end
+
+  def get_recent_chatters_username_autocomplete(channel, partial_usernames, hours \\ 2) do
+    present_user_ids =
+      Enum.map(
+        Glimesh.Presence.list_presences(
+          Glimesh.Streams.get_subscribe_topic(:chatters, channel.id)
+        ),
+        fn data ->
+          data[:user_id]
+        end
+      )
+
+    Enum.flat_map(partial_usernames, fn partial_username ->
+      list_recent_chatters_with_partial_username(
+        channel,
+        partial_username,
+        present_user_ids,
+        hours
+      )
+    end)
+  end
+
   @doc """
   Returns a list of all chat_messages in a channel
   """

--- a/lib/glimesh_web/live/chat_live/message_form.ex
+++ b/lib/glimesh_web/live/chat_live/message_form.ex
@@ -30,6 +30,13 @@ defmodule GlimeshWeb.ChatLive.MessageForm do
     save_chat_message(socket, channel, user, chat_message_params)
   end
 
+  def handle_event("user_autocomplete", %{"partial_usernames" => partial_usernames}, socket) do
+    channel = Glimesh.ChannelLookups.get_channel!(socket.assigns.channel.id)
+    user_suggestions = Chat.get_recent_chatters_username_autocomplete(channel, partial_usernames)
+
+    {:reply, %{suggestions: user_suggestions}, socket}
+  end
+
   defp save_chat_message(socket, channel, user, chat_message_params) do
     case Chat.create_chat_message(user, channel, chat_message_params) do
       {:ok, _chat_message} ->

--- a/lib/glimesh_web/live/chat_live/message_form.html.heex
+++ b/lib/glimesh_web/live/chat_live/message_form.html.heex
@@ -7,6 +7,7 @@
     phx-target={@myself}
     phx-submit="send"
   >
+    <div id="autocomplete-suggestions" class="d-none autocomplete-suggestions"></div>
     <%= if message = f.errors[:message] do %>
       <div id="channel-footer" class="channel-footer">
         <span class="text-danger"><%= translate_error(message) %></span>

--- a/test/glimesh/chat_test.exs
+++ b/test/glimesh/chat_test.exs
@@ -2,9 +2,11 @@ defmodule Glimesh.ChatTest do
   use Glimesh.DataCase
 
   import Glimesh.AccountsFixtures
+  import Ecto.Query
 
   alias Glimesh.Accounts
   alias Glimesh.Chat
+  alias Glimesh.Chat.ChatMessage
   alias Glimesh.Streams
   alias Glimesh.StreamModeration
   alias Glimesh.Streams.ChannelModerationLog
@@ -399,5 +401,147 @@ defmodule Glimesh.ChatTest do
       assert {:error, "You must confirm your email address before chatting."} =
                Chat.create_chat_message(user_fixture(), channel, "Hello world")
     end
+  end
+
+  describe "chat autocomplete users" do
+    test "can autocomplete active user" do
+      streamer = streamer_fixture()
+      channel = streamer.channel
+      %{active_user: active_user} = setup_chat_active_user(streamer)
+
+      partial_username = String.slice(active_user.username, 0, 3)
+      suggestions = Chat.get_recent_chatters_username_autocomplete(channel, [partial_username])
+      assert Enum.count(suggestions) == 1
+      assert suggestions == [%{partial: partial_username, suggestion: active_user.username}]
+    end
+
+    test "can NOT autocomplete lurker" do
+      streamer = streamer_fixture()
+      channel = streamer.channel
+      %{lurker: lurker} = setup_chat_lurker(streamer)
+
+      partial_username = String.slice(lurker.username, 0, 3)
+      suggestions = Chat.get_recent_chatters_username_autocomplete(channel, [partial_username])
+      assert Enum.count(suggestions) == 0
+      refute suggestions == [%{partial: partial_username, suggestion: lurker.username}]
+    end
+
+    test "will suggest active users only even when lurkers match" do
+      streamer = streamer_fixture()
+      channel = streamer.channel
+      %{active_user: active_user} = setup_chat_active_user(streamer)
+      %{lurker: _lurker} = setup_chat_lurker(streamer)
+
+      partial_username = String.slice(active_user.username, 0, 3)
+      suggestions = Chat.get_recent_chatters_username_autocomplete(channel, [partial_username])
+
+      assert Enum.count(suggestions) == 1
+      assert suggestions == [%{partial: partial_username, suggestion: active_user.username}]
+    end
+
+    test "will return empty enum if a full username is passed in" do
+      streamer = streamer_fixture()
+      channel = streamer.channel
+      %{active_user: active_user} = setup_chat_active_user(streamer)
+
+      suggestions =
+        Chat.get_recent_chatters_username_autocomplete(channel, [active_user.username])
+
+      assert Enum.count(suggestions) == 0
+      refute suggestions == [%{partial: active_user.username, suggestion: active_user.username}]
+    end
+
+    test "will suggest based on the first non-complete username passed in" do
+      streamer = streamer_fixture()
+      channel = streamer.channel
+      %{active_user: active_user} = setup_chat_active_user(streamer)
+      %{active_user: active_user_two} = setup_chat_active_user(streamer)
+      %{lurker: lurker} = setup_chat_lurker(streamer)
+
+      partial_username = String.slice(active_user_two.username, 0, 3)
+
+      suggestions =
+        Chat.get_recent_chatters_username_autocomplete(channel, [
+          active_user.username,
+          partial_username
+        ])
+
+      assert Enum.count(suggestions) == 2
+      refute Enum.any?(suggestions, fn item -> item[:partial] == active_user.username end)
+      assert Enum.all?(suggestions, fn item -> item[:partial] == partial_username end)
+      refute Enum.any?(suggestions, fn item -> item[:suggestion] == lurker.username end)
+    end
+
+    test "will suggest a maximum of 5 usernames" do
+      streamer = streamer_fixture()
+      channel = streamer.channel
+
+      %{active_user: active_user} = setup_chat_active_user(streamer)
+      Enum.each(1..25, fn _ -> setup_chat_active_user(streamer) end)
+
+      partial_username = String.slice(active_user.username, 0, 3)
+      suggestions = Chat.get_recent_chatters_username_autocomplete(channel, [partial_username])
+
+      assert Enum.count(suggestions) == 5
+    end
+  end
+
+  defp setup_chat_active_user(streamer) do
+    active_user = user_fixture()
+
+    Glimesh.Presence.track_presence(
+      self(),
+      Glimesh.Streams.get_subscribe_topic(:chatters, streamer.channel.id),
+      active_user.id,
+      %{
+        typing: false,
+        username: active_user.username,
+        avatar: Glimesh.Avatar.url({active_user.avatar, active_user}, :original),
+        user_id: active_user.id,
+        size: 48
+      }
+    )
+
+    create_chat_message_for_user(active_user, streamer.channel, "test message", 1)
+
+    %{
+      active_user: active_user
+    }
+  end
+
+  defp setup_chat_lurker(streamer) do
+    lurker = user_fixture()
+
+    Glimesh.Presence.track_presence(
+      self(),
+      Glimesh.Streams.get_subscribe_topic(:chatters, streamer.channel.id),
+      lurker.id,
+      %{
+        typing: false,
+        username: lurker.username,
+        avatar: Glimesh.Avatar.url({lurker.avatar, lurker}, :original),
+        user_id: lurker.id,
+        size: 48
+      }
+    )
+
+    create_chat_message_for_user(lurker, streamer.channel, "test message", 3)
+
+    %{
+      lurker: lurker
+    }
+  end
+
+  defp create_chat_message_for_user(user, channel, message, hours_past) do
+    {:ok, chat_message} = Chat.create_chat_message(user, channel, %{message: message})
+    updated_at = NaiveDateTime.add(chat_message.updated_at, hours_past * -1 * 60 * 60, :second)
+
+    from(m in ChatMessage,
+      where: m.id == ^chat_message.id,
+      update: [set: [inserted_at: ^updated_at, updated_at: ^updated_at]]
+    )
+    |> Glimesh.Repo.update_all([])
+
+    Glimesh.Repo.get(ChatMessage, chat_message.id)
   end
 end

--- a/test/glimesh_web/graph_api/chats_test.exs
+++ b/test/glimesh_web/graph_api/chats_test.exs
@@ -109,6 +109,11 @@ defmodule GlimeshWeb.GraphApi.ChatsTest do
     }
   }
   """
+  @get_chatter_username_autocomplete_query """
+  query ChatAutocomplete($channelId: ID!, $partialUsernames: [String]!) {
+    autocompleteRecentChatUsers(channelId: $channelId, partialUsernames: $partialUsernames)
+  }
+  """
 
   describe "chat api without scope" do
     setup [:create_user, :create_channel]
@@ -353,6 +358,51 @@ defmodule GlimeshWeb.GraphApi.ChatsTest do
         assert m.message !== "This is a bad message"
       end)
     end
+
+    test "can get autocomplete suggestions", %{conn: conn, channel: channel} do
+      %{
+        user_one: user_one,
+        user_two: user_two
+      } = setup_chat_users(conn, channel)
+
+      user_one_partial = String.slice(user_one.displayname, 0, 3)
+      user_two_partial = String.slice(user_two.displayname, 1, 3)
+
+      conn =
+        post(conn, "/api/graph", %{
+          "query" => @get_chatter_username_autocomplete_query,
+          "variables" => %{
+            channelId: "#{channel.id}",
+            partialUsernames: [user_one_partial, user_two_partial]
+          }
+        })
+
+      assert json_response(conn, 200)["data"]["autocompleteRecentChatUsers"] == [
+               user_one.displayname,
+               user_two.displayname
+             ]
+    end
+
+    test "autocomplete suggestions will not show lurkers", %{conn: conn, channel: channel} do
+      %{
+        lurk_user: lurk_user
+      } = setup_chat_users_with_lurker(conn, channel)
+
+      lurk_partial = String.slice(lurk_user.displayname, 0, 3)
+
+      conn =
+        post(conn, "/api/graph", %{
+          "query" => @get_chatter_username_autocomplete_query,
+          "variables" => %{
+            channelId: "#{channel.id}",
+            partialUsernames: [lurk_partial]
+          }
+        })
+
+      refute json_response(conn, 200)["data"]["autocompleteRecentChatUsers"] == [
+               lurk_user.displayname
+             ]
+    end
   end
 
   describe "chat api with app client credentials" do
@@ -393,5 +443,78 @@ defmodule GlimeshWeb.GraphApi.ChatsTest do
 
   def create_emote(_) do
     %{emote: static_global_emote_fixture()}
+  end
+
+  defp setup_chat_users(conn, channel) do
+    %{conn: user_one_conn, user: user_one} = register_and_log_in_user(%{conn: conn})
+    %{conn: user_two_conn, user: user_two} = register_and_log_in_user(%{conn: conn})
+    Glimesh.Chat.create_chat_message(user_one, channel, %{message: "test message"})
+    Glimesh.Chat.create_chat_message(user_two, channel, %{message: "test another message"})
+
+    Glimesh.Presence.track_presence(
+      self(),
+      Streams.get_subscribe_topic(:chatters, channel.id),
+      user_one.id,
+      %{
+        typing: false,
+        username: user_one.username,
+        avatar: Glimesh.Avatar.url({user_one.avatar, user_one}, :original),
+        user_id: user_one.id,
+        size: 48
+      }
+    )
+
+    Glimesh.Presence.track_presence(
+      self(),
+      Streams.get_subscribe_topic(:chatters, channel.id),
+      user_two.id,
+      %{
+        typing: false,
+        username: user_two.username,
+        avatar: Glimesh.Avatar.url({user_two.avatar, user_two}, :original),
+        user_id: user_two.id,
+        size: 48
+      }
+    )
+
+    %{
+      user_one: user_one,
+      user_two: user_two,
+      user_one_conn: user_one_conn,
+      user_two_conn: user_two_conn
+    }
+  end
+
+  defp setup_chat_users_with_lurker(conn, channel) do
+    %{
+      user_one: user_one,
+      user_two: user_two,
+      user_one_conn: user_one_conn,
+      user_two_conn: user_two_conn
+    } = setup_chat_users(conn, channel)
+
+    %{conn: user_three_conn, user: user_three} = register_and_log_in_user(%{conn: conn})
+
+    Glimesh.Presence.track_presence(
+      self(),
+      Streams.get_subscribe_topic(:chatters, channel.id),
+      user_three.id,
+      %{
+        typing: false,
+        username: user_three.username,
+        avatar: Glimesh.Avatar.url({user_three.avatar, user_three}, :original),
+        user_id: user_three.id,
+        size: 48
+      }
+    )
+
+    %{
+      user_one: user_one,
+      user_two: user_two,
+      lurk_user: user_three,
+      user_one_conn: user_one_conn,
+      user_two_conn: user_two_conn,
+      lurk_user_conn: user_three_conn
+    }
   end
 end


### PR DESCRIPTION
## Description
When viewers want to direct their chat messages at specific users they can use the "@username" tag in their chat messages.  This change will add an auto-complete functionality to the chat field when viewers begin to type a partial username after the "@" symbol.

### Features
- Will suggest up to 5 usernames after viewers type at least 3 characters after the "@" symbol
- Case-insensitive
- Can handle multiple partial usernames in the same chat message
- Can select suggestions with either the keyboard or mouse
- Will only suggest usernames for chatters that have participated in chat within the last 2 hours (will not suggest lurkers).
- Will attempt to sort suggestions based on the chatters with the most recent message.

### Keyboard Support
When suggestions are visible, the up/down arrow keys can be used to navigate them and the enter key can be used to select the highlighted suggestion.  When suggestions are not visible, the arrow keys will revert to recalling the previous message and the enter key will revert to submitting the message.

### API Support
A new API query can be called to get autocomplete suggestions:
```
  query ChatAutocomplete($channelId: ID!, $partialUsernames: [String]!) {
    autocompleteRecentChatUsers(channelId: $channelId, partialUsernames: $partialUsernames)
  }
```
The endpoint will return a list of usernames (up to 5) that match the list of partial usernames passed in.  Full usernames passed to the endpoint will be ignored and suggestions will be returned starting with the first partial username passed in the input list.

## In Action
![autocomplete-finished](https://user-images.githubusercontent.com/5142625/212816976-51f5cc6c-e85d-42af-8adf-41e78f8d5fe7.gif)

Note, I've made changes to the colors of the suggestions since the above recording, here's what it looks like now:

![image](https://user-images.githubusercontent.com/5142625/213844827-4762b6fd-703d-49f8-bf6e-3847d1017f97.png)
