### PR TITLE
Theater mode for stream page

### DIFF
--- a/assets/css/glimesh/components/stream.scss
+++ b/assets/css/glimesh/components/stream.scss
@@ -79,6 +79,98 @@
     }
 }
 
+.theater-mode {
+    #top-site-navigation{
+        @extend .collapse;
+    }
+
+    #outer-stream-container {
+        margin: 0;
+        padding: 0;
+    }
+
+    #outer-stream-container .row {
+        margin-top: 5px !important;
+    }
+
+    #stream-profile-content {
+        display: none;
+    }
+
+    #stream-title-header {
+        display: none;
+    }
+
+    #stream-footer {
+        display: none !important;
+    }
+
+    #site-footer {
+        display: none;
+    }
+
+    #video-column {
+        max-height: 100vh;
+        height: 100vh;
+        padding-left: 1em !important;
+        padding-right: 0 !important;
+        padding-top: 0 !important;
+        padding-bottom: 1em !important;
+        @extend .col-lg-10;
+    }
+
+    #video-column:hover {
+        #stream-title-header {
+            animation: slide-in 1.5s forwards;
+            display: block;
+            position: absolute;
+            top:0;
+            left:0;
+            z-index: 300;
+
+            @extend .col-12;
+        }
+
+        #stream-footer {
+            animation: slide-up 1s forwards;
+            display: block !important;
+            position: absolute;
+            bottom: 0;
+            left: 0;
+            z-index: 300;
+
+            @extend .col-12;
+        }
+
+    }
+
+    @keyframes slide-in {
+        0% { top: -100px; }
+        100% { top: 5px; }
+    }
+
+    @keyframes slide-out {
+        0% { top:5px; }
+        100% { top:-100px; }
+    }
+
+    @keyframes slide-up {
+        0% { bottom: -200vh; }
+        100% { bottom: 8vh; }
+    }
+
+    #chat-column {
+        #chat {
+            max-height: 100vh;
+            height: calc(100vh - 20px);
+        }
+        padding-left: 0 !important;
+        padding-right: 0 !important;
+        padding-top: 0 !important;
+        padding-bottom: 1em !important;
+        @extend .col-lg-2;
+    }
+}
 
 // Initial sizing for mobile, quickly overwritten any time we have columns
 #chat-column {

--- a/assets/css/glimesh/components/stream.scss
+++ b/assets/css/glimesh/components/stream.scss
@@ -85,12 +85,15 @@
     }
 
     #outer-stream-container {
-        margin: 0;
-        padding: 0;
+        padding-bottom: 0;
+        padding-left: 0;
+        padding-right: 0;
+        padding-top: 0;
     }
 
     #outer-stream-container .row {
         margin-top: 5px !important;
+        margin-bottom: 5px !important;
     }
 
     #stream-profile-content {
@@ -110,12 +113,11 @@
     }
 
     #video-column {
-        max-height: 100vh;
-        height: 100vh;
-        padding-left: 1em !important;
-        padding-right: 0 !important;
-        padding-top: 0 !important;
-        padding-bottom: 1em !important;
+        max-height: calc(100vh - 10px);
+        height: calc(100vh - 10px);
+        padding-left: 15px !important;
+        padding-right: 2.5px !important;
+        padding-bottom: 0;
         @extend .col-lg-10;
     }
 
@@ -125,7 +127,9 @@
             display: block;
             position: absolute;
             top:0;
-            left:0;
+            left: 0;
+            padding-left: 15px !important;
+            padding-right: 15px !important;
             z-index: 300;
 
             @extend .col-12;
@@ -137,6 +141,8 @@
             position: absolute;
             bottom: 0;
             left: 0;
+            padding-left: 15px !important;
+            padding-right: 15px !important;
             z-index: 300;
 
             @extend .col-12;
@@ -161,13 +167,13 @@
 
     #chat-column {
         #chat {
-            max-height: 100vh;
-            height: calc(100vh - 20px);
+            max-height: calc(100vh - 10px);
+            height: calc(100vh - 10px);
         }
-        padding-left: 0 !important;
-        padding-right: 0 !important;
-        padding-top: 0 !important;
-        padding-bottom: 1em !important;
+        padding-left: 2.5px !important;
+        padding-right: 15px !important;
+        padding-bottom: 0;
+
         @extend .col-lg-2;
     }
 }

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -18,6 +18,7 @@ import Tagify from "./hooks/Tagify";
 import ChannelLookupTypeahead from "./hooks/ChannelLookupTypeahead";
 import RecentTags from "./hooks/RecentTags";
 import Bootstrapize from "./hooks/Bootstrapize";
+import TheaterMode from "./hooks/TheaterMode";
 
 // https://github.com/github/markdown-toolbar-element
 import "@github/markdown-toolbar-element";
@@ -42,6 +43,7 @@ Hooks.Tagify = Tagify;
 Hooks.ChannelLookupTypeahead = ChannelLookupTypeahead;
 Hooks.RecentTags = RecentTags;
 Hooks.Bootstrapize = Bootstrapize;
