### PR TITLE
Fix URL by removing duplicate forward slash

### DIFF
--- a/lib/glimesh_web/templates/channel_moderator/index.html.eex
+++ b/lib/glimesh_web/templates/channel_moderator/index.html.eex
@@ -4,7 +4,7 @@
       <h2><%= gettext("Channel Moderators") %></h2>
     </div>
     <div class="col-3">
-      <%= link gettext("Add Moderator"), to: ~p"//users/settings/channel/mods/new", class: "btn btn-primary btn-block" %>
+      <%= link gettext("Add Moderator"), to: ~p"/users/settings/channel/mods/new", class: "btn btn-primary btn-block" %>
     </div>
   </div>
 


### PR DESCRIPTION
Previously, the URL was broken due to an extra forward slash in the path. This pull request removes the duplicate forward slash and fixes the link on the website. 