### PR TITLE
Fix Dev Applications

### DIFF
--- a/lib/glimesh_web/templates/user_applications/new.html.eex
+++ b/lib/glimesh_web/templates/user_applications/new.html.eex
@@ -10,7 +10,7 @@
 
   <div class="card">
     <div class="card-body">
-      <%= render "form.html", Map.put(assigns, :action, ~p"/users/settings/applications/create") %>
+      <%= render "form.html", Map.put(assigns, :action, ~p"/users/settings/applications") %>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Fix an incorrect URL that prevented new applications from being created.

It was supposed to be a POST request to `users/settings/applications`. Instead it was set to `users/settings/applications/create`. 