+Hooks.TheaterMode = TheaterMode;
 
 let csrfToken = document.querySelector("meta[name='csrf-token']").getAttribute("content");
 let liveSocket = new LiveSocket("/live", Socket, {

--- a/assets/js/hooks/TheaterMode.js
+++ b/assets/js/hooks/TheaterMode.js
@@ -1,0 +1,16 @@
+export default {
+    toggle() {
+        document.body.classList.toggle('theater-mode');
+    },
+    mounted() {
+        this.el.addEventListener("click", e => {
+            this.toggle();
+        });
+
+        document.addEventListener("keyup", e => {
+            if(e.altKey && e.key === "t") {
+                this.toggle();
+            }
+        });
+    }
+}

--- a/lib/glimesh_web/live/user_live/stream.html.heex
+++ b/lib/glimesh_web/live/user_live/stream.html.heex
@@ -106,11 +106,11 @@
   </div>
 <% end %>
 
-<div class="container-fluid container-stream">
+<div id="outer-stream-container" class="container-fluid container-stream">
   <div class="row mt-lg-3">
     <div id="video-column" class="col-lg-9 layout-spacing">
       <div class="card">
-        <div class="card-header p-1">
+        <div id="stream-title-header" class="card-header p-1">
           <div class="row">
             <div class="col align-self-center d-block text-truncate">
               <%= live_render(@socket, GlimeshWeb.UserLive.Components.ChannelTitle,
@@ -202,7 +202,7 @@
             </div>
           <% end %>
         </div>
-        <div class="card-footer p-1 d-none d-sm-block">
+        <div id="stream-footer" class="card-footer p-1 d-none d-sm-block">
           <%= if @webrtc_error do %>
             <div class="alert alert-warning" role="alert">
               There was an unexpected error loading the video: <%= @webrtc_error %>
@@ -254,6 +254,17 @@
             </div>
             <div class="col-4 align-self-center">
               <div class="float-right mr-sm-2">
+                <div class="d-inline-block mr-sm-2">
+                  <a
+                    id="theater-mode-button"
+                    href="#"
+                    phx-hook="TheaterMode"
+                    class="text-color-link"
+                    title={gettext("Theater Mode")}
+                  >
+                    <i class="fas fa-expand-arrows-alt"></i>
+                  </a>
+                </div>
                 <div class="d-inline-block mr-sm-2">
                   <a
                     href="#"
@@ -358,7 +369,7 @@ updated_at: <%= @stream_metadata.updated_at %>
     </div>
   </div>
 
-  <div class="row">
+  <div id="stream-profile-content" class="row">
     <div class="col-lg-9 layout-spacing">
       <div class="card">
         <div class="card-header">

--- a/lib/glimesh_web/templates/layout/_navbar.html.heex
+++ b/lib/glimesh_web/templates/layout/_navbar.html.heex
@@ -1,4 +1,4 @@
-<nav class="navbar navbar-expand-lg sticky-top shadow-sm acrylic">
+<nav id="top-site-navigation" class="navbar navbar-expand-lg sticky-top shadow-sm acrylic">
   <%= live_redirect class: "navbar-brand", to: Routes.homepage_path(@conn, :index) do %>
     <picture class="d-inline-block align-top" height="34">
       <source srcset="/images/logos/logo-sm-alpha.png" media="(max-width: 768px)" />

--- a/lib/glimesh_web/templates/layout/root.html.heex
+++ b/lib/glimesh_web/templates/layout/root.html.heex
@@ -140,7 +140,7 @@
     </div>
 
     <%= if Map.get(assigns, :render_footer, true) do %>
-      <footer>
+      <footer id="site-footer">
         <section class="footer-main pt-5 pb-5">
           <div class="container">
             <div class="row">


### PR DESCRIPTION
## Description
Viewers have requested the ability to expand the viewable area of streams to minimize the extraneous information on the stream page and focus on the streaming video and chat.

## Features
- Added a "Theater Mode" button below the stream next to the debug icon:
![image](https://user-images.githubusercontent.com/5142625/216842109-bfcdad03-3d49-4fc2-b011-67e097612836.png)
- Theater Mode can also be toggled on/off via a the keyboard shortcut: ALT-T
- When activated, "Theater Mode" will hide the header/footer of the stream, hide the header/footer of the site, and hide the profile section/chat rules section so the stream and chat can take up all the real estate.  The stream is made slightly larger (col-9 -> col-10) and the chat is made slightly smaller (col-3 -> col-2).
- When the viewer hovers over the video column, the stream header/footer containing the stream title/buttons and the streamer name/language/pronouns and the new theater mode button, debug button, and report user buttons will animate into position above the video on top and bottom respectively.
![theater-mode-in-action](https://user-images.githubusercontent.com/5142625/216842570-9db727a1-0c7b-4022-a385-61c81e3a5e45.gif)
- All the UI buttons, including the video buttons, and chat should continue to work correctly in theater mode.

## Limitations
- Smaller screens, such as those on mobile devices, will not see any benefit to this feature and probably should not use it.

## Development notes
- Most of this feature is achieved via CSS with a small javascript hook called TheaterMode to handle button click, keyboard input, and the toggling of the CSS class on the body element.

## Community Contributors
Thank you to the following community contributors who helped with CSS and other style inputs:
- Cykotiq
- MrTeeXD1
