### PR TITLE
Only call Twitter API when necessary

### DIFF
--- a/lib/glimesh_web/controllers/gct_controller.ex
+++ b/lib/glimesh_web/controllers/gct_controller.ex
@@ -116,7 +116,6 @@ defmodule GlimeshWeb.GctController do
   def edit_user_profile(conn, %{"username" => username}) do
     current_user = conn.assigns.current_user
     user = Accounts.get_by_username(username, true)
-    twitter_auth_url = Glimesh.Socials.Twitter.authorize_url(conn)
 
     with :ok <- Bodyguard.permit(Glimesh.CommunityTeam, :edit_user_profile, current_user, user) do
       CommunityTeam.create_audit_entry(current_user, %{
@@ -133,7 +132,6 @@ defmodule GlimeshWeb.GctController do
           "edit_user_profile.html",
           user: user,
           user_changeset: user_changeset,
-          twitter_auth_url: twitter_auth_url,
           page_title: format_page_title("Editing Profile - #{user.displayname}")
         )
       else
@@ -163,8 +161,7 @@ defmodule GlimeshWeb.GctController do
         {:error, changeset} ->
           render(conn, "edit_user_profile.html",
             user_changeset: changeset,
-            user: user,
-            twitter_auth_url: Glimesh.Socials.Twitter.authorize_url(conn)
+            user: user
           )
       end
     end

--- a/lib/glimesh_web/controllers/user_settings_controller.ex
+++ b/lib/glimesh_web/controllers/user_settings_controller.ex
@@ -162,11 +162,9 @@ defmodule GlimeshWeb.UserSettingsController do
   defp assign_profile_changesets(conn, _opts) do
     user = conn.assigns.current_user
     user_preference = Accounts.get_user_preference!(user)
-    twitter_auth_url = Glimesh.Socials.Twitter.authorize_url(conn)
 
     conn
     |> assign(:user, user)
-    |> assign(:twitter_auth_url, twitter_auth_url)
     |> assign(:profile_changeset, Accounts.change_user_profile(user))
     |> assign(:preference_changeset, Accounts.change_user_preference(user_preference))
   end

--- a/lib/glimesh_web/controllers/user_social_controller.ex
+++ b/lib/glimesh_web/controllers/user_social_controller.ex
@@ -47,4 +47,16 @@ defmodule GlimeshWeb.UserSocialController do
         |> redirect(to: Routes.user_settings_path(conn, :profile))
     end
   end
+
+  def twitter_connect(conn, _params) do
+    auth_url = Glimesh.Socials.Twitter.authorize_url(conn)
+
+    if is_nil(auth_url) do
+      conn
+      |> put_flash(:error, gettext("There was a problem connecting your twitter account."))
+      |> redirect(to: Routes.user_settings_path(conn, :profile))
+    else
+      redirect(conn, external: auth_url)
+    end
+  end
 end

--- a/lib/glimesh_web/live/user_settings/components/profile_settings_live.ex
+++ b/lib/glimesh_web/live/user_settings/components/profile_settings_live.ex
@@ -13,7 +13,6 @@ defmodule GlimeshWeb.UserSettings.Components.ProfileSettingsLive do
      socket
      |> put_flash(:info, nil)
      |> assign(:profile_changeset, session["profile_changeset"])
-     |> assign(:twitter_auth_url, session["twitter_auth_url"])
      |> assign(:twitter_account, Glimesh.Socials.get_social(session["user"], "twitter"))
      |> assign(:user, session["user"])
      |> assign(:route, session["route"])

--- a/lib/glimesh_web/live/user_settings/components/profile_settings_live.html.heex
+++ b/lib/glimesh_web/live/user_settings/components/profile_settings_live.html.heex
@@ -98,10 +98,8 @@
                     <% end %>
                   <% else %>
                     <a
-                      href={@twitter_auth_url}
-                      class={
-                        ["btn btn-info btn-block", unless(@twitter_auth_url, do: "disabled")]
-                      }
+                      href={Routes.user_social_path(@socket, :twitter_connect)}
+                      class={["twitter-button btn btn-info btn-block"]}
                     >
                       <i class="fab fa-twitter fa-fw"></i>
                       <%= if f.data.social_twitter do %>

--- a/lib/glimesh_web/router.ex
+++ b/lib/glimesh_web/router.ex
@@ -114,6 +114,7 @@ defmodule GlimeshWeb.Router do
     live "/platform_subscriptions", PlatformSubscriptionLive.Index, :index
 
     get "/users/social/twitter", UserSocialController, :twitter
+    get "/users/social/twitter/connect", UserSocialController, :twitter_connect
     delete "/users/social/disconnect/:platform", UserSocialController, :disconnect
 
     get "/users/payments", UserPaymentsController, :index

--- a/lib/glimesh_web/templates/gct/edit_user_profile.html.eex
+++ b/lib/glimesh_web/templates/gct/edit_user_profile.html.eex
@@ -5,6 +5,6 @@
     </div>
 
     <%= live_redirect gettext("Go Back"), class: "btn btn-primary mb-4", to: Routes.gct_path(@conn, :username_lookup, query: @user.username) %>
-    <%= live_render(@conn, GlimeshWeb.UserSettings.Components.ProfileSettingsLive, id: "profile-settings-form", session: %{"route" => Routes.gct_path(@conn, :update_user_profile, @user.username), "profile_changeset" => @user_changeset, "twitter_auth_url" => @twitter_auth_url, "user" => @user}) %>
+    <%= live_render(@conn, GlimeshWeb.UserSettings.Components.ProfileSettingsLive, id: "profile-settings-form", session: %{"route" => Routes.gct_path(@conn, :update_user_profile, @user.username), "profile_changeset" => @user_changeset, "user" => @user}) %>
 
 </div>

--- a/lib/glimesh_web/templates/user_settings/profile.html.eex
+++ b/lib/glimesh_web/templates/user_settings/profile.html.eex
@@ -1,4 +1,4 @@
 <div class="container">
     <h2 class="mt-4"><%= gettext "Your Profile" %></h2>
-    <%= live_render(@conn, GlimeshWeb.UserSettings.Components.ProfileSettingsLive, id: "profile-settings-form", session: %{"route" => Routes.user_settings_path(@conn, :update_profile), "profile_changeset" => @profile_changeset, "twitter_auth_url" => @twitter_auth_url, "user" => @user}) %>
+    <%= live_render(@conn, GlimeshWeb.UserSettings.Components.ProfileSettingsLive, id: "profile-settings-form", session: %{"route" => Routes.user_settings_path(@conn, :update_profile), "profile_changeset" => @profile_changeset, "user" => @user}) %>
 </div>

--- a/test/glimesh_web/controllers/user_social_controller_test.exs
+++ b/test/glimesh_web/controllers/user_social_controller_test.exs
@@ -1,0 +1,30 @@
+defmodule GlimeshWeb.UserSocialControllerTest do
+  use GlimeshWeb.ConnCase, async: true
+
+  setup :register_and_log_in_user
+
+  describe "GET /users/social/twitter/twitter_connect" do
+    test "redirects correctly", %{conn: conn} do
+      auth_url =
+        conn
+        |> bypass_through()
+        |> get("/")
+        |> Glimesh.Socials.Twitter.authorize_url()
+
+      if is_nil(auth_url) do
+        conn =
+          conn
+          |> get(Routes.user_social_path(conn, :twitter_connect))
+
+        assert redirected_to(conn) == Routes.user_settings_path(conn, :profile)
+        assert get_flash(conn, :error) =~ "There was a problem connecting your twitter account."
+      else
+        conn =
+          conn
+          |> get(Routes.user_social_path(conn, :twitter_connect))
+
+        assert redirected_to(conn) =~ "twitter.com"
+      end
+    end
+  end
+end


### PR DESCRIPTION
fixes #634 

Currently we are calling the Twitter API on each settings page load unnecessarily.  I've removed the calls to the api and consolidated it to a new endpoint on the UserSocialController -- "/users/social/twitter/connect".

The new endpoint will do the Twitter authorization_url lookup and, if successful, do the redirect to Twitter that the "Connect with Twitter" button on the user profile page would have done.  If we are not successful in contacting the Twitter API, the endpoint will redirect the user back to the user profile page with an error message:

![image](https://user-images.githubusercontent.com/5142625/221339807-8e6ba776-ffad-49ae-9fb9-4cecf7b7ddad.png)

NOTE: I am awaiting access from Twitter to their API, so I am only able to test the error path and not the successful path at this time.

There should be no other changes to the Twitter auth flow as a result of this change.