### PR TITLE
Fix route to add mods by removing /create

### DIFF
--- a/lib/glimesh_web/templates/channel_moderator/new.html.eex
+++ b/lib/glimesh_web/templates/channel_moderator/new.html.eex
@@ -10,7 +10,7 @@
 
     <div class="card">
         <div class="card-body">
-            <%= render "form.html", Map.put(assigns, :action, ~p"/users/settings/channel/mods/create") %>
+            <%= render "form.html", Map.put(assigns, :action, ~p"/users/settings/channel/mods") %>
         </div>
     </div>
 </div>


### PR DESCRIPTION
Fix bug where route to add mods (`"/users/settings/channel/mods/create"`) was returning not found. Removing the /create should fix this issue since the :create route is on the mods route itself. 

Routes Screenshot
![image](https://user-images.githubusercontent.com/47222556/230702829-2011f274-6b42-4a16-9e1c-df15ee321b10.png)